### PR TITLE
refactor(email): align templates with recovery.html Ardoise palette

### DIFF
--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -80,38 +80,40 @@ export async function sendNewMessageNotification(to: string, data: NewMessageDat
 // HTML TEMPLATES
 // ============================================
 
-function emailLayout(content: string): string {
+function emailLayout(title: string, content: string): string {
   return `<!DOCTYPE html>
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Unilien</title>
+  <title>${title}</title>
 </head>
-<body style="margin:0;padding:0;background:#f5f5f5;font-family:Inter,Arial,sans-serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f5;padding:32px 0;">
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
     <tr>
       <td align="center">
-        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
-          <!-- Header -->
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
           <tr>
-            <td style="background:#2563eb;padding:24px 32px;">
-              <span style="color:#ffffff;font-size:22px;font-weight:700;letter-spacing:-0.5px;">Unilien</span>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
             </td>
           </tr>
-          <!-- Content -->
           <tr>
-            <td style="padding:32px;">
+            <td style="padding:40px 32px 24px 32px;">
               ${content}
             </td>
           </tr>
-          <!-- Footer -->
           <tr>
-            <td style="padding:20px 32px;border-top:1px solid #f0f0f0;background:#fafafa;">
-              <p style="margin:0;font-size:12px;color:#999;text-align:center;">
-                Unilien — Gestion de vos auxiliaires de vie<br/>
-                <a href="https://unilien.app" style="color:#2563eb;text-decoration:none;">unilien.app</a>
-              </p>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
             </td>
           </tr>
         </table>
@@ -123,61 +125,69 @@ function emailLayout(content: string): string {
 }
 
 function shiftReminderTemplate(data: ShiftReminderData): string {
-  return emailLayout(`
-    <h2 style="margin:0 0 8px;font-size:20px;color:#111;font-weight:600;">Rappel d'intervention</h2>
-    <p style="margin:0 0 24px;font-size:14px;color:#666;">Bonjour ${data.recipientName},</p>
+  return emailLayout('Rappel d\'intervention', `
+    <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Rappel d'intervention</h2>
+    <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Bonjour ${data.recipientName}, votre prochaine intervention est prévue pour demain.</p>
 
-    <div style="background:#eff6ff;border-radius:8px;padding:20px;margin-bottom:24px;">
-      <table width="100%" cellpadding="0" cellspacing="0">
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="font-size:13px;color:#6b7280;display:block;">Date</span>
-            <span style="font-size:15px;color:#111;font-weight:600;">${data.date}</span>
-          </td>
-        </tr>
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="font-size:13px;color:#6b7280;display:block;">Horaires</span>
-            <span style="font-size:15px;color:#111;font-weight:600;">${data.startTime}${data.endTime ? ` – ${data.endTime}` : ''}</span>
-          </td>
-        </tr>
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="font-size:13px;color:#6b7280;display:block;">Employeur</span>
-            <span style="font-size:15px;color:#111;font-weight:600;">${data.employerName}</span>
-          </td>
-        </tr>
-        ${data.address ? `
-        <tr>
-          <td style="padding:6px 0;">
-            <span style="font-size:13px;color:#6b7280;display:block;">Adresse</span>
-            <span style="font-size:15px;color:#111;font-weight:600;">${data.address}</span>
-          </td>
-        </tr>` : ''}
-      </table>
-    </div>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#EDF1F5;border-radius:8px;margin-bottom:24px;">
+      <tr>
+        <td style="padding:20px 24px;">
+          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Date</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.date}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Horaires</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.startTime}${data.endTime ? ` – ${data.endTime}` : ''}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Employeur</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.employerName}</span>
+              </td>
+            </tr>
+            ${data.address ? `
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Adresse</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.address}</span>
+              </td>
+            </tr>` : ''}
+          </table>
+        </td>
+      </tr>
+    </table>
 
-    <a href="https://unilien.app/planning" style="display:inline-block;background:#2563eb;color:#ffffff;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;">
-      Voir le planning
-    </a>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td align="center" style="padding:8px 0 0 0;">
+          <a href="https://unilien.app/planning" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Voir le planning</a>
+        </td>
+      </tr>
+    </table>
   `)
 }
 
 function newMessageTemplate(data: NewMessageData): string {
-  return emailLayout(`
-    <h2 style="margin:0 0 8px;font-size:20px;color:#111;font-weight:600;">Nouveau message</h2>
-    <p style="margin:0 0 24px;font-size:14px;color:#666;">Bonjour ${data.recipientName},</p>
+  return emailLayout('Nouveau message', `
+    <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Nouveau message</h2>
+    <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Bonjour ${data.recipientName}, <strong style="color:#1F2C3B;">${data.senderName}</strong> vous a envoyé un message.</p>
 
-    <p style="margin:0 0 16px;font-size:15px;color:#333;">
-      <strong>${data.senderName}</strong> vous a envoyé un message :
-    </p>
-
-    <div style="background:#f9fafb;border-left:3px solid #2563eb;border-radius:4px;padding:16px;margin-bottom:24px;">
-      <p style="margin:0;font-size:14px;color:#555;font-style:italic;">"${data.preview}…"</p>
+    <div style="background-color:#EDF1F5;border-left:3px solid #3D5166;border-radius:4px;padding:16px 20px;margin:0 0 24px 0;">
+      <p style="margin:0;font-size:15px;color:#4E6478;font-style:italic;">&ldquo;${data.preview}…&rdquo;</p>
     </div>
 
-    <a href="${data.conversationUrl}" style="display:inline-block;background:#2563eb;color:#ffffff;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600;text-decoration:none;">
-      Répondre
-    </a>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td align="center" style="padding:8px 0 0 0;">
+          <a href="${data.conversationUrl}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Répondre</a>
+        </td>
+      </tr>
+    </table>
   `)
 }


### PR DESCRIPTION
## Summary

Alignement visuel des templates email transactionnels (`shiftReminderTemplate`, `newMessageTemplate`) sur le design du template `recovery.html` (réinitialisation mot de passe) pour une cohérence de marque entre tous les emails envoyés aux utilisateurs.

### Changements

- Header : fond Ardoise `#3D5166` + **logo Unilien** dans un carré blanc arrondi (remplace le simple titre texte)
- Typographie : stack native `-apple-system, BlinkMacSystemFont, 'Segoe UI'...` (remplace Inter)
- Palette textes : `#1F2C3B` (brand-700) / `#4E6478` (brand-400) / `#6D93AD` (brand-300)
- Boîte info rappel intervention : fond `#EDF1F5` (brand-50)
- Bloc citation nouveau message : border-left Ardoise `#3D5166`
- Bouton CTA : `#3D5166` padding 14px 32px (plus présent)
- Footer : fond `#EDF1F5` + border `#C2D2E0` (brand-100) + liens slate

### Résultat

Les emails "rappel intervention" et "nouveau message" partagent désormais la même identité visuelle que le mail de réinitialisation de mot de passe (palette Ardoise, logo, typographie).

## Test plan

- [x] `npm run lint` ✅
- [x] `npm run typecheck` ✅
- [x] Envoi test aux 4 providers (Gmail, Outlook, ProtonMail, Yahoo) ✅ Resend IDs reçus
- [ ] Vérifier rendu light mode sur les 4 providers
- [x] Vérifier rendu dark mode sur les 4 providers
- [x] Vérifier cohérence visuelle avec mail de reset password