### PR TITLE
fix(dashboard): resolve employee grid row conflict + ProfileCompletionWidget 2FA

### DIFF
--- a/src/components/dashboard/EmployeeDashboard.tsx
+++ b/src/components/dashboard/EmployeeDashboard.tsx
@@ -92,23 +92,18 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
         <OnboardingWidget profile={profile} userRole="employee" />
       </GridItem>
 
-      {/* 8 mobile / 3 desktop. Stats — full width */}
+      {/* 3. Stats — full width */}
       <GridItem order={{ base: 8, lg: 0 }} gridColumn={{ base: '1', lg: '1 / -1' }} gridRow={{ lg: '3' }}>
         <StatsWidget userRole="employee" profileId={profile.id} />
       </GridItem>
 
-      {/* 2. Timeline — main col */}
-      <GridItem order={{ base: 2, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '3' }}>
+      {/* 4. Timeline — main col */}
+      <GridItem order={{ base: 2, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '4' }}>
         <EmployeeShiftTimeline employeeId={profile.id} />
       </GridItem>
 
-      {/* 3. Messages — aside col */}
-      <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '4' }}>
-        <RecentMessagesWidget userId={profile.id} />
-      </GridItem>
-
       {/* 4. Clock-in — aside col */}
-      <GridItem order={{ base: 4, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '3' }}>
+      <GridItem order={{ base: 4, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '4' }}>
         <ClockInWidget
           hasActiveShift={!!activeShift}
           activeShiftLabel={activeShift ? `Intervention ${activeShift.startTime.slice(0, 5)} – ${activeShift.endTime.slice(0, 5)}` : undefined}
@@ -116,17 +111,22 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
       </GridItem>
 
       {/* 5. Heures du mois — main col */}
-      <GridItem order={{ base: 5, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '4' }}>
+      <GridItem order={{ base: 5, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '5' }}>
         <EmployeeHoursProgress employeeId={profile.id} />
       </GridItem>
 
+      {/* 5. Messages — aside col */}
+      <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '5' }}>
+        <RecentMessagesWidget userId={profile.id} />
+      </GridItem>
+
       {/* 6. Congés & absences — main col */}
-      <GridItem order={{ base: 6, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '5' }}>
+      <GridItem order={{ base: 6, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '6' }}>
         <EmployeeLeaveWidget employeeId={profile.id} />
       </GridItem>
 
-      {/* 7. Mes documents — aside col */}
-      <GridItem order={{ base: 7, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '5' }}>
+      {/* 6. Mes documents — aside col */}
+      <GridItem order={{ base: 7, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '6' }}>
         <EmployeeDocumentsWidget employeeId={profile.id} />
       </GridItem>
     </Grid>

--- a/src/components/profile/ProfileCompletionWidget.tsx
+++ b/src/components/profile/ProfileCompletionWidget.tsx
@@ -14,9 +14,10 @@ interface ProfileCompletionWidgetProps {
   employer?: Employer | null
   employee?: Employee | null
   caregiver?: Caregiver | null
+  isMfaEnabled?: boolean
 }
 
-function getEmployerChecklist(profile: Profile, employer?: Employer | null): CheckItem[] {
+function getEmployerChecklist(profile: Profile, employer?: Employer | null, isMfaEnabled?: boolean): CheckItem[] {
   const hasAddress = !!(employer?.address?.street && employer?.address?.city)
   const hasHandicap = !!employer?.handicapType
   const hasPch = !!employer?.pchBeneficiary
@@ -30,10 +31,11 @@ function getEmployerChecklist(profile: Profile, employer?: Employer | null): Che
     { label: 'Numéro CESU', done: hasCesu, link: { label: 'Renseigner', to: '#section-situation' } },
     { label: 'PCH configurée', done: hasPch, link: { label: 'Configurer', to: '#section-situation' } },
     { label: "Contacts d'urgence", done: hasEmergencyContacts, link: { label: 'Ajouter', to: '#section-urgence' } },
+    { label: 'Double authentification', done: !!isMfaEnabled, link: { label: 'Activer', to: '/parametres' } },
   ]
 }
 
