### PR TITLE
chore(deps): bump dompurify from 3.3.3 to 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@react-pdf/renderer": "^4.4.1",
         "@supabase/supabase-js": "^2.101.0",
         "date-fns": "^4.1.0",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.0",
         "framer-motion": "^12.38.0",
         "pako": "^2.1.0",
         "react": "^19.2.5",
@@ -6221,9 +6221,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-pdf/renderer": "^4.4.1",
     "@supabase/supabase-js": "^2.101.0",
     "date-fns": "^4.1.0",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "framer-motion": "^12.38.0",
     "pako": "^2.1.0",
     "react": "^19.2.5",


### PR DESCRIPTION
## Summary
- Mise à jour de DOMPurify 3.3.3 → 3.4.0 pour corriger la vulnérabilité modérée GHSA-39q2-94rc-95cp
- `npm audit` passe désormais à 0 vulnérabilités

### Changements
- `package.json` / `package-lock.json` : bump dompurify

## Test plan
- [x] 42 tests sanitize passent
- [x] `npm audit` : 0 vulnerabilities
- [x] Vérifier que la saisie de texte dans le cahier de liaison / messages fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)