### PR TITLE
fix(security): allow WebAssembly in CSP for @react-pdf/renderer

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,7 +20,7 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(self), geolocation=()"
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co wss://*.supabase.co; img-src 'self' data: blob: https://*.supabase.co; font-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co wss://*.supabase.co; img-src 'self' data: blob: https://*.supabase.co; font-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
 # Cache long pour les assets statiques (hash dans le nom)
 [[headers]]


### PR DESCRIPTION
## Summary
- Ajout de `'wasm-unsafe-eval'` à la directive `script-src` de la CSP dans `netlify.toml`
- Corrige l'erreur `CompileError: call to WebAssembly.instantiate() blocked by CSP`
- Causé par `@react-pdf/renderer` (pdfkit utilise WASM pour compression/polices)

### Changements
- `netlify.toml` : `script-src 'self' 'wasm-unsafe-eval'`

## Test plan
- [ ] Vérifier que la génération de bulletins PDF fonctionne en production
- [ ] Vérifier que l'erreur WASM/CSP a disparu dans la console
- [ ] Vérifier que `eval()` reste bloqué (tester dans la console DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)