-function getEmployeeChecklist(profile: Profile, employee?: Employee | null): CheckItem[] {
+function getEmployeeChecklist(profile: Profile, employee?: Employee | null, isMfaEnabled?: boolean): CheckItem[] {
   const hasSSN = !!employee?.socialSecurityNumber
   const hasEmergencyContacts = (employee?.emergencyContacts?.length ?? 0) > 0
   const hasLicense = !!employee?.driversLicense?.hasLicense
@@ -47,27 +49,29 @@ function getEmployeeChecklist(profile: Profile, employee?: Employee | null): Che
     { label: "Contacts d'urgence", done: hasEmergencyContacts, link: { label: 'Ajouter', to: '#section-urgence-employee' } },
     { label: 'Permis / mobilité', done: hasLicense, link: { label: 'Renseigner', to: '#section-metier' } },
     { label: 'IBAN', done: hasIban, link: { label: 'Renseigner', to: '#section-metier' } },
+    { label: 'Double authentification', done: !!isMfaEnabled, link: { label: 'Activer', to: '/parametres' } },
   ]
 }
 
-function getCaregiverChecklist(profile: Profile, caregiver?: Caregiver | null): CheckItem[] {
+function getCaregiverChecklist(profile: Profile, caregiver?: Caregiver | null, isMfaEnabled?: boolean): CheckItem[] {
   const hasRelationship = !!caregiver?.relationship
-  const hasPermissions = !!caregiver?.permissions
+  const hasPch = !!caregiver?.availabilityHours
 
   return [
     { label: 'Informations personnelles', done: !!(profile.firstName && profile.lastName && profile.phone) },
     { label: 'Lien de parenté', done: hasRelationship, link: { label: 'Renseigner', to: '#section-aidant' } },
-    { label: "Droits d'accès", done: hasPermissions },
+    { label: 'Enveloppe PCH', done: hasPch, link: { label: 'Configurer', to: '/parametres' } },
+    { label: 'Double authentification', done: !!isMfaEnabled, link: { label: 'Activer', to: '/parametres' } },
   ]
 }
 
-export function ProfileCompletionWidget({ profile, employer, employee, caregiver }: ProfileCompletionWidgetProps) {
+export function ProfileCompletionWidget({ profile, employer, employee, caregiver, isMfaEnabled }: ProfileCompletionWidgetProps) {
   const checklist =
     profile.role === 'employer'
-      ? getEmployerChecklist(profile, employer)
+      ? getEmployerChecklist(profile, employer, isMfaEnabled)
       : profile.role === 'employee'
-        ? getEmployeeChecklist(profile, employee)
-        : getCaregiverChecklist(profile, caregiver)
+        ? getEmployeeChecklist(profile, employee, isMfaEnabled)
+        : getCaregiverChecklist(profile, caregiver, isMfaEnabled)
 
   const doneCount = checklist.filter((item) => item.done).length
   const percentage = Math.round((doneCount / checklist.length) * 100)

--- a/src/components/profile/ProfileSidebar.tsx
+++ b/src/components/profile/ProfileSidebar.tsx
@@ -157,6 +157,8 @@ function LogoutButton() {
 }
 
 export function ProfileSidebar({ profile, employer, employee, caregiver }: ProfileSidebarProps) {
+  const { isEnabled: isMfaEnabled } = useMfa()
+
   return (
     <Stack gap={4} position="sticky" top="100px">
       {/* Widget complétude */}
@@ -165,6 +167,7 @@ export function ProfileSidebar({ profile, employer, employee, caregiver }: Profi
         employer={employer}
         employee={employee}
         caregiver={caregiver}
+        isMfaEnabled={isMfaEnabled}
       />
 
       {/* Widget sécurité */}


### PR DESCRIPTION
## Summary

Deux corrections indépendantes.

### 1. Fix layout dashboard employé

`StatsWidget` (full-width, row 3) partageait `gridRow: 3` avec `EmployeeShiftTimeline` et `ClockInWidget`, provoquant des artefacts visuels (contours de cards fantômes en bas du widget planning).

**Nouveau layout :**
| Row | Contenu |
|-----|---------|
| 3 | StatsWidget (full width) |
| 4 | EmployeeShiftTimeline + ClockInWidget |
| 5 | EmployeeHoursProgress + RecentMessages |
| 6 | EmployeeLeave + Documents |

### 2. ProfileCompletionWidget — 2FA + aidant

- Ajout item **"Double authentification"** dans la checklist des 3 rôles (lié à `useMfa()` via `ProfileSidebar`)
- Aidant : remplacement "Droits d'accès" → **"Enveloppe PCH"** (`availabilityHours`)

## Test plan

- [x] `npm run lint` — 0 erreurs
- [x] `npm run test:run` — 2210/2210 passent
- [ ] Vérifier visuellement le dashboard employé (plus de cards fantômes)
- [ ] Vérifier widget complétude profil (item 2FA visible, aidant avec PCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)