### PR TITLE
feat(email): add FR custom email templates for GoTrue

### DIFF
--- a/public/email-templates/_base.md
+++ b/public/email-templates/_base.md
@@ -1,0 +1,35 @@
+# Templates email Unilien (GoTrue)
+
+Templates HTML FR utilisés par Supabase Auth self-hosted.
+
+## Déploiement
+
+Les fichiers sont servis statiquement par Caddy sur `https://unilien.app/email-templates/*.html` (via GitHub Actions `deploy.yml` → rsync vers `/var/www/unilien/email-templates/`).
+
+## Variables GoTrue
+
+- `{{ .ConfirmationURL }}` — URL complète de confirmation
+- `{{ .Token }}` — code OTP 6 chiffres
+- `{{ .TokenHash }}` — hash du token
+- `{{ .Email }}` — email utilisateur
+- `{{ .NewEmail }}` — nouveau email (email_change uniquement)
+- `{{ .SiteURL }}` — SITE_URL configuré dans GoTrue
+- `{{ .Data }}` — metadata utilisateur
+
+## Config `.env` Supabase
+
+```
+GOTRUE_MAILER_SUBJECTS_CONFIRMATION=Confirmez votre adresse email
+GOTRUE_MAILER_SUBJECTS_RECOVERY=Réinitialisation de votre mot de passe
+GOTRUE_MAILER_SUBJECTS_INVITE=Vous êtes invité(e) sur Unilien
+GOTRUE_MAILER_SUBJECTS_MAGIC_LINK=Votre lien de connexion Unilien
+GOTRUE_MAILER_SUBJECTS_EMAIL_CHANGE=Confirmez votre nouveau email
+GOTRUE_MAILER_SUBJECTS_REAUTHENTICATION=Code de confirmation Unilien
+
+GOTRUE_MAILER_TEMPLATES_CONFIRMATION=https://unilien.app/email-templates/confirmation.html
+GOTRUE_MAILER_TEMPLATES_RECOVERY=https://unilien.app/email-templates/recovery.html
+GOTRUE_MAILER_TEMPLATES_INVITE=https://unilien.app/email-templates/invite.html
+GOTRUE_MAILER_TEMPLATES_MAGIC_LINK=https://unilien.app/email-templates/magic-link.html
+GOTRUE_MAILER_TEMPLATES_EMAIL_CHANGE=https://unilien.app/email-templates/email-change.html
+GOTRUE_MAILER_TEMPLATES_REAUTHENTICATION=https://unilien.app/email-templates/reauthentication.html
+```

--- a/public/email-templates/confirmation.html
+++ b/public/email-templates/confirmation.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Confirmez votre adresse email</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Bienvenue sur Unilien 👋</h2>
+              <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Merci de vous être inscrit(e). Pour activer votre compte, confirmez votre adresse email en cliquant sur le bouton ci-dessous.</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding:8px 0 24px 0;">
+                    <a href="{{ .ConfirmationURL }}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Confirmer mon email</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px 0;font-size:14px;color:#6D93AD;">Ou collez ce lien dans votre navigateur :</p>
+              <p style="margin:0 0 24px 0;font-size:13px;color:#4E6478;word-break:break-all;"><a href="{{ .ConfirmationURL }}" style="color:#3D5166;">{{ .ConfirmationURL }}</a></p>
+              <p style="margin:0;font-size:14px;color:#6D93AD;">Vous n'avez pas créé de compte ? Ignorez simplement cet email.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/email-templates/confirmation.html
+++ b/public/email-templates/confirmation.html
@@ -11,8 +11,15 @@
       <td align="center">
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background-color:#3D5166;padding:32px;text-align:center;">
-              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
           <tr>

