### PR TITLE
fix(security): add rate limiting to invite edge functions

### DIFF
--- a/supabase/functions/_shared/rateLimit.ts
+++ b/supabase/functions/_shared/rateLimit.ts
@@ -1,0 +1,42 @@
+/**
+ * Rate limiter en mémoire par clé (userId).
+ * Chaque instance gère sa propre Map — créer une instance par Edge Function.
+ * Reset automatique au redéploiement de la fonction.
+ */
+
+interface RateLimitEntry {
+  count: number
+  resetAt: number
+}
+
+export function createRateLimiter(maxRequests: number, windowMs: number = 60_000) {
+  const map = new Map<string, RateLimitEntry>()
+
+  return {
+    /**
+     * Vérifie si la clé est rate-limitée.
+     * Incrémente le compteur à chaque appel.
+     * @returns true si la limite est dépassée
+     */
+    isLimited(key: string): boolean {
+      const now = Date.now()
+      const entry = map.get(key)
+
+      if (!entry || now > entry.resetAt) {
+        map.set(key, { count: 1, resetAt: now + windowMs })
+        return false
+      }
+
+      entry.count++
+      return entry.count > maxRequests
+    },
+
+    /** Réponse 429 standard avec headers CORS */
+    tooManyRequestsResponse(headers: Record<string, string>): Response {
+      return new Response(
+        JSON.stringify({ error: 'Too many requests' }),
+        { status: 429, headers }
+      )
+    },
+  }
+}

--- a/supabase/functions/invite-caregiver/index.ts
+++ b/supabase/functions/invite-caregiver/index.ts
@@ -5,6 +5,9 @@
 // ============================================
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { createRateLimiter } from '../_shared/rateLimit.ts'
+
+const rateLimiter = createRateLimiter(5) // max 5 invitations/min
 
 interface InvitePayload {
   email: string
@@ -68,6 +71,12 @@ serve(async (req: Request) => {
     // Verify the caller is actually the employer
     const token = authHeader.replace('Bearer ', '')
     const { data: { user: caller }, error: authError } = await supabaseAdmin.auth.getUser(token)
+
+    // Rate limiting par utilisateur authentifié
+    if (caller && rateLimiter.isLimited(caller.id)) {
+      return rateLimiter.tooManyRequestsResponse({ ...corsHeaders(req), 'Content-Type': 'application/json' })
+    }
+
     if (authError || !caller || caller.id !== employerId) {
       console.error('Auth check failed:', authError?.message, 'caller:', caller?.id, 'employerId:', employerId)
       return new Response(

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -5,6 +5,9 @@
 // ============================================
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { createRateLimiter } from '../_shared/rateLimit.ts'
+
+const rateLimiter = createRateLimiter(5) // max 5 invitations/min
 
 interface InvitePayload {
   email: string
@@ -68,6 +71,12 @@ serve(async (req: Request) => {
     // Verify the caller is actually the employer
     const token = authHeader.replace('Bearer ', '')
     const { data: { user: caller }, error: authError } = await supabaseAdmin.auth.getUser(token)
+
+    // Rate limiting par utilisateur authentifié
+    if (caller && rateLimiter.isLimited(caller.id)) {
+      return rateLimiter.tooManyRequestsResponse({ ...corsHeaders(req), 'Content-Type': 'application/json' })
+    }
+
     if (authError || !caller || caller.id !== employerId) {
       console.error('Auth check failed:', authError?.message, 'caller:', caller?.id, 'employerId:', employerId)
       return new Response(

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -3,6 +3,7 @@
 // ============================================
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { createRateLimiter } from '../_shared/rateLimit.ts'
 
 interface EmailPayload {
   to: string
@@ -24,21 +25,7 @@ function getCorsOrigin(req: Request): string {
   return ALLOWED_ORIGINS[0]
 }
 
-// Rate limiting en mémoire par userId (reset au redéploiement)
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
-const RATE_LIMIT_MAX = 10       // max 10 emails
-const RATE_LIMIT_WINDOW = 60000 // par minute
-
-function isRateLimited(userId: string): boolean {
-  const now = Date.now()
-  const entry = rateLimitMap.get(userId)
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(userId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW })
-    return false
-  }
-  entry.count++
-  return entry.count > RATE_LIMIT_MAX
-}
+const rateLimiter = createRateLimiter(10) // max 10 emails/min
 
 serve(async (req) => {
   const corsOrigin = getCorsOrigin(req)
@@ -94,11 +81,8 @@ serve(async (req) => {
     }
 
     // Rate limiting
-    if (isRateLimited(user.id)) {
-      return new Response(JSON.stringify({ error: 'Too many requests' }), {
-        status: 429,
-        headers: corsHeaders,
-      })
+    if (rateLimiter.isLimited(user.id)) {
+      return rateLimiter.tooManyRequestsResponse(corsHeaders)
     }
 
     const payload: EmailPayload = await req.json()

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -4,6 +4,7 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
 import webpush from 'npm:web-push@3.6.7'
+import { createRateLimiter } from '../_shared/rateLimit.ts'
 
 interface PushPayload {
   notificationId: string
@@ -22,21 +23,7 @@ function getCorsOrigin(req: Request): string {
   return ALLOWED_ORIGINS[0]
 }
 
-// Rate limiting en mémoire par userId (reset au redéploiement)
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
-const RATE_LIMIT_MAX = 30      // max 30 appels
-const RATE_LIMIT_WINDOW = 60000 // par minute
-
-function isRateLimited(userId: string): boolean {
-  const now = Date.now()
-  const entry = rateLimitMap.get(userId)
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(userId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW })
-    return false
-  }
-  entry.count++
-  return entry.count > RATE_LIMIT_MAX
-}
+const rateLimiter = createRateLimiter(30) // max 30 push/min
 
 serve(async (req) => {
   const corsOrigin = getCorsOrigin(req)
@@ -76,8 +63,8 @@ serve(async (req) => {
     }
 
     // Rate limiting par utilisateur authentifié
-    if (isRateLimited(user.id)) {
-      return new Response(JSON.stringify({ error: 'Too many requests' }), { status: 429, headers: corsHeaders })
+    if (rateLimiter.isLimited(user.id)) {
+      return rateLimiter.tooManyRequestsResponse(corsHeaders)
     }
 
     if (!vapidPublicKey || !vapidPrivateKey) {


### PR DESCRIPTION
## Summary
- Extraction de la logique de rate limiting dupliquée dans `_shared/rateLimit.ts` (factory `createRateLimiter`)
- Ajout du rate limiting (5/min) aux Edge Functions `invite-caregiver` et `invite-employee` qui n'avaient aucune protection
- Refactoring de `send-email` (10/min) et `send-push-notification` (30/min) pour utiliser le module partagé

### Changements
- `supabase/functions/_shared/rateLimit.ts` : nouveau module partagé
- `supabase/functions/invite-caregiver/index.ts` : rate limit 5/min ajouté
- `supabase/functions/invite-employee/index.ts` : rate limit 5/min ajouté
- `supabase/functions/send-email/index.ts` : refactoré vers `_shared/rateLimit`
- `supabase/functions/send-push-notification/index.ts` : refactoré vers `_shared/rateLimit`

## Test plan
- [x] Vérifier que l'invitation d'un aidant fonctionne toujours
- [x] Vérifier que l'invitation d'un employé fonctionne toujours
- [x] Vérifier qu'après 5 invitations rapides, la 6e retourne 429
- [x] Vérifier que l'envoi d'email et push fonctionnent toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)