### PR TITLE
chore(ci): restrict production deploy to main branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,14 @@ name: Deploy to Production
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     environment:
       name: env_unilien
       url: ${{ vars.VITE_APP_URL }}


### PR DESCRIPTION
## Summary
Restreint le workflow de déploiement production à la seule branche `main` pour éviter un déploiement accidentel via `workflow_dispatch` depuis une autre branche.

### Changements
- Retrait de `master` du trigger `push.branches` (branche inexistante)
- Ajout d'une garde `if: github.ref == 'refs/heads/main'` sur le job `deploy` — double protection pour `workflow_dispatch`

## Test plan
- [ ] Workflow visible sur main après merge
- [ ] Vérifier qu'un `workflow_dispatch` lancé depuis une autre branche skip le job (badge "Skipped" au lieu de "Success")
- [ ] Premier push sur main post-merge déploie normalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)