### PR TITLE
fix(security): sanitize file names and extensions in upload services

### DIFF
--- a/src/lib/sanitize.test.ts
+++ b/src/lib/sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sanitizeText, sanitizeBasicHtml, escapeHtml, cleanUserInput } from './sanitize'
+import { sanitizeText, sanitizeBasicHtml, escapeHtml, cleanUserInput, sanitizeFileExtension, sanitizeFileName } from './sanitize'
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
@@ -131,5 +131,68 @@ describe('cleanUserInput', () => {
 
   it('retourne le texte propre sans modification si déjà propre', () => {
     expect(cleanUserInput('Texte propre')).toBe('Texte propre')
+  })
+})
+
+describe('sanitizeFileExtension', () => {
+  it('conserve une extension valide', () => {
+    expect(sanitizeFileExtension('pdf')).toBe('pdf')
+  })
+
+  it('convertit en minuscules', () => {
+    expect(sanitizeFileExtension('PDF')).toBe('pdf')
+  })
+
+  it('supprime les caractères spéciaux (path traversal)', () => {
+    expect(sanitizeFileExtension('pdf../../x')).toBe('pdfx')
+  })
+
+  it('supprime les slashes', () => {
+    expect(sanitizeFileExtension('pdf/../../etc/passwd')).toBe('pdfetcpass')
+  })
+
+  it('retourne "bin" pour une extension vide', () => {
+    expect(sanitizeFileExtension('')).toBe('bin')
+  })
+
+  it('retourne "bin" si que des caractères spéciaux', () => {
+    expect(sanitizeFileExtension('../../')).toBe('bin')
+  })
+
+  it('tronque les extensions trop longues', () => {
+    expect(sanitizeFileExtension('a'.repeat(50))).toHaveLength(10)
+  })
+})
+
+describe('sanitizeFileName', () => {
+  it('conserve un nom valide', () => {
+    expect(sanitizeFileName('bulletin_curie_2026_01.pdf')).toBe('bulletin_curie_2026_01.pdf')
+  })
+
+  it('remplace les caractères spéciaux par des underscores', () => {
+    expect(sanitizeFileName('fichier<script>.pdf')).toBe('fichier_script_.pdf')
+  })
+
+  it('bloque le path traversal (double points)', () => {
+    const result = sanitizeFileName('../../etc/passwd')
+    expect(result).not.toContain('..')
+    expect(result).not.toContain('/')
+  })
+
+  it('remplace les espaces par des underscores', () => {
+    expect(sanitizeFileName('mon fichier.pdf')).toBe('mon_fichier.pdf')
+  })
+
+  it('décode les noms URL-encodés', () => {
+    expect(sanitizeFileName('fichier%20test.pdf')).toBe('fichier_test.pdf')
+  })
+
+  it('tronque les noms trop longs à 200 caractères', () => {
+    const longName = 'a'.repeat(250) + '.pdf'
+    expect(sanitizeFileName(longName).length).toBeLessThanOrEqual(200)
+  })
+
+  it('retourne un nom par défaut si le résultat est vide', () => {
+    expect(sanitizeFileName('')).toMatch(/^file_\d+$/)
   })
 })

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -62,6 +62,29 @@ export function escapeHtml(text: string | null | undefined): string {
 }
 
 /**
+ * Sanitise une extension de fichier — n'autorise que [a-z0-9].
+ * Prévient le path traversal via des extensions malveillantes (ex: `pdf../../x`).
+ */
+export function sanitizeFileExtension(ext: string): string {
+  return ext.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 10) || 'bin'
+}
+
+/**
+ * Sanitise un nom de fichier pour le stockage Supabase.
+ * Whitelist : alphanumérique, underscore, tiret, point.
+ * Prévient le path traversal et les caractères spéciaux.
+ */
+export function sanitizeFileName(name: string): string {
+  const decoded = (() => { try { return decodeURIComponent(name) } catch { return name } })()
+  return decoded
+    .replace(/[^a-zA-Z0-9_.\- ]/g, '_')
+    .replace(/\.{2,}/g, '_')
+    .replace(/\s+/g, '_')
+    .slice(0, 200)
+    || `file_${Date.now()}`
+}
+
+/**
  * Nettoie et normalise le texte utilisateur
  * - Supprime le HTML
  * - Normalise les espaces multiples

--- a/src/services/absenceJustificationService.ts
+++ b/src/services/absenceJustificationService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
+import { sanitizeFileExtension } from '@/lib/sanitize'
 import type { Absence } from '@/types'
 
 const JUSTIFICATIONS_BUCKET = 'justifications'
@@ -79,7 +80,7 @@ export async function uploadJustification(
     throw new Error(validation.error)
   }
 
-  const fileExt = file.name.split('.').pop()?.toLowerCase() || 'pdf'
+  const fileExt = sanitizeFileExtension(file.name.split('.').pop() || 'pdf')
   const fileName = generateJustificationFileName(employeeId, fileExt, options)
 
   const { error: uploadError } = await supabase.storage

--- a/src/services/absenceService.test.ts
+++ b/src/services/absenceService.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/logger', () => ({
 
 vi.mock('@/lib/sanitize', () => ({
   sanitizeText: vi.fn((text: string) => text.trim()),
+  sanitizeFileExtension: vi.fn((ext: string) => ext.toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 10) || 'bin'),
 }))
 
 const mockValidateAbsenceRequest = vi.fn()

--- a/src/services/payslipStorageService.ts
+++ b/src/services/payslipStorageService.ts
@@ -10,6 +10,7 @@
 
 import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
+import { sanitizeFileName } from '@/lib/sanitize'
 import type { Payslip } from '@/types'
 import type { PayslipDbRow } from '@/types/database'
 import type { PayslipData } from '@/lib/export/types'
@@ -75,7 +76,8 @@ export async function uploadPayslipPdf(
   pdfDataUri: string
 ): Promise<string | null> {
   const blob = dataUriToBlob(pdfDataUri)
-  const path = `${employerId}/${employeeId}/${year}/${String(month).padStart(2, '0')}/${filename}`
+  const safeName = sanitizeFileName(filename)
+  const path = `${employerId}/${employeeId}/${year}/${String(month).padStart(2, '0')}/${safeName}`
 
   const { error } = await supabase.storage
     .from(BUCKET)

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
-import { sanitizeText } from '@/lib/sanitize'
+import { sanitizeText, sanitizeFileExtension } from '@/lib/sanitize'
 import { logAudit } from '@/services/auditService'
 import type { Profile, Employer, Employee, PchType } from '@/types'
 import type { ProfileDbRow } from '@/types/database'
@@ -144,7 +144,7 @@ export async function uploadAvatar(
   }
 
   // Générer un nom de fichier unique
-  const fileExt = file.name.split('.').pop()?.toLowerCase() || 'jpg'
+  const fileExt = sanitizeFileExtension(file.name.split('.').pop() || 'jpg')
   const fileName = `${profileId}/${Date.now()}.${fileExt}`
 
   // Supprimer l'ancien avatar s'il existe


### PR DESCRIPTION
## Summary
- Ajout de `sanitizeFileExtension()` et `sanitizeFileName()` dans `sanitize.ts` pour prévenir le path traversal dans les chemins de stockage Supabase
- Appliqué aux 3 services d'upload vulnérables : justificatifs d'absence, avatars, bulletins de paie

### Changements
- `src/lib/sanitize.ts` : 2 nouvelles fonctions (whitelist alphanum, blocage `..`, troncature)
- `src/services/absenceJustificationService.ts` : extension sanitisée
- `src/services/profileService.ts` : extension avatar sanitisée
- `src/services/payslipStorageService.ts` : filename complet sanitisé
- `src/lib/sanitize.test.ts` : 14 nouveaux tests (path traversal, slashes, troncature, edge cases)
- `src/services/absenceService.test.ts` : mock mis à jour

## Test plan
- [x] 2265 tests passent (128 fichiers)
- [x] Lint OK (0 errors)
- [x] Vérifier upload avatar dans Paramètres > Profil
- [x] Vérifier upload justificatif d'absence
- [x] Vérifier génération bulletin de paie avec stockage

🤖 Generated with [Claude Code](https://claude.com/claude-code)