### PR TITLE
feat(email): use verified unilien.app domain for Resend

### DIFF
--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -110,7 +110,7 @@ function emailLayout(content: string): string {
             <td style="padding:20px 32px;border-top:1px solid #f0f0f0;background:#fafafa;">
               <p style="margin:0;font-size:12px;color:#999;text-align:center;">
                 Unilien — Gestion de vos auxiliaires de vie<br/>
-                <a href="https://unilien.fr" style="color:#2563eb;text-decoration:none;">unilien.fr</a>
+                <a href="https://unilien.app" style="color:#2563eb;text-decoration:none;">unilien.app</a>
               </p>
             </td>
           </tr>
@@ -157,7 +157,7 @@ function shiftReminderTemplate(data: ShiftReminderData): string {
       </table>
     </div>
 
-    <a href="https://unilien.fr/planning" style="display:inline-block;background:#2563eb;color:#ffffff;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;">
+    <a href="https://unilien.app/planning" style="display:inline-block;background:#2563eb;color:#ffffff;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;">
       Voir le planning
     </a>
   `)

--- a/src/services/notificationCreators.ts
+++ b/src/services/notificationCreators.ts
@@ -202,7 +202,7 @@ export async function createMessageNotification(
         recipientName,
         senderName,
         preview: messagePreview.substring(0, 120),
-        conversationUrl: 'https://unilien.fr/messagerie',
+        conversationUrl: 'https://unilien.app/messagerie',
       })
     }
   } catch (err) {

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -13,9 +13,8 @@ interface EmailPayload {
 }
 
 const ALLOWED_ORIGINS = [
-  'https://unilien.fr',
-  'https://www.unilien.fr',
-  'https://unilien.netlify.app',
+  'https://unilien.app',
+  'https://www.unilien.app',
 ]
 
 function getCorsOrigin(req: Request): string {
@@ -101,7 +100,7 @@ serve(async (req) => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        from: 'Unilien <onboarding@resend.dev>',
+        from: 'Unilien <notifications@unilien.app>',
         to: payload.to,
         subject: payload.subject,
         html: payload.html,


### PR DESCRIPTION
## Summary

Migration de l'expéditeur Resend depuis `onboarding@resend.dev` (limité au compte) vers le domaine vérifié `unilien.app`. Débloque l'envoi d'emails transactionnels à tous les utilisateurs.

### Changements

- Expéditeur Edge Function : `Unilien <notifications@unilien.app>`
- `ALLOWED_ORIGINS` nettoyés : `unilien.app` + `www.unilien.app` (suppression `unilien.fr` + `unilien.netlify.app`)
- Liens dans les templates email (footer + CTA planning) → `unilien.app`
- URL messagerie dans `notificationCreators.ts` → `unilien.app`

### Hors scope (PR séparée)

- CORS des autres Edge Functions (`send-push-notification`, `invite-employee`, `invite-caregiver`)
- `supabase/config.toml` redirect URLs
- Pages UI (LegalPage, ContactPage) qui affichent `contact@unilien.fr`
- `public/robots.txt` sitemap

## Test plan

- [ ] Déployer Edge Function `send-email` sur Supabase self-hosted
- [ ] Envoi rappel intervention J-1 → vérifier réception Gmail (light + dark mode)
- [ ] Envoi rappel intervention J-1 → vérifier réception Outlook
- [ ] Envoi rappel intervention J-1 → vérifier réception ProtonMail
- [ ] Envoi notification nouveau message → vérifier rendu + lien CTA
- [ ] Vérifier DKIM/SPF/DMARC valides dans les headers reçus
- [ ] `npm run lint` ✅
- [ ] `npm run test:run` ✅ (2265/2265)