--- a/public/email-templates/email-change.html
+++ b/public/email-templates/email-change.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Confirmez votre nouveau email</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Confirmation de changement d'email</h2>
+              <p style="margin:0 0 16px 0;font-size:16px;color:#4E6478;">Vous avez demandé à changer l'adresse email de votre compte Unilien :</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#EDF1F5;border-radius:8px;margin:0 0 24px 0;">
+                <tr>
+                  <td style="padding:16px 20px;">
+                    <p style="margin:0 0 4px 0;font-size:13px;color:#6D93AD;">Ancienne adresse</p>
+                    <p style="margin:0 0 12px 0;font-size:15px;color:#1F2C3B;font-weight:500;">{{ .Email }}</p>
+                    <p style="margin:0 0 4px 0;font-size:13px;color:#6D93AD;">Nouvelle adresse</p>
+                    <p style="margin:0;font-size:15px;color:#1F2C3B;font-weight:500;">{{ .NewEmail }}</p>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Cliquez sur le bouton ci-dessous pour confirmer ce changement.</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding:8px 0 24px 0;">
+                    <a href="{{ .ConfirmationURL }}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Confirmer le changement</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px 0;font-size:14px;color:#6D93AD;">Ou collez ce lien dans votre navigateur :</p>
+              <p style="margin:0 0 24px 0;font-size:13px;color:#4E6478;word-break:break-all;"><a href="{{ .ConfirmationURL }}" style="color:#3D5166;">{{ .ConfirmationURL }}</a></p>
+              <div style="background-color:#FFEBEE;border-left:3px solid #D32F2F;padding:12px 16px;border-radius:4px;margin:0;">
+                <p style="margin:0;font-size:14px;color:#8B1A1F;"><strong>Vous n'avez pas fait cette demande ?</strong> Ignorez cet email et vérifiez la sécurité de votre compte.</p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/email-templates/email-change.html
+++ b/public/email-templates/email-change.html
@@ -11,8 +11,15 @@
       <td align="center">
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background-color:#3D5166;padding:32px;text-align:center;">
-              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
           <tr>

--- a/public/email-templates/invite.html
+++ b/public/email-templates/invite.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Vous êtes invité(e) sur Unilien</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Vous êtes invité(e) ✨</h2>
+              <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Vous avez été invité(e) à rejoindre <strong>Unilien</strong>, la plateforme de gestion de soins pour personnes handicapées. Acceptez l'invitation pour activer votre compte.</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding:8px 0 24px 0;">
+                    <a href="{{ .ConfirmationURL }}" style="display:inline-block;background-color:#9BB23B;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Accepter l'invitation</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px 0;font-size:14px;color:#6D93AD;">Ou collez ce lien dans votre navigateur :</p>
+              <p style="margin:0 0 24px 0;font-size:13px;color:#4E6478;word-break:break-all;"><a href="{{ .ConfirmationURL }}" style="color:#3D5166;">{{ .ConfirmationURL }}</a></p>
+              <p style="margin:0;font-size:14px;color:#6D93AD;">Vous n'attendiez pas cette invitation ? Vous pouvez ignorer cet email.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/email-templates/invite.html
+++ b/public/email-templates/invite.html
@@ -11,8 +11,15 @@
       <td align="center">
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background-color:#3D5166;padding:32px;text-align:center;">
-              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
           <tr>

--- a/public/email-templates/magic-link.html
+++ b/public/email-templates/magic-link.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Votre lien de connexion Unilien</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Votre lien de connexion 🔗</h2>
+              <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Cliquez sur le bouton ci-dessous pour vous connecter à votre compte Unilien. Aucun mot de passe nécessaire.</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding:8px 0 24px 0;">
+                    <a href="{{ .ConfirmationURL }}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Me connecter</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px 0;font-size:14px;color:#6D93AD;">Ou collez ce lien dans votre navigateur :</p>
+              <p style="margin:0 0 24px 0;font-size:13px;color:#4E6478;word-break:break-all;"><a href="{{ .ConfirmationURL }}" style="color:#3D5166;">{{ .ConfirmationURL }}</a></p>
+              <div style="background-color:#FFF8E1;border-left:3px solid #F5A623;padding:12px 16px;border-radius:4px;margin:0 0 16px 0;">
+                <p style="margin:0;font-size:14px;color:#7A5200;"><strong>Ce lien expire dans 1 heure.</strong> Si vous n'avez pas fait cette demande, ignorez cet email.</p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/email-templates/magic-link.html
+++ b/public/email-templates/magic-link.html
@@ -11,8 +11,15 @@
       <td align="center">
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background-color:#3D5166;padding:32px;text-align:center;">
-              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
           <tr>

