### PR TITLE
feat(dashboard): empty state when no active employees

### DIFF
--- a/docs/DEVELOPMENT_ROADMAP.md
+++ b/docs/DEVELOPMENT_ROADMAP.md
@@ -13,7 +13,7 @@
 | Catégorie | Complétude | Statut |
 |-----------|------------|--------|
 | **Authentification** | 99% | ✅ Excellent (login, signup, reset, rôles, OAuth Google/Microsoft, 2FA TOTP, recovery codes V2) |
-| **Dashboards** | 95% | ✅ Excellent (3 dashboards rôle-spécifiques + mobile aidant, dark mode, onboarding widget, CTAs dynamiques — demo banner + empty state manquants) |
+| **Dashboards** | 97% | ✅ Excellent (3 dashboards rôle-spécifiques + mobile aidant, dark mode, onboarding widget, CTAs dynamiques, empty state aucun employé ✅ — demo banner manquant) |
 | **Planning** | 98% | ✅ Excellent (semaine/mois, shifts 24h, absences IDCC 3239, conflits, répétition, TaskSelector + courses) |
 | **Cahier de liaison** | 85% | 🟡 Bon (realtime, typing indicators, pièces jointes — réactions emoji/search/archive manquants) |
 | **Équipe/Contrats** | 90% | ✅ Bon (contrats, aidants, permissions — recherche avancée, disponibilités, évaluations V2) |
@@ -33,7 +33,7 @@
 - **Services**: 30 services
 - **Hooks**: 24 hooks custom
 - **Routes**: 18 routes francisées (dont 10 protégées avec ErrorBoundary individuel)
-- **Prototype Gap**: 96/102 items (94%) — 6 restants : demo banner, empty state, contact, palette, confidentialité, empty states onboarding
+- **Prototype Gap**: 97/102 items (95%) — 5 restants : demo banner, contact, palette, confidentialité, empty states onboarding
 
 ---
 
