### PR TITLE
feat(security): add data retention policy and purge function

### DIFF
--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -1,0 +1,140 @@
+# Politique de conservation des données — Unilien
+
+_Dernière mise à jour : 16 avril 2026_
+
+---
+
+## 1. Contexte et base légale
+
+Unilien collecte et traite des données personnelles dans le cadre de la gestion de l'emploi à domicile pour personnes en situation de handicap. Conformément au **RGPD article 5.1(e)** (limitation de la conservation), les données ne doivent pas être conservées au-delà de la durée nécessaire à leur finalité.
+
+Cette politique définit les durées de conservation applicables et les mécanismes de purge automatique implémentés.
+
+### Références réglementaires
+
+| Texte | Application |
+|-------|-------------|
+| RGPD art. 5.1(e) | Limitation de la conservation |
+| RGPD art. 9 | Données de santé — traitement interdit sauf exceptions |
+| RGPD art. 17 | Droit à l'effacement (implémenté via `delete_own_data` / `delete_own_account`) |
+| Code du travail L3243-4 | Conservation des bulletins de paie — 5 ans |
+| Code du travail L1234-19 | Conservation des documents contractuels — 5 ans après fin de contrat |
+| Code de la sécurité sociale | Prescription URSSAF — 3 ans |
+| Code civil art. 2224 | Prescription de droit commun — 5 ans |
+
+---
+
+## 2. Durées de conservation
+
+Le point de départ de la durée de rétention est la **date de fin du dernier contrat actif** de l'employeur. Tant qu'un contrat est actif ou suspendu, aucune donnée n'est purgée.
+
+| Catégorie | Données concernées | Durée | Justification |
+|-----------|-------------------|-------|---------------|
+| **Contrats** | Table `contracts` | 5 ans | Code du travail — prescription prud'homale |
+| **Bulletins de paie** | Table `payslips` + PDFs Storage | 5 ans | Code du travail L3243-4 |
+| **Interventions** | Table `shifts` | 5 ans | Lié aux bulletins de paie (preuve des heures) |
+| **Absences** | Table `absences` + justificatifs Storage | 5 ans | Prescription prud'homale (litiges congés/maladie) |
+| **Déclarations CESU** | Table `cesu_declarations` + PDFs Storage | 3 ans | Prescription URSSAF |
+| **Données de santé** | Table `employer_health_data` | 6 mois | RGPD art. 9 — finalité cessée + délai de grâce |
+| **Messages** | Tables `conversations` + `liaison_messages` | 2 ans | Pas d'obligation légale — durée raisonnable |
+| **Notifications** | Tables `notifications`, `push_subscriptions`, `notification_preferences` | 6 mois | Pas d'obligation légale — données éphémères |
+| **Journal d'audit** | Table `audit_logs` | 5 ans | Traçabilité CNIL recommandée |
+
+---
+
+## 3. Cas particuliers
+
+### 3.1. Suppression volontaire par l'utilisateur (RGPD art. 17)
+
+L'utilisateur peut à tout moment demander la suppression de ses données via **Paramètres > Zone de danger** :
+
+- **Supprimer mes données** (`delete_own_data`) : supprime toutes les données personnelles, anonymise les audit logs
+- **Supprimer mon compte** (`delete_own_account`) : supprime les données + le compte auth
+
+Ces actions sont immédiates et ne dépendent pas de la politique de rétention.
+
+### 3.2. Contrats actifs
+
+Aucune purge automatique n'est effectuée tant qu'au moins un contrat de l'employeur est en statut `active` ou `suspended`. La rétention ne commence qu'après la fin du **dernier** contrat.
+
+### 3.3. Données partagées
+
+Les données liées à une relation employeur-employé (shifts, absences, messages) sont purgées en se basant sur le contrat de l'employeur. Les employés et aidants conservent leur profil tant qu'ils ont d'autres contrats actifs.
+
+### 3.4. Fichiers Storage (Supabase)
+
+Les fichiers stockés dans Supabase Storage (bulletins PDF, justificatifs, avatars) suivent les mêmes durées que leurs tables associées. La purge des enregistrements DB n'entraîne pas automatiquement la suppression des fichiers Storage — un nettoyage complémentaire est nécessaire (voir section 5).
+
+### 3.5. Audit logs
+
+Les audit logs de type `purge_retention` (preuve de la purge elle-même) sont conservés au-delà des 5 ans — ils ne sont jamais purgés automatiquement, pour garantir la traçabilité de la conformité.
+
+---
+
+## 4. Implémentation technique
+
+### 4.1. Table de configuration
+
+```sql
+-- Table : data_retention_policy (migration 050)
+-- Colonnes : data_category, retention_months, description, legal_basis
+```
+
+Les durées sont configurables en base de données. Toute modification doit être validée par le responsable légal et documentée.
+
+### 4.2. Fonction de purge
+
+```sql
+-- RPC : purge_expired_data()
+-- Type : SECURITY DEFINER (exécution avec les droits owner)
+-- Retour : jsonb avec le nombre d'éléments purgés par catégorie
+```
+
+La fonction :
+1. Identifie les employeurs dont **tous** les contrats sont terminés
+2. Pour chaque catégorie, vérifie si la durée de rétention est dépassée
+3. Supprime les données expirées
+4. Inscrit chaque purge dans `audit_logs` (action `purge_retention`)
+
+### 4.3. Exécution
+
+| Méthode | Disponibilité | Fréquence |
+|---------|--------------|-----------|
+| Appel manuel | Disponible | `SELECT purge_expired_data()` |
+| pg_cron | Supabase Pro requis | `0 3 1 * *` (1er du mois, 3h) |
+| Edge Function schedulée | Alternative | Cron externe appelant la RPC |
+
+**Recommandation** : exécuter la purge **une fois par mois**, de nuit, pour minimiser l'impact sur les performances.
+
+---
+
+## 5. Limitations actuelles et TODO
+
+| Élément | Statut | Description |
+|---------|--------|-------------|
+| Purge DB | ✅ Implémenté | RPC `purge_expired_data()` (migration 050) |
+| Configuration | ✅ Implémenté | Table `data_retention_policy` modifiable |
+| Audit trail | ✅ Implémenté | Chaque purge loguée dans `audit_logs` |
+| Exécution automatique | ⏳ En attente | Nécessite pg_cron (Supabase Pro) ou cron externe |
+| Purge fichiers Storage | ⏳ En attente | Les PDFs/images dans Storage ne sont pas encore purgés automatiquement |
+| Notification pré-suppression | ⏳ En attente | Prévenir l'utilisateur 30 jours avant la purge |
+| Archivage avant purge | ⏳ En attente | Option d'export des données avant suppression définitive |
+
+---
+
+## 6. Processus de révision
+
+Cette politique doit être révisée :
+- **Annuellement** dans le cadre de la revue RGPD
+- **À chaque changement réglementaire** affectant les durées de conservation
+- **À chaque évolution fonctionnelle** introduisant de nouvelles catégories de données
+
+Toute modification des durées dans `data_retention_policy` doit être accompagnée d'une mise à jour de ce document et d'une entrée dans `audit_logs`.
+
+---
+
+## 7. Contact
+
+Pour toute question relative à la conservation des données :
+- **Responsable du traitement** : l'employeur (utilisateur Unilien)
+- **Contact technique** : vzepharren@gmail.com

