### PR TITLE
feat(planning): improve guard 24h UX and add hours breakdown

### DIFF
--- a/src/components/planning/Guard24hSection.tsx
+++ b/src/components/planning/Guard24hSection.tsx
@@ -5,7 +5,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { AccessibleInput, AccessibleButton } from '@/components/ui'
-import { calculateShiftDuration } from '@/lib/compliance/utils'
+import { calculateShiftDuration, calculateNightHours } from '@/lib/compliance/utils'
 import { REQUALIFICATION_THRESHOLD } from '@/hooks/useShiftRequalification'
 import type { GuardSegment } from '@/types'
 import { formatHoursCompact } from '@/lib/formatHours'
@@ -25,14 +25,25 @@ interface Guard24hSectionProps {
 
 const SEG_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
-  { value: 'presence_day', label: 'Présence responsable (jour)' },
-  { value: 'presence_night', label: 'Présence (nuit)' },
+  { value: 'presence', label: 'Présence responsable' },
 ]
 
 const SEG_COLORS: Record<string, string> = {
   effective: '#93B4D1',
   presence_day: '#B3D4A0',
   presence_night: '#C4B5E0',
+}
+
+/** Map DB type to select value */
+function toSelectValue(type: GuardSegment['type']): string {
+  return type === 'presence_day' || type === 'presence_night' ? 'presence' : type
+}
+
+/** Auto-detect presence_day or presence_night based on segment time range */
+function detectPresenceType(startTime: string, endTime: string): GuardSegment['type'] {
+  const nightHours = calculateNightHours(new Date(), startTime, endTime)
+  const totalHours = calculateShiftDuration(startTime, endTime, 0) / 60
+  return nightHours > totalHours / 2 ? 'presence_night' : 'presence_day'
 }
 
 export function Guard24hSection({
@@ -64,7 +75,7 @@ export function Guard24hSection({
         color="text.muted"
         mb={3}
       >
-        Segments de la garde
+        Découpage des 24h
       </Text>
 
       {/* Barre visuelle — proto: guard-bar (10px, full radius) */}
@@ -129,8 +140,16 @@ export function Guard24hSection({
 
               {/* Select type — inline, pas de label */}
               <select
-                value={seg.type}
-                onChange={(e) => onUpdateSegmentType(i, e.target.value as GuardSegment['type'])}
+                value={toSelectValue(seg.type)}
+                onChange={(e) => {
+                  const val = e.target.value
+                  if (val === 'presence') {
+                    const segEnd = guardSegments[i + 1]?.startTime ?? guardSegments[0].startTime
+                    onUpdateSegmentType(i, detectPresenceType(seg.startTime, segEnd))
+                  } else {
+                    onUpdateSegmentType(i, val as GuardSegment['type'])
+                  }
+                }}
                 style={{
                   fontSize: '13px',
                   fontWeight: 500,
@@ -151,10 +170,12 @@ export function Guard24hSection({
               {/* Break — inline petit input + "min" */}
               {seg.type === 'effective' ? (
                 <Flex align="center" gap={1} fontSize="12px" color="text.muted">
+                  <Text fontSize="12px" color="text.muted">Pause</Text>
                   <input
                     type="number"
                     value={seg.breakMinutes ?? 0}
                     onChange={(e) => onUpdateSegmentBreak(i, Math.max(0, parseInt(e.target.value) || 0))}
+                    aria-label="Pause en minutes"
                     style={{
                       width: '50px',
                       padding: '4px 6px',
@@ -167,9 +188,21 @@ export function Guard24hSection({
                   />
                   <Text fontSize="12px" color="text.muted">min</Text>
                 </Flex>
-              ) : (
-                <Text fontSize="12px" color="text.muted" px={2}>—</Text>
-              )}
+              ) : (() => {
+                const segEnd = guardSegments[i + 1]?.startTime ?? guardSegments[0].startTime
+                const totalMins = calculateShiftDuration(seg.startTime, segEnd, 0)
+                const totalH = totalMins / 60
+                const nightH = calculateNightHours(new Date(), seg.startTime, segEnd)
+                const dayH = Math.max(0, totalH - nightH)
+                return (
+                  <Text fontSize="12px" color="text.muted" px={2} whiteSpace="nowrap">
+                    {dayH > 0 && `${formatHoursCompact(dayH)} jour`}
+                    {dayH > 0 && nightH > 0 && ' · '}
+                    {nightH > 0 && `${formatHoursCompact(nightH)} nuit`}
+                    {dayH === 0 && nightH === 0 && '—'}
+                  </Text>
+                )
+              })()}
 
               {/* Bouton ÷ — proto: btn-icon-sm */}
               <Flex
@@ -229,35 +262,83 @@ export function Guard24hSection({
       </Stack>
 
       {/* Footer — proto: guard-footer */}
-      <Flex
-        justify="space-between"
-        align="center"
-        pt={3}
-        borderTopWidth="1px"
-        borderColor="border.default"
-        mb={4}
-      >
-        <Text fontSize="14px" color="brand.500">
-          Travail effectif :{' '}
-          <Text as="span" fontWeight="bold" color={(effectiveHoursComputed ?? 0) > 12 ? '#DC2626' : 'brand.500'}>
-            {formatHoursCompact(effectiveHoursComputed ?? 0)}
-          </Text>
-          {' '}/ 12h max
-        </Text>
-        <AccessibleButton
-          variant="outline"
-          size="sm"
-          bg="transparent"
-          color="brand.500"
-          borderWidth="1.5px"
-          borderColor="border.default"
-          _hover={{ borderColor: 'brand.500', bg: 'brand.subtle' }}
-          onClick={() => onAddSegment(guardSegments.length - 1)}
-          accessibleLabel="Ajouter un segment"
-        >
-          + Ajouter un segment
-        </AccessibleButton>
-      </Flex>
+      {(() => {
+        let presenceDayH = 0
+        let presenceNightH = 0
+        guardSegments.forEach((seg, i) => {
+          if (seg.type !== 'presence_day' && seg.type !== 'presence_night') return
+          const segEnd = guardSegments[i + 1]?.startTime ?? guardSegments[0].startTime
+          const totalH = calculateShiftDuration(seg.startTime, segEnd, 0) / 60
+          const nightH = calculateNightHours(new Date(), seg.startTime, segEnd)
+          presenceDayH += Math.max(0, totalH - nightH)
+          presenceNightH += nightH
+        })
+        const effective = effectiveHoursComputed ?? 0
+        const totalCumul = effective + presenceDayH + presenceNightH
+        const hasPresence = presenceDayH > 0 || presenceNightH > 0
+
+        return (
+          <Stack
+            gap={1.5}
+            pt={3}
+            borderTopWidth="1px"
+            borderColor="border.default"
+            mb={4}
+          >
+            <Flex justify="space-between" align="center" gap={3}>
+              <Text fontSize="14px" color="brand.500">
+                Travail effectif :{' '}
+                <Text as="span" fontWeight="bold" color={effective > 12 ? '#DC2626' : 'brand.500'}>
+                  {formatHoursCompact(effective)}
+                </Text>
+                {' '}/ 12h max
+              </Text>
+              <AccessibleButton
+                variant="outline"
+                size="sm"
+                bg="transparent"
+                color="brand.500"
+                borderWidth="1.5px"
+                borderColor="border.default"
+                _hover={{ borderColor: 'brand.500', bg: 'brand.subtle' }}
+                onClick={() => onAddSegment(guardSegments.length - 1)}
+                accessibleLabel="Ajouter une plage"
+              >
+                + Ajouter une plage
+              </AccessibleButton>
+            </Flex>
+
+            {hasPresence && (
+              <Stack gap={0.5} fontSize="13px" color="text.muted">
+                {presenceDayH > 0 && (
+                  <Flex gap={2}>
+                    <Text minW="220px">Présence responsable (jour) :</Text>
+                    <Text fontWeight="600" color="text.default">
+                      {formatHoursCompact(presenceDayH)}
+                    </Text>
+                  </Flex>
+                )}
+                {presenceNightH > 0 && (
+                  <Flex gap={2}>
+                    <Text minW="220px">Présence responsable (nuit) :</Text>
+                    <Text fontWeight="600" color="text.default">
+                      {formatHoursCompact(presenceNightH)}
+                    </Text>
+                  </Flex>
+                )}
+              </Stack>
+            )}
+
+            <Text fontSize="13px" color="text.default" fontWeight="600">
+              Total cumulé :{' '}
+              <Text as="span" color={totalCumul > 24 ? '#DC2626' : 'text.default'}>
+                {formatHoursCompact(totalCumul)}
+              </Text>
+              {' '}/ 24h
+            </Text>
+          </Stack>
+        )
+      })()}
 
       {/* Nombre d'interventions nocturnes */}
       <Box mb={nightInterventionsCount >= REQUALIFICATION_THRESHOLD ? 3 : 0}>

--- a/src/hooks/useGuardSegments.ts
+++ b/src/hooks/useGuardSegments.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { calculateShiftDuration } from '@/lib/compliance'
+import { calculateShiftDuration, calculateNightHours } from '@/lib/compliance'
 import type { GuardSegment } from '@/types'
 
 /**
@@ -34,6 +34,22 @@ export function applyMinBreaks(segments: GuardSegment[]): GuardSegment[] {
     if (seg.type !== 'effective') return seg
     const minBreak = getMinBreakForSegment(i, segments)
     return { ...seg, breakMinutes: minBreak }
+  })
+}
+
+/**
+ * Re-detect presence_day/presence_night for presence segments based on time range.
+ * A segment is presence_night if majority of its hours fall in 21h-6h window.
+ */
+function redetectPresenceTypes(segments: GuardSegment[]): GuardSegment[] {
+  return segments.map((seg, i) => {
+    if (seg.type !== 'presence_day' && seg.type !== 'presence_night') return seg
+    const segEnd = segments[i + 1]?.startTime ?? segments[0].startTime
+    const totalHours = calculateShiftDuration(seg.startTime, segEnd, 0) / 60
+    if (totalHours <= 0) return seg
+    const nightHours = calculateNightHours(new Date(), seg.startTime, segEnd)
+    const detectedType = nightHours > totalHours / 2 ? 'presence_night' : 'presence_day'
+    return detectedType !== seg.type ? { ...seg, type: detectedType } : seg
   })
 }
 
@@ -84,7 +100,7 @@ export function useGuardSegments() {
       if (index + 1 < next.length) {
         next[index + 1] = { ...next[index + 1], startTime: newEndTime }
       }
-      return applyMinBreaks(next)
+      return applyMinBreaks(redetectPresenceTypes(next))
     })
   }, [])
 


### PR DESCRIPTION
## Summary
Améliorations UX de l'éditeur "Garde 24h" dans la modale intervention : clarification des libellés, ajout d'un label "Pause" sur l'input break, et enrichissement du footer avec détail présence responsable + total cumulé / 24h.

### Changements

**`Guard24hSection.tsx`**
- Titre : `Segments de la garde` → **`Découpage des 24h`**
- Bouton : `+ Ajouter un segment` → **`+ Ajouter une plage`** (+ aria-label synchro)
- Input pause : ajout du label **`Pause`** devant le champ minutes + `aria-label` pour accessibilité
- Footer restructuré (Stack) :
  - Ligne 1 : `Travail effectif : Xh / 12h max` (+ bouton ajouter une plage)
  - Ligne 2+3 : détail `Présence responsable (jour) : Xh` / `(nuit) : Xh` — libellés alignés sur 220px
  - Ligne 4 : `Total cumulé : Xh / 24h` (rouge si > 24h)

**`useGuardSegments.ts`**
- Ajout `redetectPresenceTypes()` : re-détecte automatiquement `presence_day` vs `presence_night` lorsque les bornes d'un segment présence sont modifiées (majorité nuit 21h-6h → `presence_night`)
- Appelé depuis `updateGuardSegmentEnd`

## Test plan
- [ ] Ouvrir une intervention Garde 24h → vérifier les nouveaux libellés (titre, bouton, pause)
- [ ] Vérifier alignement des lignes Présence responsable (jour)/(nuit) dans le footer
- [ ] Vérifier calcul Total cumulé = effectif + présence jour + présence nuit
- [ ] Total > 24h → affichage rouge
- [ ] Modifier la borne fin d'un segment présence → bascule auto jour ↔ nuit selon l'heure
- [x] `npm run lint` pass (0 errors)
- [x] `npm run test:run` pass (2265 tests / 128 fichiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)