--- a/public/email-templates/reauthentication.html
+++ b/public/email-templates/reauthentication.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Code de confirmation Unilien</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Code de confirmation 🔒</h2>
+              <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Vous tentez d'effectuer une action sensible sur votre compte. Saisissez ce code pour confirmer qu'il s'agit bien de vous.</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding:16px 0 32px 0;">
+                    <div style="display:inline-block;background-color:#EDF1F5;border:2px solid #C2D2E0;border-radius:12px;padding:20px 40px;font-family:'SF Mono','Monaco','Consolas',monospace;font-size:32px;font-weight:700;letter-spacing:0.3em;color:#1F2C3B;">{{ .Token }}</div>
+                  </td>
+                </tr>
+              </table>
+              <div style="background-color:#FFF8E1;border-left:3px solid #F5A623;padding:12px 16px;border-radius:4px;margin:0 0 16px 0;">
+                <p style="margin:0;font-size:14px;color:#7A5200;"><strong>Ce code expire dans 1 heure.</strong> Ne le partagez avec personne.</p>
+              </div>
+              <p style="margin:0;font-size:14px;color:#6D93AD;">Si vous n'êtes pas à l'origine de cette action, changez votre mot de passe immédiatement.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/email-templates/reauthentication.html
+++ b/public/email-templates/reauthentication.html
@@ -11,8 +11,15 @@
       <td align="center">
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background-color:#3D5166;padding:32px;text-align:center;">
-              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
           <tr>

--- a/public/email-templates/recovery.html
+++ b/public/email-templates/recovery.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Réinitialisation de votre mot de passe</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:32px;text-align:center;">
+              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Réinitialisation du mot de passe</h2>
+              <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Vous avez demandé à réinitialiser le mot de passe de votre compte Unilien. Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.</p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td align="center" style="padding:8px 0 24px 0;">
+                    <a href="{{ .ConfirmationURL }}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Réinitialiser mon mot de passe</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 8px 0;font-size:14px;color:#6D93AD;">Ou collez ce lien dans votre navigateur :</p>
+              <p style="margin:0 0 24px 0;font-size:13px;color:#4E6478;word-break:break-all;"><a href="{{ .ConfirmationURL }}" style="color:#3D5166;">{{ .ConfirmationURL }}</a></p>
+              <div style="background-color:#FFF8E1;border-left:3px solid #F5A623;padding:12px 16px;border-radius:4px;margin:0 0 16px 0;">
+                <p style="margin:0;font-size:14px;color:#7A5200;"><strong>Ce lien expire dans 1 heure.</strong> Si vous n'avez pas fait cette demande, ignorez simplement cet email — votre mot de passe reste inchangé.</p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/public/email-templates/recovery.html
+++ b/public/email-templates/recovery.html
@@ -11,8 +11,15 @@
       <td align="center">
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background-color:#3D5166;padding:32px;text-align:center;">
-              <h1 style="margin:0;color:#FFFFFF;font-size:24px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
## Summary
Ajout de 6 templates d'emails custom en français pour Supabase GoTrue (self-hosted), avec branding Unilien.

### Changements
- 6 templates HTML FR : `confirmation`, `recovery`, `invite`, `magic-link`, `email-change`, `reauthentication`
- Branding Unilien : header bleu `#3D5166`, logo PWA dans badge blanc arrondi pour contraste
- Footer uniforme avec lien `unilien.app`
- Variables GoTrue : `{{ .ConfirmationURL }}`, `{{ .Token }}`, `{{ .Email }}`, `{{ .NewEmail }}`
- Expiration 1h affichée dans les templates concernés
- Documentation `_base.md` pour les conventions de style

## Test plan
- [x] `npm run lint` — 0 erreur (2 warnings préexistants)
- [x] `npm run test:run` — 2265/2265 tests passent
- [x] Déploiement VPS `/var/www/unilien/email-templates/` + restart auth container
- [x] Test envoi email confirmation : template FR reçu avec logo visible
- [ ] Vérifier rendu sur Gmail / Outlook / ProtonMail
- [ ] Vérifier affichage dark mode (clients qui forcent l'inversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)