### PR TITLE
fix(build): split vendor-chakra chunk to resolve TDZ error on Netlify

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,16 +83,21 @@ export default defineConfig({
             id.includes('/blob-stream/')
           ) return 'vendor-pdf'
 
-          // Chakra UI + Emotion + framer-motion + @ark-ui + @floating-ui (toujours chargés, groupés)
+          // @ark-ui + @zag-js en premier (dépendances primitives de Chakra)
+          if (id.includes('@ark-ui') || id.includes('@zag-js') || id.includes('@zagjs')) return 'vendor-ark'
+
+          // Emotion (CSS-in-JS runtime, chargé avant Chakra)
+          if (id.includes('@emotion')) return 'vendor-emotion'
+
+          // framer-motion / motion
           if (
-            id.includes('@chakra-ui') ||
-            id.includes('@emotion') ||
             id.includes('framer-motion') ||
             id.includes('/motion-dom/') ||
-            id.includes('/motion-utils/') ||
-            id.includes('@ark-ui') ||
-            id.includes('@floating-ui')
-          ) return 'vendor-chakra'
+            id.includes('/motion-utils/')
+          ) return 'vendor-motion'
+
+          // Chakra UI + @floating-ui (dépend d'Emotion + Ark)
+          if (id.includes('@chakra-ui') || id.includes('@floating-ui')) return 'vendor-chakra'
 
           // Supabase
           if (id.includes('@supabase')) return 'vendor-supabase'


### PR DESCRIPTION
## Summary

Correction d'une page blanche sur Netlify causée par une erreur TDZ (Temporal Dead Zone) dans le chunk `vendor-chakra`.

### Cause
Le lockdown SES de MetaMask modifie l'environnement JS avant le chargement des modules, ce qui déclenche une `ReferenceError: can't access lexical declaration 'hr' before initialization` dans le bundle monolithique Chakra (dépendances circulaires entre Chakra, Emotion, @ark-ui et framer-motion).

### Changements
- Découpage du chunk `vendor-chakra` en 4 chunks distincts :
  - `vendor-ark` — @ark-ui + @zag-js (primitives)
  - `vendor-emotion` — @emotion (CSS-in-JS runtime)
  - `vendor-motion` — framer-motion
  - `vendor-chakra` — @chakra-ui + @floating-ui

L'ordre de chargement est maintenant déterministe, ce qui résout l'erreur TDZ.

## Test plan
- [ ] Vérifier que le build passe (`npm run build`)
- [ ] Tester l'URL Netlify après deploy (avec et sans MetaMask)
- [ ] Vérifier qu'aucune régression visuelle sur les composants Chakra

🤖 Generated with [Claude Code](https://claude.com/claude-code)