--- a/docs/MEDICAL_DATA_COMPLIANCE.md
+++ b/docs/MEDICAL_DATA_COMPLIANCE.md
@@ -97,7 +97,7 @@ Le traitement de donnees de sante est **interdit par defaut** sauf exceptions. L
 |----------|------------------------|
 | **Minimisation** (art. 5.1c) | Tous les champs medicaux sont optionnels — OK |
 | **Limitation de la finalite** (art. 5.1b) | Les donnees servent uniquement a adapter l'accompagnement et calculer les droits PCH |
-| **Limitation de conservation** (art. 5.1e) | A definir : supprimer les donnees X mois apres la fin de tous les contrats |
+| **Limitation de conservation** (art. 5.1e) | Defini : purge automatique apres fin de tous les contrats (migration 050, table `data_retention_policy`) |
 | **Integrite et confidentialite** (art. 5.1f) | Chiffrement + RLS + controle d'acces |
 | **Responsabilite** (art. 5.2) | Registre des traitements + mentions legales |
 
@@ -139,7 +139,7 @@ La certification HDS (articles L.1111-8 et R.1111-8-8 du Code de la sante publiq
 | Mesure | Priorite | Description |
 |--------|----------|-------------|
 | **Chiffrement colonnes** | Haute | Chiffrer `handicap_type`, `handicap_name`, `specific_needs` avec `pgsodium` — en attente migration Supabase self-hosted |
-| **Duree de conservation** | Moyenne | Politique de suppression automatique apres fin des contrats |
+| ~~**Duree de conservation**~~ | ~~Moyenne~~ | ✅ Table `data_retention_policy` + RPC `purge_expired_data()` (migration 050) |
 | **Registre des traitements** | Basse | Document formel pour la CNIL |
 
 ---
@@ -226,5 +226,6 @@ SELECT pgsodium.create_key(name := 'medical_data_key');
 - [x] Droit a l'effacement donnees (RPC `delete_own_data`) — migration 047
 - [x] Suppression de compte (RPC `delete_own_account` + double confirmation UI) — migration 047
 - [ ] Chiffrer les colonnes sensibles (pgsodium) — en attente migration self-hosted
-- [ ] Definir la duree de conservation et la politique de purge
+- [x] Definir la duree de conservation et la politique de purge — migration 050 (`data_retention_policy` + `purge_expired_data()`)
 - [ ] Creer le registre des traitements (document CNIL)
+- [ ] Activer l'execution automatique de `purge_expired_data()` via pg_cron (Supabase Pro) ou Edge Function schedulee

--- a/docs/SECURITY_SUMMARY.md
+++ b/docs/SECURITY_SUMMARY.md
@@ -57,13 +57,13 @@ Conclusion : la base de sécurité est saine et nettement au-dessus de la moyenn
   - Suivre `npm audit` (ex. chaîne `vite-plugin-pwa` / `serialize-javascript`) et appliquer les correctifs sans régression PWA.
 
 - **Stockage client**
-  - `localStorage` contient le profil utilisateur (sans tokens). En cas de XSS, ce profil reste exposé : limiter les champs persistés au strict nécessaire.
+  - `localStorage` ne contient plus que `id` et `role` du profil (PR #262). Les données personnelles (nom, email, téléphone) ne sont plus exposées en cas de XSS.
 
 - **Chiffrement des données sensibles**
   - Données de santé isolées dans `employer_health_data` et protégées par RLS owner-only ; chiffrement au repos (`pgsodium`) reste un objectif après migration Supabase self-hosted.
 
 - **Rate limiting**
-  - Pas encore de politique homogène sur tous les points sensibles (auth, upload, notifications) — à planifier selon l’hébergeur / Edge.
+  - Politique homogène sur toutes les Edge Functions : `send-email` (10/min), `send-push` (30/min), `invite-caregiver` (5/min), `invite-employee` (5/min). Module partagé `_shared/rateLimit.ts` (PR #264). Auth rate-limité nativement par Supabase.
 
 - **Pièces jointes / noms de fichiers**
   - Sanitisation du nom de fichier dans `attachmentService` (path traversal) — toujours pertinente.
@@ -97,7 +97,7 @@ Conclusion : la base de sécurité est saine et nettement au-dessus de la moyenn
   - Maintenir les dépendances à jour et rejouer les scénarios de non-régression décrits dans les rapports pentest après chaque migration RLS.
 
 - **Moyen terme**
-  - Chiffrement au repos pour données de santé ; rate limiting ciblé ; sanitisation stricte des noms de fichiers uploadés.
+  - Chiffrement au repos pour données de santé ; ~~rate limiting ciblé~~ ✅ ; ~~sanitisation stricte des noms de fichiers uploadés~~ ✅ (PR #263).
 
 - **Continu**
   - Auditer les policies RLS à chaque évolution de schéma ; tests d’autorisation sur les fonctions edge et tables clés.

--- a/supabase/migrations/050_data_retention_policy.sql
+++ b/supabase/migrations/050_data_retention_policy.sql
@@ -1,0 +1,201 @@
+-- ============================================
+-- Migration 050: Politique de conservation des données (RGPD art. 5.1e)
+-- ============================================
+
+-- Table de configuration des durées de rétention (modifiable par admin)
+CREATE TABLE IF NOT EXISTS data_retention_policy (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  data_category TEXT NOT NULL UNIQUE,
+  retention_months INTEGER NOT NULL,
+  description TEXT,
+  legal_basis TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Politique par défaut
+INSERT INTO data_retention_policy (data_category, retention_months, description, legal_basis) VALUES
+  ('payslips',           60, 'Bulletins de paie',                    'Code du travail L3243-4 — 5 ans'),
+  ('contracts',          60, 'Contrats de travail',                  'Code du travail — 5 ans après fin contrat'),
+  ('cesu_declarations',  36, 'Déclarations CESU',                   'Prescription URSSAF — 3 ans'),
+  ('health_data',         6, 'Données de santé (employer_health_data)', 'RGPD art. 9 — dès fin de finalité + 6 mois grâce'),
+  ('messages',           24, 'Messages et conversations',            'Pas d''obligation légale — 2 ans'),
+  ('notifications',       6, 'Notifications et push subscriptions',  'Pas d''obligation légale — 6 mois'),
+  ('shifts',             60, 'Interventions (shifts)',               'Lié aux bulletins de paie — 5 ans'),
+  ('absences',           60, 'Absences et justificatifs',            'Prescription prud''homale — 5 ans'),
+  ('audit_logs',         60, 'Journal d''audit',                     'Traçabilité CNIL recommandée — 5 ans')
+ON CONFLICT (data_category) DO NOTHING;
+
+-- RLS : lecture seule pour les utilisateurs authentifiés (admin only pour écriture)
+ALTER TABLE data_retention_policy ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read retention policy"
+  ON data_retention_policy FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- ============================================
+-- Fonction de purge des données expirées
+-- ============================================
+-- Appelée manuellement ou via cron (pg_cron / Edge Function schedulée)
+-- Purge les données des utilisateurs dont TOUS les contrats sont terminés
+-- depuis plus longtemps que la durée de rétention configurée.
+
+CREATE OR REPLACE FUNCTION purge_expired_data()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_policy RECORD;
+  v_employer RECORD;
+  v_cutoff TIMESTAMPTZ;
+  v_result jsonb := '{}'::jsonb;
+  v_count INTEGER;
+BEGIN
+  -- Pour chaque employeur dont TOUS les contrats sont terminés
+  FOR v_employer IN
+    SELECT DISTINCT c.employer_id,
+           MAX(c.end_date) AS last_contract_end
+    FROM contracts c
+    WHERE c.status = 'terminated'
+      AND c.end_date IS NOT NULL
+    GROUP BY c.employer_id
+    -- Exclure les employeurs qui ont encore des contrats actifs
+    HAVING NOT EXISTS (
+      SELECT 1 FROM contracts c2
+      WHERE c2.employer_id = c.employer_id
+        AND c2.status IN ('active', 'suspended')
+    )
+  LOOP
+    -- ── Données de santé ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'health_data';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM employer_health_data WHERE profile_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('health_data_purged', COALESCE((v_result->>'health_data_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'employer_health_data', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+    -- ── Messages et conversations ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'messages';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      -- Supprimer les messages des conversations de cet employeur
+      DELETE FROM liaison_messages WHERE conversation_id IN (
+        SELECT id FROM conversations WHERE employer_id = v_employer.employer_id
+      );
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('messages_purged', COALESCE((v_result->>'messages_purged')::int, 0) + v_count);
+      END IF;
+      -- Supprimer les conversations
+      DELETE FROM conversations WHERE employer_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('conversations_purged', COALESCE((v_result->>'conversations_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'conversations', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+    -- ── Notifications ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'notifications';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM notifications WHERE user_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('notifications_purged', COALESCE((v_result->>'notifications_purged')::int, 0) + v_count);
+      END IF;
+      DELETE FROM push_subscriptions WHERE user_id = v_employer.employer_id;
+      DELETE FROM notification_preferences WHERE user_id = v_employer.employer_id;
+    END IF;
+
+    -- ── Bulletins de paie ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'payslips';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM payslips WHERE employer_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('payslips_purged', COALESCE((v_result->>'payslips_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'payslips', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+    -- ── Déclarations CESU ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'cesu_declarations';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM cesu_declarations WHERE employer_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('cesu_purged', COALESCE((v_result->>'cesu_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'cesu_declarations', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+    -- ── Shifts (interventions) ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'shifts';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM shifts WHERE employer_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('shifts_purged', COALESCE((v_result->>'shifts_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'shifts', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+    -- ── Absences ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'absences';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM absences WHERE employer_id = v_employer.employer_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('absences_purged', COALESCE((v_result->>'absences_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'absences', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+    -- ── Contrats ──
+    SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'contracts';
+    v_cutoff := v_employer.last_contract_end::timestamptz + (v_policy.retention_months || ' months')::interval;
+    IF now() > v_cutoff THEN
+      DELETE FROM contracts WHERE employer_id = v_employer.employer_id AND status = 'terminated';
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_result := v_result || jsonb_build_object('contracts_purged', COALESCE((v_result->>'contracts_purged')::int, 0) + v_count);
+        INSERT INTO audit_logs (user_id, action, resource, details)
+        VALUES (v_employer.employer_id, 'purge_retention', 'contracts', jsonb_build_object('reason', 'retention_expired', 'cutoff', v_cutoff));
+      END IF;
+    END IF;
+
+  END LOOP;
+
+  -- ── Audit logs (global, pas par employeur) ──
+  SELECT retention_months INTO v_policy FROM data_retention_policy WHERE data_category = 'audit_logs';
+  v_cutoff := now() - (v_policy.retention_months || ' months')::interval;
+  DELETE FROM audit_logs WHERE created_at < v_cutoff AND action != 'purge_retention';
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  IF v_count > 0 THEN
+    v_result := v_result || jsonb_build_object('audit_logs_purged', v_count);
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+-- Note : pour automatiser, activer pg_cron (Supabase Pro) :
+-- SELECT cron.schedule('purge-expired-data', '0 3 1 * *', 'SELECT purge_expired_data()');
+-- Ou appeler via une Edge Function schedulée / cron externe.


### PR DESCRIPTION
## Summary
- Implémentation de la politique de conservation des données (RGPD art. 5.1e)
- Migration 050 : table `data_retention_policy` + RPC `purge_expired_data()`
- Documentation complète dans `docs/DATA_RETENTION_POLICY.md`

### Changements
- `supabase/migrations/050_data_retention_policy.sql` : table config + RPC de purge
- `docs/DATA_RETENTION_POLICY.md` : politique complète (durées, cas particuliers, implémentation, TODO)
- `docs/MEDICAL_DATA_COMPLIANCE.md` : checklist item coché + mise à jour
- `docs/SECURITY_SUMMARY.md` : items localStorage, rate limiting, sanitisation marqués résolus

### Durées de rétention (après fin du dernier contrat)
| Catégorie | Durée |
|-----------|-------|
| Bulletins, contrats, shifts, absences | 5 ans |
| Déclarations CESU | 3 ans |
| Données de santé | 6 mois |
| Messages | 2 ans |
| Notifications | 6 mois |
| Audit logs | 5 ans |

## Test plan
- [x] Appliquer la migration sur un environnement de test
- [x] Vérifier `SELECT * FROM data_retention_policy` — 9 lignes
- [x] Appeler `SELECT purge_expired_data()` — retourne `{}` si aucun contrat terminé
- [x] Vérifier que la purge ne touche pas les employeurs avec contrats actifs

🤖 Generated with [Claude Code](https://claude.com/claude-code)