### PR TITLE
feat(a11y): enforce 44px touch target on buttons for mobile

### DIFF
--- a/docs/DEVELOPMENT_ROADMAP.md
+++ b/docs/DEVELOPMENT_ROADMAP.md
@@ -53,7 +53,7 @@ Audit complet des 9 sections de la roadmap :
 - Types `accessibility_settings` + `computed_pay` alignés dans `database.ts` ✅
 - Sanitisation 5 services + tests ProtectedRoute vérifiés ✅
 - FAQ intégrée (`HelpPage`) ✅, upload documents Storage ✅, rate limiting Edge Functions ✅
-- Tokens design : colors/typography ✅, spacing custom ⏳
+- Tokens design : colors/typography ✅, spacing custom ✅
 - PWA offline : assets + Storage ✅, `/rest/v1/` exclu volontairement ⏳
 - Table documents : upload + prévisualisation ✅, search + table unifiée ⏳
 
@@ -1593,7 +1593,7 @@ Le dashboard garde ses widgets actuels comme aperçu, avec liens "voir plus" ver
 ```
 - ❌ Documentation composants (Storybook?)
 - ❌ Variantes composants (sizes, colors)
-- 🔧 Tokens design (spacing, colors, typography) — colors ✅ + typography ✅ (theme.ts PR #185) | spacing custom ⏳
+- ✅ Tokens design (spacing, colors, typography) — colors ✅ + typography ✅ (theme.ts PR #185) | spacing custom ✅ (PR #250)
 - ❌ Guidelines accessibilité
 ```
 
@@ -1616,7 +1616,7 @@ Le dashboard garde ses widgets actuels comme aperçu, avec liens "voir plus" ver
 #### 9.3 Responsive Mobile Amélioré
 
 ```
-- 🔧 Optimisation touch targets — AccessibleInput/Select avec tailles min, pas de système global 44px ⏳
+- ✅ Optimisation touch targets — AccessibleInput/Select 44px + globalCss `@media (pointer: coarse)` pour tous les boutons
 - 🔧 Navigation mobile simplifiée — sidebar mobile + overlay existants, pas de simplification dédiée mobile ⏳
 - ❌ Gestes tactiles (swipe, pinch)
 - 🔧 Mode offline (PWA) — Service worker + workbox actif, cache assets + Storage Supabase. /rest/v1/ exclu volontairement (données sensibles) ⏳
@@ -2029,7 +2029,7 @@ La cible < 200 KB n'est pas atteignable avec React 19 + Chakra UI v3 + Supabase.
 **Semaine 23-26** :
 - 🟡 SMS notifications + vérification téléphone
 - 🟡 Tests UI Phase 3 (composants restants)
-- 🟡 Spacing tokens custom
+- ✅ Spacing tokens custom
 - 🟢 Performance (Web Vitals, Sentry)
 - Préparation release v1.0
 
@@ -2204,9 +2204,11 @@ La cible < 200 KB n'est pas atteignable avec React 19 + Chakra UI v3 + Supabase.
    - ❌ Upload pièce jointe (PDF/PNG, 5 Mo max)
 
 9. **Spacing tokens custom** — compléter la migration design tokens
-   - ❌ Espaces custom (`spacing.xs`, etc.) dans le thème Chakra UI v3
+   - ✅ Espaces custom (`spacing.xs`, etc.) dans le thème Chakra UI v3 (PR #250)
 
-10. **Touch targets 44px** — système global pour mobile (AccessibleInput/Select déjà partiels)
+10. **Touch targets 44px** — système global pour mobile
+   - ✅ AccessibleInput/Select : `minH="44px"` hardcodé
+   - ✅ Tous les `button` / `[role="button"]` : `globalCss @media (pointer: coarse)` (PR #251)
 
 11. **Tests UI — Phase 3** — composants restants sans couverture
     - ✅ SettingsPage (66 tests)

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,6 +4,17 @@ import { createSystem, defaultConfig, defineConfig } from '@chakra-ui/react'
 // Palette : --c-primary #3D5166, --c-accent #9BB23B
 // Tous les contrastes texte/fond >= 7:1 (WCAG AAA)
 const config = defineConfig({
+  // WCAG 2.5.5 — cible tactile 44px sur mobile uniquement
+  // pointer: coarse = écran tactile (pas souris desktop)
+  // AccessibleInput/Select ont déjà minH 44px hardcodé (toujours)
+  globalCss: {
+    '@media (pointer: coarse)': {
+      'button, [role="button"]': {
+        minHeight: '44px',
+        minWidth: '44px',
+      },
+    },
+  },
   theme: {
     tokens: {
       // Espaces sémantiques alignés sur le prototype (--sp-N)


### PR DESCRIPTION
## Summary

Système global de cibles tactiles 44px pour les appareils mobiles (WCAG 2.5.5).

### Approche

`@media (pointer: coarse)` cible uniquement les écrans tactiles (smartphones/tablettes), sans impacter le desktop (souris).

```ts
globalCss: {
  '@media (pointer: coarse)': {
    'button, [role="button"]': {
      minHeight: '44px',
      minWidth: '44px',
    },
  },
}
```

### Couverture complète

| Élément | Avant | Après |
|---------|-------|-------|
| `AccessibleInput` | ✅ `minH="44px"` (hardcodé) | ✅ inchangé |
| `AccessibleSelect` | ✅ `minHeight: 44px` (css) | ✅ inchangé |
| `AccessibleButton` | ✅ `size="lg"` = 44px | ✅ inchangé |
| `Button size="md"` (direct) | ❌ 40px mobile | ✅ 44px via globalCss |
| `Button size="sm"` (direct) | ❌ 36px mobile | ✅ 44px via globalCss |
| `[role="button"]` | ❌ non couvert | ✅ 44px via globalCss |

### Roadmap
- ✅ Spacing tokens custom (PR #250)
- ✅ Touch targets 44px

## Test plan
- [x] TypeScript : 0 erreurs
- [x] Desktop non impacté (`pointer: fine`)
- [x] Mobile : `minH/minW 44px` sur tous les boutons

🤖 Generated with [Claude Code](https://claude.com/claude-code)