### PR TITLE
fix(security): limit localStorage profile to id and role only

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -72,9 +72,14 @@ export const useAuthStore = create<AuthState>()(
     {
       name: 'unilien-auth',
       storage: createJSONStorage(() => localStorage),
-      // Ne persister que certaines données
+      // Ne persister que le strict minimum (id + role) pour le routage RBAC.
+      // Les données personnelles (nom, email, téléphone) ne sont PAS persistées
+      // afin de limiter l'exposition en cas de XSS sur localStorage.
+      // Le profil complet est re-fetché depuis Supabase à chaque chargement.
       partialize: (state) => ({
-        profile: state.profile,
+        profile: state.profile
+          ? { id: state.profile.id, role: state.profile.role }
+          : null,
       }),
     }
   )


### PR DESCRIPTION
## Summary
- Réduit l'exposition XSS en ne persistant que `id` et `role` dans localStorage au lieu du profil complet (`firstName`, `lastName`, `email`, `phone`)
- Le profil complet est re-fetché depuis Supabase à chaque chargement via `initialize()`, avant que le `<LoadingPage />` disparaisse — aucun impact UI

### Changements
- `src/stores/authStore.ts` : `partialize` filtre le profil pour ne garder que `id` et `role`

## Test plan
- [x] 2251 tests passent (128 fichiers)
- [x] Lint OK (0 errors)
- [x] Vérifier manuellement que le login fonctionne et que le nom s'affiche bien dans le header après chargement
- [x] Vérifier dans DevTools > Application > localStorage que seuls `id` et `role` sont stockés dans `unilien-auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)