### PR TITLE
feat(theme): add semantic spacing tokens (xs → 6xl)

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -6,6 +6,20 @@ import { createSystem, defaultConfig, defineConfig } from '@chakra-ui/react'
 const config = defineConfig({
   theme: {
     tokens: {
+      // Espaces sémantiques alignés sur le prototype (--sp-N)
+      // Usage : p="xs", gap="md", mt="2xl", etc.
+      spacing: {
+        xs:  { value: '4px' },   // --sp-1  : micro-gaps, inline elements
+        sm:  { value: '8px' },   // --sp-2  : badges, boutons sm, listes serrées
+        md:  { value: '12px' },  // --sp-3  : espacement standard composants
+        lg:  { value: '16px' },  // --sp-4  : card padding, sections
+        xl:  { value: '20px' },  // --sp-5
+        '2xl': { value: '24px' }, // --sp-6
+        '3xl': { value: '32px' }, // --sp-8
+        '4xl': { value: '40px' }, // --sp-10
+        '5xl': { value: '48px' }, // --sp-12
+        '6xl': { value: '64px' }, // --sp-16
+      },
       colors: {
         // Brand : slate-blue (prototype --c-primary)
         brand: {


### PR DESCRIPTION
## Summary

Ajout des tokens d'espacement sémantiques dans le thème Chakra UI v3, alignés sur les variables `--sp-N` du prototype.

### Tokens ajoutés (`tokens.spacing`)

| Token | Valeur | Prototype |
|-------|--------|-----------|
| `xs`  | 4px    | `--sp-1`  |
| `sm`  | 8px    | `--sp-2`  |
| `md`  | 12px   | `--sp-3`  |
| `lg`  | 16px   | `--sp-4`  |
| `xl`  | 20px   | `--sp-5`  |
| `2xl` | 24px   | `--sp-6`  |
| `3xl` | 32px   | `--sp-8`  |
| `4xl` | 40px   | `--sp-10` |
| `5xl` | 48px   | `--sp-12` |
| `6xl` | 64px   | `--sp-16` |

### Usage

```tsx
<Box p="lg" gap="sm" mt="2xl" />
<Stack gap="md" />
<Card p="xl" />
```

## Test plan
- [x] TypeScript : 0 erreurs
- [x] Lint : 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)