### PR TITLE
chore(ci): sync Edge Functions to VPS on main deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,24 @@ jobs:
             -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
             dist/ "$VPS_USER@$VPS_HOST:/var/www/unilien/"
 
+      - name: Deploy Edge Functions to VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          # Sync Edge Functions (preserve main/ and hello/ — runtime entrypoints)
+          rsync -avz --delete \
+            --exclude='.DS_Store' \
+            --exclude='*.test.ts' \
+            --exclude='main/' \
+            --exclude='hello/' \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            supabase/functions/ "$VPS_USER@$VPS_HOST:/opt/supabase/docker/volumes/functions/"
+
+          # Restart edge-runtime container to pick up new code
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "$VPS_USER@$VPS_HOST" \
+            "sudo -n docker compose --project-directory /opt/supabase/docker restart functions"
+
       - name: Health check
         run: |
           sleep 3


### PR DESCRIPTION
## Summary

Étend le workflow `deploy.yml` pour synchroniser automatiquement les Edge Functions Supabase sur le VPS self-hosted lors d'un push sur `main`, avec redémarrage du container `edge-runtime`.

Avant cette PR, `deploy.yml` ne déployait que le front (`dist/` → `/var/www/unilien/`) — toute modification des Edge Functions nécessitait un déploiement manuel (scp + docker restart).

### Changements

- Nouveau step **Deploy Edge Functions to VPS** après le deploy front
- `rsync` de `supabase/functions/` → `/opt/supabase/docker/volumes/functions/` sur le VPS
- Exclusions :
  - `main/` et `hello/` : entrypoints du runtime Supabase, non versionnés dans le repo
  - `*.test.ts` : fichiers de tests
  - `.DS_Store`
- `--delete` activé pour miroir : une fonction supprimée du repo disparaît du VPS
- Restart du container via `sudo -n docker compose restart functions` (passwordless sudo)

### Prérequis VPS (déjà appliqués)

- Ownership `debian:debian` sur tous les dossiers de `/opt/supabase/docker/volumes/functions/` (hors `main/` et `hello/`)
- Passwordless sudo pour `docker compose` vérifié OK

## Test plan

- [x] Dry-run rsync local → sync 4 fonctions + `_shared`, ne touche pas `main/hello/`
- [x] `sudo -n docker compose restart functions` OK manuellement
- [x] Merge → vérifier que le workflow passe sur main
- [x] Modifier une Edge Function dans une future PR → vérifier que le redéploiement automatique fonctionne