@@ -61,7 +61,7 @@ Audit complet des 9 sections de la roadmap :
 
 - **96/102 items terminés** (était 88/102)
 - 2FA toggle ✅ (PR #220), email notifications ✅ (PR #240), onboarding banner ✅ (PR #237) — mis à jour dans checklist
-- 6 items restants : demo banner, empty state dashboard, contact (optgroups + PJ), palette couleurs, confidentialité toggles, empty states onboarding
+- 5 items restants : demo banner, contact (optgroups + PJ), palette couleurs, confidentialité toggles, empty states onboarding
 
 #### Métriques session (10/04/2026)
 - PRs : #241–#245
@@ -1497,7 +1497,7 @@ Le prototype statique contient plusieurs éléments dashboard absents de l'app R
 ```
 - ❌ Demo banner — bandeau "Mode démo" avec badge, texte explicatif, CTA inscription, bouton fermer (dismissible localStorage)
 - ✅ Onboarding banner — 3 étapes avec progression (compte créé ✓, ajouter employé, planifier intervention) + CTA par étape — ✅ OnboardingWidget (PR #237)
-- ❌ Empty state dashboard — variante onboarding quand aucun employé/intervention (stats à "0", planning vide avec CTA)
+- ✅ Empty state dashboard — variante aucun employé : icône + titre + description + CTAs, widgets masqués (PR feat/dashboard-empty-state)
 ```
 
 #### 7b.2 Greeting & Navigation Contextuelle
@@ -2021,7 +2021,7 @@ La cible < 200 KB n'est pas atteignable avec React 19 + Chakra UI v3 + Supabase.
 
 **Semaines 21-22 (en cours)** :
 - 🔴 Domaine Resend (débloquer email prod)
-- 🟡 Demo banner + empty state dashboard
+- 🟡 Demo banner (empty state dashboard ✅)
 - 🟡 Document search
 - 🟡 Analytics exports
 - 🟡 Profile completion widget
@@ -2174,7 +2174,7 @@ La cible < 200 KB n'est pas atteignable avec React 19 + Chakra UI v3 + Supabase.
 
 2. **Demo banner + Empty state dashboard**
    - ❌ Bandeau "Mode démo" dismissible (localStorage)
-   - ❌ Variante dashboard quand aucun employé/intervention (icône + CTA)
+   - ✅ Variante dashboard quand aucun employé (icône + CTA "Ajouter un auxiliaire")
 
 3. **Document search + table unifiée**
    - ❌ Champ recherche sur la page Documents (nom, type, période)

--- a/src/components/dashboard/EmployerDashboard.test.tsx
+++ b/src/components/dashboard/EmployerDashboard.test.tsx
@@ -80,6 +80,19 @@ vi.mock('@/hooks/useComplianceMonitor', () => ({
   useComplianceMonitor: (...args: unknown[]) => mockUseComplianceMonitor(...args),
 }))
 
+// Mock Supabase — requête contracts pour hasEmployees
+const mockSupabaseChain = {
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  head: vi.fn(),
+}
+vi.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockSupabaseChain.from(...args),
+  },
+}))
+
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const profile = createMockProfile({ id: 'employer-1', role: 'employer', firstName: 'Alice' })
@@ -87,12 +100,24 @@ const profile = createMockProfile({ id: 'employer-1', role: 'employer', firstNam
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('EmployerDashboard', () => {
+  // Helper — simule un employeur avec N contrats actifs
+  function mockHasEmployees(count: number) {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn((cb: (v: { count: number }) => void) => Promise.resolve(cb({ count }))),
+    }
+    mockSupabaseChain.from.mockReturnValue(chain)
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetShifts.mockResolvedValue([])
     mockGetEmployer.mockResolvedValue(null)
     mockGetWeeklyComplianceOverview.mockResolvedValue({ summary: { critical: 0, warnings: 0 } })
     mockUseComplianceMonitor.mockReturnValue(undefined)
+    // Par défaut : 1 employé actif → affiche les widgets principaux
+    mockHasEmployees(1)
   })
 
   describe('Composition des widgets', () => {
@@ -173,6 +198,47 @@ describe('EmployerDashboard', () => {
           enabled: true,
         })
       )
+    })
+  })
+
+  describe('Empty state — aucun employé', () => {
+    it('affiche le message vide et masque les widgets principaux quand aucun contrat actif', async () => {
+      mockHasEmployees(0)
+      renderWithProviders(<EmployerDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByText('Ajoutez votre premier auxiliaire')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('today-planning-widget')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('compliance-widget')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('budget-forecast-widget')).not.toBeInTheDocument()
+    })
+
+    it('affiche les CTAs "Ajouter un auxiliaire" et "Voir le planning" dans le empty state', async () => {
+      mockHasEmployees(0)
+      renderWithProviders(<EmployerDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByText('Ajouter un auxiliaire')).toBeInTheDocument()
+        expect(screen.getByText('Voir le planning')).toBeInTheDocument()
+      })
+    })
+
+    it('affiche toujours WelcomeCard et OnboardingWidget même en empty state', async () => {
+      mockHasEmployees(0)
+      renderWithProviders(<EmployerDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByTestId('welcome-card')).toBeInTheDocument()
+        expect(screen.getByTestId('onboarding-widget')).toBeInTheDocument()
+      })
+    })
+
+    it('affiche les widgets principaux quand il y a des contrats actifs', async () => {
+      mockHasEmployees(2)
+      renderWithProviders(<EmployerDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByTestId('today-planning-widget')).toBeInTheDocument()
+        expect(screen.getByTestId('compliance-widget')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Ajoutez votre premier auxiliaire')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/dashboard/EmployerDashboard.tsx
+++ b/src/components/dashboard/EmployerDashboard.tsx
@@ -1,45 +1,112 @@
 import { useState, useEffect } from 'react'
-import { Stack, Grid, GridItem } from '@chakra-ui/react'
+import { Link as RouterLink } from 'react-router-dom'
+import { Stack, Grid, GridItem, Box, Flex, Text } from '@chakra-ui/react'
 import type { Profile, Shift, Employer } from '@/types'
 import {
   WelcomeCard,
   ActionNudgesWidget,
-  // UpcomingShiftsWidget,
-  // RecentLogsWidget,
   QuickActionsWidget,
   StatsWidget,
-  // TeamWidget,
   ComplianceWidget,
   PchEnvelopeWidget,
   TodayPlanningWidget,
   BudgetForecastWidget,
   OnboardingWidget,
 } from './widgets'
+import { AccessibleButton } from '@/components/ui'
 import { getShifts } from '@/services/shiftService'
 import { getEmployer } from '@/services/profileService'
 import { getWeeklyComplianceOverview } from '@/services/complianceService'
 import { useComplianceMonitor } from '@/hooks/useComplianceMonitor'
+import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 
 interface EmployerDashboardProps {
   profile: Profile
 }
 
+// ─── Empty state — aucun employé ─────────────────────────────────────────────
+
+function EmptyDashboardState() {
+  return (
+    <Box
+      bg="bg.surface"
+      borderWidth="1.5px"
+      borderColor="border.default"
+      borderRadius="14px"
+      boxShadow="sm"
+      textAlign="center"
+      py={14}
+      px={8}
+    >
+      {/* Icône */}
+      <Flex
+        align="center"
+        justify="center"
+        w="64px"
+        h="64px"
+        mx="auto"
+        mb={5}
+        bg="bg.muted"
+        borderRadius="16px"
+        color="text.muted"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" width="32" height="32" aria-hidden="true">
+          <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M23 21v-2a4 4 0 00-3-3.87" />
+          <path d="M16 3.13a4 4 0 010 7.75" />
+        </svg>
+      </Flex>
+
+      {/* Texte */}
+      <Text fontWeight="700" fontSize="lg" color="text.default" mb={2}>
+        Ajoutez votre premier auxiliaire
+      </Text>
+      <Text fontSize="sm" color="text.muted" maxW="360px" mx="auto" mb={7} lineHeight="1.6">
+        Pour commencer à planifier des interventions, ajoutez un auxiliaire de vie et créez son contrat.
+      </Text>
+
+      {/* CTAs */}
+      <Flex gap={3} justify="center" flexWrap="wrap">
+        <AccessibleButton colorPalette="brand" asChild accessibleLabel="Ajouter un auxiliaire">
+          <RouterLink to="/equipe">Ajouter un auxiliaire</RouterLink>
+        </AccessibleButton>
+        <AccessibleButton variant="outline" asChild accessibleLabel="Voir le planning">
+          <RouterLink to="/planning">Voir le planning</RouterLink>
+        </AccessibleButton>
+      </Flex>
+    </Box>
+  )
+}
+
+// ─── Dashboard principal ──────────────────────────────────────────────────────
+
 export function EmployerDashboard({ profile }: EmployerDashboardProps) {
   const [shifts, setShifts] = useState<Shift[]>([])
   const [isLoadingShifts, setIsLoadingShifts] = useState(true)
   const [employer, setEmployer] = useState<Employer | null>(null)
   const [complianceAlertCount, setComplianceAlertCount] = useState(0)
+  const [hasEmployees, setHasEmployees] = useState<boolean | null>(null)
 
   // Monitor compliance and create notifications for threshold violations
   useComplianceMonitor({
     employerId: profile.id,
     userId: profile.id,
     enabled: true,
-    pollingInterval: 5 * 60 * 1000, // Check every 5 minutes
+    pollingInterval: 5 * 60 * 1000,
   })
 
   useEffect(() => {
+    // Vérifier s'il existe au moins un contrat actif
+    supabase
+      .from('contracts')
+      .select('id', { count: 'exact', head: true })
+      .eq('employer_id', profile.id)
+      .eq('status', 'active')
+      .then(({ count }) => setHasEmployees((count ?? 0) > 0))
+      .catch(() => setHasEmployees(false))
+
     getEmployer(profile.id)
       .then(setEmployer)
       .catch((err) => logger.error('Erreur chargement profil employeur:', err))
@@ -61,7 +128,6 @@ export function EmployerDashboard({ profile }: EmployerDashboardProps) {
         nextWeek.setDate(nextWeek.getDate() + 7)
 
         const data = await getShifts(profile.id, 'employer', today, nextWeek)
-        // Filter only planned/future shifts and limit to 5
         const upcomingShifts = data
           .filter((s) => s.status === 'planned')
           .slice(0, 5)
@@ -81,7 +147,7 @@ export function EmployerDashboard({ profile }: EmployerDashboardProps) {
       templateColumns={{ base: '1fr', lg: '1fr 340px' }}
       gap={6}
     >
-      {/* Mobile: 1 — Desktop: full width row */}
+      {/* WelcomeCard — toujours affiché */}
       <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 1, lg: 0 }}>
         <WelcomeCard
           profile={profile}
@@ -91,45 +157,57 @@ export function EmployerDashboard({ profile }: EmployerDashboardProps) {
         />
       </GridItem>
 
-      {/* Onboarding — full width, before nudges */}
+      {/* Onboarding — toujours affiché (se masque auto quand terminé) */}
       <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 2, lg: 1 }}>
         <OnboardingWidget profile={profile} userRole="employer" />
       </GridItem>
 
-      {/* Mobile: 5 — Desktop: 3e (full width) — collapse quand vide */}
-      <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 5, lg: 2 }} css={{ '&:has(> [data-empty])': { display: 'none' } }}>
-        <ActionNudgesWidget employerId={profile.id} />
-      </GridItem>
-
-      {/* Mobile: 8 (dernier) — Desktop: 3e (full width, avant la grille) */}
-      <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 8, lg: 2 }}>
-        <StatsWidget userRole="employer" profileId={profile.id} />
-      </GridItem>
-
-      {/* Mobile: 2 — Desktop: col gauche */}
-      <GridItem order={{ base: 2, lg: 3 }} minW={0}>
-        <TodayPlanningWidget employerId={profile.id} />
-      </GridItem>
-
-      {/* Mobile: 3 — Desktop: col droite, span rows */}
-      <GridItem order={{ base: 3, lg: 3 }} gridRow={{ lg: 'span 3' }} minW={0}>
-        <Stack gap={6}>
-          <ComplianceWidget employerId={profile.id} />
-          <QuickActionsWidget userRole="employer" />
-        </Stack>
-      </GridItem>
-
-      {/* Mobile: 6 — Desktop: col gauche */}
-      {employer?.pchBeneficiary && employer.pchType && employer.pchMonthlyHours && (
-        <GridItem order={{ base: 6, lg: 4 }} minW={0}>
-          <PchEnvelopeWidget employerId={profile.id} />
+      {/* Empty state — aucun employé */}
+      {hasEmployees === false && (
+        <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 3, lg: 2 }}>
+          <EmptyDashboardState />
         </GridItem>
       )}
 
-      {/* Mobile: 7 — Desktop: col gauche */}
-      <GridItem order={{ base: 7, lg: 5 }} minW={0}>
-        <BudgetForecastWidget employerId={profile.id} />
-      </GridItem>
+      {/* Widgets principaux — uniquement si au moins un employé */}
+      {hasEmployees && (
+        <>
+          {/* Nudges — collapse si vide */}
+          <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 4, lg: 3 }} css={{ '&:has(> [data-empty])': { display: 'none' } }}>
+            <ActionNudgesWidget employerId={profile.id} />
+          </GridItem>
+
+          {/* Stats */}
+          <GridItem colSpan={{ base: 1, lg: 2 }} order={{ base: 8, lg: 3 }}>
+            <StatsWidget userRole="employer" profileId={profile.id} />
+          </GridItem>
+
+          {/* Planning du jour — col gauche */}
+          <GridItem order={{ base: 5, lg: 4 }} minW={0}>
+            <TodayPlanningWidget employerId={profile.id} />
+          </GridItem>
+
+          {/* Compliance + Actions rapides — col droite */}
+          <GridItem order={{ base: 6, lg: 4 }} gridRow={{ lg: 'span 3' }} minW={0}>
+            <Stack gap={6}>
+              <ComplianceWidget employerId={profile.id} />
+              <QuickActionsWidget userRole="employer" />
+            </Stack>
+          </GridItem>
+
+          {/* PCH — col gauche */}
+          {employer?.pchBeneficiary && employer.pchType && employer.pchMonthlyHours && (
+            <GridItem order={{ base: 6, lg: 5 }} minW={0}>
+              <PchEnvelopeWidget employerId={profile.id} />
+            </GridItem>
+          )}
+
+          {/* Budget — col gauche */}
+          <GridItem order={{ base: 7, lg: 6 }} minW={0}>
+            <BudgetForecastWidget employerId={profile.id} />
+          </GridItem>
+        </>
+      )}
     </Grid>
   )
 }


### PR DESCRIPTION
## Summary

Variante du dashboard employeur quand aucun contrat actif n'existe — remplace la grille de widgets vides par un empty state proéminent.

### Comportement

| État | Affichage |
|------|-----------|
| Aucun employé | Empty state (icône + titre + description + 2 CTAs) |
| ≥ 1 employé actif | Dashboard complet (planning, compliance, stats, budget…) |
| Toujours | WelcomeCard + OnboardingWidget (guide 3 étapes) |

### Empty state
- Icône "équipe" dans un carré arrondi
- Titre : "Ajoutez votre premier auxiliaire"
- Description + CTAs : "Ajouter un auxiliaire" → `/equipe` · "Voir le planning" → `/planning`
- Détection via `supabase.from('contracts').count` filtré `status = active`

### Tests (+4)
- Empty state affiché et widgets masqués quand 0 contrat
- CTAs présents dans l'empty state
- WelcomeCard + OnboardingWidget toujours visibles
- Widgets principaux affichés quand ≥ 1 contrat

### Roadmap
- 97/102 items prototype (95%)

## Test plan
- [x] 2214/2214 tests passent
- [x] TypeScript : 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)