### PR TITLE
docs: self-host migration guide + meeting feedback + Whisper plan

### DIFF
--- a/docs/FEEDBACK_REUNION_2026-04-16.md
+++ b/docs/FEEDBACK_REUNION_2026-04-16.md
@@ -1,0 +1,238 @@
+# Feedback réunion — 16 avril 2026
+
+> Synthèse issue de la réunion avec Marie, Vincent, Nico (mentions : John, Philippe, Christophe).
+> Source : transcription audio automatique (fichier `reunion-16.04.2026.txt`).
+
+## Vue d'ensemble
+
+Retour globalement très positif sur l'avancée du produit. Marie considère qu'**on est proches d'une sortie en bêta**, avec quelques ajustements UX à faire avant de lancer les premiers tests utilisateurs.
+
+Trois axes de travail distincts ressortent :
+
+1. **Quick wins UI** (ajustements saisie intervention, pointage, suivi des heures)
+2. **Modèles de données / logique métier** (heures jour-nuit, absences, pauses)
+3. **Stratégie produit & commercialisation** (modules, formules, cibles)
+
+---
+
+## 1. Saisie d'intervention
+
+### 1.1 Segments jour / nuit → calcul automatique
+
+**Problème soulevé par Marie** : dans le tableau de saisie, la distinction manuelle `présence de jour` / `présence de nuit` pose problème dès qu'un créneau est à cheval (ex. 20h → 23h).
+
+**Statut : ✅ déjà implémenté pour la garde 24h** — voir `docs/Garde_de_24_heures.md` + section `Garde de 24h — N-segments libres (18/02/2026)` du CLAUDE.md.
+
+- Les segments sont typés `effective | astreinte | break` (pas jour/nuit).
+- Les majorations nuit sont appliquées **automatiquement** sur les segments effectifs entre 21h et 6h (migration `030_guard_segments_v2`).
+- Validations : total effectif ≤ 12h (bloquant), présence nuit > 12h (avertissement).
+
+**Action** : vérifier si Marie testait **une autre saisie** que la garde 24h (intervention standard ?) — si oui, aligner l'UX sur le même pattern `effective/astreinte/break`. Sinon, lui refaire une démo rapide du segmenteur existant, c'est probablement un malentendu.
+
+**À ajouter éventuellement** : récap visible en bas du tableau des segments (`Total effectif X dont Y nuit / Total astreinte X dont Y nuit`) si pas déjà affiché.
+
+### 1.2 Format des heures
+
+**Problème** : affichage actuel `10.3` / `10,50` = ambigu (décimal base 100 vs sexagésimal base 60).
+
+**À faire** : afficher systématiquement au format `10h30` ou `10:30` (jamais décimal).
+
+### 1.3 Pause obligatoire
+
+**Problème** : le champ "pause 20 min / 6h" est modifiable — risque que l'employeur mette `5 min` et devienne en infraction.
+
+**À faire** :
+
+- Passer ce champ en **info fixe** (non modifiable), affichée sous forme d'encart bleu d'information.
+- Texte type : _"Pause obligatoire de 20 minutes pour toute période de travail effectif de 6 heures consécutives. La pause doit être prise d'affilée."_
+
+### 1.4 Liste des courses — découplage du planning
+
+**Problème** : demander de remplir la liste des courses pendant la création d'une intervention alourdit le flow et n'est pas pertinent à ce moment.
+
+**À faire** :
+
+- Au moment de créer l'intervention : champ facultatif avec mention "Vous pouvez remplir cette liste plus tard".
+- Sur le calendrier : **pastille / badge d'alerte** (petit panier rouge) sur les jours où une liste est attendue mais non remplie.
+- Conserver la possibilité de **listes récurrentes pré-remplies** (ex. courses hebdo du lundi) — cas d'usage validé par Marie elle-même.
+
+---
+
+## 2. Calendrier & pointage
+
+### 2.1 Validation calendrier
+
+Ce qui fonctionne bien et a été validé en direct :
+
+- Récurrence d'intervention (date de fin OU nombre de répétitions)
+- Détection de conflits (durée max, chevauchement)
+- Affichage alertes "durée max dépassée"
+
+### 2.2 Chrono sur page de pointage
+
+**Problème** : l'heure qui défile en live (`16:08:42` qui tourne) est **perturbante et inutile**.
+
+**À faire** : retirer le chrono temps réel de la page de pointage.
+
+### 2.3 Page "Suivi des heures"
+
+**Problème** : redondante avec le Planning et la page Équipe. Contenu peu lisible (`24 interventions`, `0 heures`, etc. — non contextualisés).
+
+**Options proposées** :
+
+- **Supprimer** la page "Suivi des heures" (préférence de Marie).
+- OU déplacer `Équipe` dans le menu `Gestion`, et garder "Suivi des heures" uniquement si on y ajoute une **vraie valeur différentielle** (ex. les anomalies de pointage, les interventions non validées).
+
+### 2.4 Parcours pointage "Démarrer / Terminer"
+
+**Problème** : deux chemins possibles pour pointer (depuis le dashboard ou depuis l'intervention), pas clair. Le bouton "Démarrer" n'indique pas clairement ce qu'il fait.
+
+**À faire** : repenser le parcours — proposer un bouton `Pointer` directement sur l'intervention du jour dans le dashboard, sans passer par plusieurs écrans.
+
+### 2.5 Risque fraude au pointage
+
+Point business important : en entreprise, le **pointage mobile auto-déclaratif est souvent désactivé** par crainte de fraude. Si on veut vendre aux employeurs, il faudra soit :
+
+- Géolocalisation (paramétrée par rapport à l'adresse du bénéficiaire)
+- Badge physique / NFC
+- Validation croisée par l'aidant
+
+À garder en tête mais pas prioritaire pour la sortie bêta.
+
+---
+
+## 3. Messagerie vs Cahier de liaison
+
+Distinction validée :
+
+| Canal             | Usage                                          | Accès                         |
+|-------------------|------------------------------------------------|-------------------------------|
+| Messagerie        | Informel (bon courage, info ponctuelle)        | Équipe salariée               |
+| Cahier de liaison | Formel (médication, consignes, transmissions)  | Équipe + aidants familiaux    |
+
+### Améliorations proposées
+
+- **Envoi de photos** dans les deux canaux (nouveau matériel, blessure, etc.).
+- **Transmission automatique** : dans le cahier de liaison, checkbox "Transmettre aux aidants" sur un événement important (fièvre, médicament oublié) → notification directe.
+- **Badge "Important"** avec mise en surbrillance pour le prochain salarié qui prend le relais.
+
+---
+
+## 4. Conformité & paie
+
+### 4.1 Export PDF fiche de paye
+
+**Bug observé en live** : l'export PDF affiche une erreur / PDF cassé. À investiguer.
+
+### 4.2 Clarifier le statut
+
+L'écran actuel prête à confusion — bien préciser que c'est une **simulation** / **prévisualisation**, pas le bulletin légal.
+
+### 4.3 Format d'heure (idem 1.2)
+
+Sur la fiche générée : `10,50` → `10h30`.
+
+---
+
+## 5. Absences
+
+### 5.1 "Taux de présence"
+
+**Problème** : la stat affichée n'a pas de sens métier clair.
+
+**À faire** : remplacer par une stat plus actionnable :
+
+- Nombre d'absences **non pointées**
+- Nombre d'absences **non justifiées**
+- Contrats **non validés**
+
+### 5.2 Libellés motifs d'absence
+
+**Problème** : "Annonce handicap d'un enfant → 1 jour" — le libellé est mal formulé, prête à confusion (on dirait une annonce commerciale).
+
+**À faire** : revoir tous les libellés des motifs de congés rémunérés selon le Code du travail :
+
+- Mariage salarié : 4 jours
+- Mariage enfant : 1 jour
+- Naissance / adoption
+- Décès conjoint / enfant / parent
+- Annonce handicap d'un enfant → reformuler en _"Annonce du handicap d'un enfant"_ ou _"Diagnostic handicap d'un enfant"_
+
+---
+
+## 6. Stratégie produit & commercialisation
+
+### 6.1 Refonte des formules
+
+Plutôt que formules actuelles, passer sur une **segmentation par module** :
+
+- **Module Cahier de liaison** : gratuit ou très bas prix — sert d'accroche (c'est LE module pivot identifié)
+- **Module Messagerie** : inclus / bas prix
+- **Module Paie / Conformité** : payant
+- **Module Export conformité auto** : payant
+- **Formule complète** : 3-5 € (tarif cible évoqué)
+
+Logique : faire essayer gratuitement, convertir une fois accroché.
+
+### 6.2 Pourquoi le cahier de liaison est capital
+
+> "C'est l'un des modules les plus importants. Tu peux le vendre aux entreprises, aux aidants, à tout le monde."
+
+Le cahier de liaison est le point d'entrée pour vendre à des profils différents (familles aidantes, agences, indépendants).
+
+### 6.3 Ajouts produit identifiés
+
+- **Photos contributeurs** sur la landing page (pas juste du texte)
+- **Base de procédures** accessible aux salariés (utilisation fauteuil, respirateur, lève-malade, etc.) — fiches alimentées par les aidants
+- **Notifications programmées** : rappels renouvellement dossiers (MDPH, PCH, etc.)
+
+### 6.4 Cibles et présentations
+
+| Cible              | Contact      | Action                                               |
+|--------------------|--------------|------------------------------------------------------|
+| Aidant testeur     | Philippe     | Tester la formule complète                           |
+| Entreprise / SAMU  | Christophe   | Présentation B2B — travaille avec pompiers/SAMU      |
+| Salon Autonomie    | Contact Willison | Obtenir un stand                                 |
+| Réseau Anthony     | Anthony      | Réseau médical existant                              |
+
+### 6.5 Structure juridique (conseil John)
+
+Monter une **entreprise** (pas une association) pour ne pas se faire racheter à bas prix ou absorber par un gros acteur.
+
+---
+
+## 7. Prochaines étapes
+
+### Dev — avant bêta
+
+- [ ] Vérifier sur quelle page Marie testait la saisie jour/nuit — si hors garde 24h, aligner sur le pattern `effective/astreinte/break` existant (cf. `docs/Garde_de_24_heures.md`)
+- [ ] Ajouter récap `Total effectif / Total astreinte` (dont nuit) sous le tableau de segments si absent
+- [ ] Format d'heure `10h30` partout (fiches, PDF, récap)
+- [ ] Pause obligatoire en mode info fixe (non modifiable)
+- [ ] Découpler liste des courses de la création d'intervention + pastille calendrier
+- [ ] Retirer chrono live de la page pointage
+- [ ] Décision : supprimer ou refondre "Suivi des heures"
+- [ ] Fix bug export PDF fiche de paye
+- [ ] Remplacer "Taux de présence" par stats actionnables
+- [ ] Revoir libellés motifs d'absence
+- [ ] Repenser parcours pointage (bouton direct sur intervention du jour)
+
+### Dev — post bêta
+
+- [ ] Envoi de photos dans messagerie / cahier de liaison
+- [ ] Checkbox "Transmettre aux aidants" + notification auto
+- [ ] Base de procédures matériel
+- [ ] Notifications renouvellement dossiers
+- [ ] Réflexion anti-fraude pointage (géoloc / NFC)
+
+### Business
+
+- [ ] Restructurer les formules par modules
+- [ ] Questionnaire utilisateur à préparer (post 1er mois d'usage)
+- [ ] Préparer présentation Christophe
+- [ ] Contacter Willison pour Salon Autonomie
+- [ ] Ajouter photos contributeurs sur la landing
+
+---
+
+_Document généré depuis la transcription du 16/04/2026 — à valider avec Marie et Vincent._

--- a/docs/SUPABASE_SELFHOST_OVH.md
+++ b/docs/SUPABASE_SELFHOST_OVH.md
@@ -1,0 +1,309 @@
+# Supabase self-hosted sur OVH — Guide de déploiement
+
+Guide pratique pour déployer une instance Supabase self-hostée sur un VPS OVH, destinée à l'environnement de **test / dev** d'Unilien.
+
+> ⚠️ **Prod + données de santé** : pour passer en production, il faut un hébergeur **certifié HDS** (OVH HDS, Scaleway HDS, ou rester sur Supabase Cloud). Ce guide couvre uniquement un serveur de test.
+
+---
+
+## 1. Commander le VPS OVH
+
+**Reco : VPS-3** (4 vCPU / 8 GB RAM / 160 GB NVMe / ~13€ HT/mois)
+
+- **OS** : Debian 13 (Trixie) — stable, kernel 6.x, support jusqu'en 2030. Debian 12 ou Ubuntu 22.04+ LTS fonctionnent aussi à l'identique.
+- **Datacenter** : Gravelines (GRA) ou Roubaix (RBX) — proche, RGPD-ok
+- **Option** : snapshot manuel (gratuit) — très utile avant chaque manip risquée
+
+> 💡 User SSH par défaut : `debian` sur Debian, `ubuntu` sur Ubuntu. Les commandes ci-dessous utilisent `debian@`, adapte si besoin.
+
+À la commande :
+1. Créer/utiliser une **paire SSH** (OVH la déploie automatiquement)
+2. Noter l'IPv4 publique
+3. Attendre l'email d'activation (~5-10 min)
+
+---
+
+## 2. Préparer le serveur
+
+```bash
+# Connexion
+ssh debian@<IP_VPS>
+
+# Vérifier la version Debian (attendu : 13 / Trixie)
+cat /etc/os-release
+
+# Mise à jour + utilitaires
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl ufw fail2ban rsync
+
+# Créer un user dédié (optionnel mais propre)
+sudo adduser supabase
+sudo usermod -aG sudo supabase
+sudo rsync --archive --chown=supabase:supabase ~/.ssh /home/supabase
+```
+
+### Firewall UFW
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow 22/tcp       # SSH
+sudo ufw allow 80/tcp       # HTTP (Let's Encrypt challenge)
+sudo ufw allow 443/tcp      # HTTPS
+sudo ufw enable
+```
+
+**Ne jamais exposer** directement Kong (`8000`), Postgres (`5432`) ou Studio (`3000`). Tout passe par le reverse proxy HTTPS.
+
+### Durcir SSH
+
+`/etc/ssh/sshd_config` :
+```
+PasswordAuthentication no
+PermitRootLogin no
+```
+Puis : `sudo systemctl restart ssh`
+
+---
+
+## 3. Installer Docker
+
+```bash
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Vérifier
+docker compose version
+```
+
+---
+
+## 4. Cloner Supabase
+
+Supabase fournit un `docker-compose.yml` officiel maintenu — pas besoin d'en écrire un.
+
+```bash
+cd /opt
+sudo git clone --depth 1 https://github.com/supabase/supabase.git
+sudo chown -R $USER:$USER supabase
+cd supabase/docker
+cp .env.example .env
+```
+
+---
+
+## 5. Générer les secrets
+
+### JWT secret + API keys
+
+```bash
+# JWT secret (40+ chars)
+openssl rand -hex 40
+```
+
+Puis génère les clés `ANON_KEY` et `SERVICE_ROLE_KEY` via [le générateur JWT Supabase](https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys) (copie le JWT secret dedans, il sort les deux tokens).
+
+### Password Postgres + Dashboard
+
+```bash
+openssl rand -base64 32   # POSTGRES_PASSWORD
+openssl rand -base64 32   # DASHBOARD_PASSWORD
+```
+
+### `.env` minimal à modifier
+
+```bash
+POSTGRES_PASSWORD=<strong>
+JWT_SECRET=<40+ chars hex>
+ANON_KEY=<généré>
+SERVICE_ROLE_KEY=<généré>
+
+DASHBOARD_USERNAME=admin
+DASHBOARD_PASSWORD=<strong>
+
+SITE_URL=https://test.unilien.fr       # ton front de test
+API_EXTERNAL_URL=https://api-test.unilien.fr
+SUPABASE_PUBLIC_URL=https://api-test.unilien.fr
+
+# SMTP (optionnel, pour reset password etc.)
+SMTP_HOST=smtp.resend.com
+SMTP_PORT=465
+SMTP_USER=resend
+SMTP_PASS=<resend_api_key>
+SMTP_ADMIN_EMAIL=noreply@unilien.fr
+SMTP_SENDER_NAME=Unilien
+```
+
+> ⚠️ Ne jamais committer ce `.env`. Ajoute-le au `.gitignore` local du VPS.
+
+---
+
+## 6. Lancer Supabase
+
+```bash
+cd /opt/supabase/docker
+docker compose pull
+docker compose up -d
+
+# Vérifier
+docker compose ps
+docker compose logs -f kong     # gateway API
+docker compose logs -f db       # Postgres
+```
+
+Attendre ~1-2 min que tout soit healthy.
+
+**Ports internes** (pas exposés publiquement) :
+- Kong (API gateway) : `8000`
+- Studio (UI admin) : `3000`
+- Postgres : `5432`
+
+---
+
+## 7. Reverse proxy avec Caddy (HTTPS auto)
+
+**Caddy** fait le TLS Let's Encrypt automatiquement. Plus simple que Traefik pour démarrer.
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install caddy
+```
+
+### DNS OVH
+
+Crée deux enregistrements A pointant vers l'IP du VPS :
+- `api-test.unilien.fr` → `<IP_VPS>`
+- `studio-test.unilien.fr` → `<IP_VPS>`
+
+### `/etc/caddy/Caddyfile`
+
+```caddy
+api-test.unilien.fr {
+    reverse_proxy localhost:8000
+    encode gzip
+}
+
+studio-test.unilien.fr {
+    # Protection additionnelle basique (Studio n'a pas d'auth built-in robuste)
+    basicauth {
+        admin <hash_bcrypt>
+    }
+    reverse_proxy localhost:3000
+}
+```
+
+Générer le hash bcrypt pour Studio :
+```bash
+caddy hash-password
+```
+
+Puis :
+```bash
+sudo systemctl reload caddy
+```
+
+Caddy récupère automatiquement les certificats Let's Encrypt au premier hit.
+
+---
+
+## 8. Connecter Unilien à ta Supabase self-hosted
+
+Dans `.env.local` du front (pour un build de test) :
+```bash
+VITE_SUPABASE_URL=https://api-test.unilien.fr
+VITE_SUPABASE_ANON_KEY=<ANON_KEY générée à l'étape 5>
+```
+
+Rebuild + deploy le front (Netlify branch preview ou équivalent) pointant sur cette URL.
+
+---
+
+## 9. Migrations DB
+
+Tu as 50 migrations SQL dans `supabase/migrations/`. Script dédié fourni : `scripts/supabase-selfhost-init.sh`.
+
+**Ce qu'il fait** :
+- Active les extensions Postgres requises (`uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gist`)
+- Crée une table `_migrations` pour tracer les fichiers déjà appliqués (idempotent, rejouable)
+- Applique chaque migration en **transaction** (échec → rollback automatique)
+- Affiche un résumé final (appliquées / skippées / échouées)
+
+### Usage
+
+```bash
+# 1. Ouvrir un tunnel SSH vers le Postgres du VPS (Postgres n'est jamais exposé publiquement)
+ssh -L 5432:localhost:5432 debian@<IP_VPS>
+
+# 2. Dans un autre terminal, depuis ta machine locale
+cd /media/zephdev/Jeux/warp/unilien
+export SUPABASE_DB_URL="postgresql://postgres:<POSTGRES_PASSWORD>@localhost:5432/postgres"
+./scripts/supabase-selfhost-init.sh
+```
+
+### Rejouer uniquement les nouvelles migrations
+
+Le script est idempotent : il saute celles déjà présentes dans `_migrations`. Tu peux le relancer à chaque nouvelle migration ajoutée au projet.
+
+### Alternative via CLI Supabase
+
+```bash
+npm install -g supabase
+supabase link --db-url "$SUPABASE_DB_URL"
+supabase db push
+```
+
+> L'avantage du script maison : pas de CLI Supabase à installer, traçabilité via `_migrations`, fonctionne même si le CLI n'est pas synchronisé avec ta version de self-host.
+
+---
+
+## 10. Sauvegardes
+
+Minimum vital : dump Postgres quotidien.
+
+```bash
+# /opt/supabase/backup.sh
+#!/usr/bin/env bash
+set -e
+DATE=$(date +%F)
+DIR=/opt/supabase/backups
+mkdir -p "$DIR"
+docker compose -f /opt/supabase/docker/docker-compose.yml exec -T db \
+  pg_dump -U postgres postgres | gzip > "$DIR/db-$DATE.sql.gz"
+# Garde 7 jours
+find "$DIR" -name "db-*.sql.gz" -mtime +7 -delete
+```
+
+Cron :
+```bash
+crontab -e
+# 0 3 * * * /opt/supabase/backup.sh
+```
+
+Pour du prod, complète avec un **snapshot OVH** (panel manager, gratuit, manuel) + un rsync offsite (Backblaze B2, ~0.005$/GB/mois).
+
+---
+
+## 11. Checklist avant mise en service
+
+- [ ] Firewall UFW actif, seuls 22/80/443 ouverts
+- [ ] SSH password disabled, clé obligatoire
+- [ ] `fail2ban` actif
+- [ ] `.env` Supabase hors git, secrets forts (32+ chars)
+- [ ] HTTPS OK (Caddy + Let's Encrypt) sur `api-test` et `studio-test`
+- [ ] Studio protégé par basic auth
+- [ ] Postgres **jamais** exposé publiquement
+- [ ] Dump quotidien cron actif
+- [ ] RLS activé sur toutes les tables (migrations Unilien le font déjà)
+- [ ] Disclaimer HDS mis à jour si ouverture à des testeurs externes
+
+---
+
+## Ressources
+
+- [Docs officielles Supabase self-hosting](https://supabase.com/docs/guides/self-hosting/docker)
+- [Générateur JWT Supabase](https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys)
+- [Caddy docs](https://caddyserver.com/docs/)
+- [Memoire projet](../../.claude/projects/-media-zephdev-Jeux-warp/memory/project-supabase-selfhost.md) — chiffrement colonnes (pgsodium) à implémenter après migration

--- a/docs/VOICE_WHISPER_IMPLEMENTATION.md
+++ b/docs/VOICE_WHISPER_IMPLEMENTATION.md
@@ -1,0 +1,140 @@
+# Reconnaissance vocale cross-browser — Plan Whisper self-hosted
+
+**Statut** : 📋 Planifié — en attente specs VPS
+
+---
+
+## Contexte
+
+La Web Speech API (utilisée actuellement dans `useSpeechRecognition`) n'est pas supportée sur Firefox (refus de Mozilla pour raisons de vie privée — l'audio est envoyé à Google).
+
+**État actuel** :
+- Chrome / Edge / Safari : ✅ fonctionne via Web Speech API
+- Firefox : ❌ bouton micro grisé + aria-label explicatif
+
+**Objectif** : rendre la saisie vocale disponible sur tous les navigateurs via Whisper self-hosted sur VPS.
+
+---
+
+## Architecture cible
+
+```
+Browser (Firefox/Chrome/Safari)
+  → MediaRecorder API (WebM/Opus — supporté partout)
+  → POST audio blob
+  → Supabase Edge Function "transcribe-audio"
+  → VPS faster-whisper API
+  → texte transcrit retourné
+```
+
+Le passage par une Edge Function évite les problèmes CORS et masque l'URL du VPS.
+
+---
+
+## Stack VPS recommandée
+
+```bash
+pip install faster-whisper fastapi uvicorn python-multipart
+```
+
+**Modèle recommandé** : `small` (bon équilibre qualité/vitesse en français sur CPU)
+
+| Modèle | RAM requise | Qualité FR | Vitesse CPU |
+|--------|-------------|------------|-------------|
+| `tiny` | ~1 Go | Correct | Très rapide |
+| `base` | ~1 Go | Bon | Rapide |
+| `small` | ~2 Go | Très bon | Moyen |
+| `medium` | ~5 Go | Excellent | Lent |
+| `large` | ~10 Go | Parfait | Très lent |
+
+> ⚠️ Specs VPS à confirmer avant de choisir le modèle.
+
+---
+
+## Plan d'implémentation
+
+### Étape 1 — VPS : API faster-whisper
+
+```python
+# main.py
+from fastapi import FastAPI, File, UploadFile
+from faster_whisper import WhisperModel
+import tempfile, os
+
+app = FastAPI()
+model = WhisperModel("small", device="cpu", compute_type="int8")
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    with tempfile.NamedTemporaryFile(suffix=".webm", delete=False) as tmp:
+        tmp.write(await file.read())
+        tmp_path = tmp.name
+
+    segments, _ = model.transcribe(tmp_path, language="fr")
+    text = " ".join(s.text for s in segments).strip()
+    os.unlink(tmp_path)
+    return {"text": text}
+```
+
+```bash
+# Lancer le serveur
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+Sécuriser avec un token secret en header (`X-API-Key`).
+
+### Étape 2 — Supabase Edge Function "transcribe-audio"
+
+- Reçoit le blob audio du client
+- Ajoute le `X-API-Key` et forward vers le VPS
+- Retourne le texte transcrit
+- Protégée par JWT Supabase (comme `send-email`)
+
+### Étape 3 — Hook `useSpeechRecognition` — mode hybride
+
+Adapter le hook pour détecter si la Web Speech API est disponible :
+- **Disponible** (Chrome/Edge/Safari) → utiliser Web Speech API (temps réel, pas de latence)
+- **Non disponible** (Firefox) → basculer sur `MediaRecorder` + Edge Function (transcription à l'arrêt)
+
+```ts
+// Logique de sélection dans le hook
+const useNativeAPI = !!window.SpeechRecognition || !!window.webkitSpeechRecognition
+```
+
+### Étape 4 — MessageInput
+
+Adapter le bouton micro pour afficher l'état selon le mode :
+- Mode natif : transcription en temps réel dans le textarea
+- Mode Whisper : indicateur "Enregistrement..." → transcription à l'arrêt
+
+---
+
+## Fichiers à créer / modifier
+
+| Fichier | Action |
+|---------|--------|
+| `supabase/functions/transcribe-audio/index.ts` | Créer Edge Function |
+| `src/hooks/useSpeechRecognition.ts` | Ajouter mode MediaRecorder/Whisper |
+| `src/components/liaison/MessageInput.tsx` | Adapter UI selon mode |
+| `supabase/secrets` | Ajouter `WHISPER_API_URL` + `WHISPER_API_KEY` |
+| VPS `main.py` | Déployer API faster-whisper |
+
+---
+
+## Sécurité
+
+- URL du VPS jamais exposée côté client — toujours proxié via Edge Function
+- `X-API-Key` stocké dans les secrets Supabase
+- Rate limiting à ajouter sur l'Edge Function (comme `send-email`)
+- Audio supprimé immédiatement après transcription (pas de stockage)
+
+---
+
+## TODO
+
+- [ ] Confirmer specs VPS (RAM, CPU, OS) pour choisir le modèle Whisper
+- [ ] Installer faster-whisper sur VPS + tester latence
+- [ ] Créer Edge Function `transcribe-audio`
+- [ ] Adapter `useSpeechRecognition` en mode hybride
+- [ ] Adapter `MessageInput` pour les deux modes
+- [ ] Tests cross-browser (Firefox, Chrome, Safari)

--- a/scripts/supabase-selfhost-init.sh
+++ b/scripts/supabase-selfhost-init.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Initialise une base Supabase self-hosted en rejouant toutes les migrations du projet.
+#
+# Usage :
+#   SUPABASE_DB_URL=postgresql://postgres:<pwd>@<host>:5432/postgres \
+#     ./scripts/supabase-selfhost-init.sh
+#
+# Ou via tunnel SSH local :
+#   ssh -L 5432:localhost:5432 ubuntu@<VPS_IP>
+#   SUPABASE_DB_URL=postgresql://postgres:<pwd>@localhost:5432/postgres \
+#     ./scripts/supabase-selfhost-init.sh
+#
+# Prérequis :
+#   - psql installé (apt install postgresql-client)
+#   - SUPABASE_DB_URL exportée
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="$SCRIPT_DIR/../supabase/migrations"
+
+# --- Couleurs ---
+R='\033[0;31m'; G='\033[0;32m'; Y='\033[1;33m'; B='\033[0;34m'; N='\033[0m'
+
+log()   { echo -e "${B}▸${N} $*"; }
+ok()    { echo -e "${G}✓${N} $*"; }
+warn()  { echo -e "${Y}⚠${N} $*"; }
+fail()  { echo -e "${R}✗${N} $*" >&2; exit 1; }
+
+# --- Vérifs préalables ---
+[[ -z "${SUPABASE_DB_URL:-}" ]] && fail "SUPABASE_DB_URL non définie. Exemple :
+  export SUPABASE_DB_URL=postgresql://postgres:<pwd>@localhost:5432/postgres"
+
+command -v psql >/dev/null 2>&1 || fail "psql introuvable. Installe postgresql-client."
+
+[[ -d "$MIGRATIONS_DIR" ]] || fail "Dossier migrations introuvable : $MIGRATIONS_DIR"
+
+# --- Test connexion ---
+log "Test connexion base..."
+if ! psql "$SUPABASE_DB_URL" -c "SELECT 1;" >/dev/null 2>&1; then
+  fail "Impossible de se connecter à la base. Vérifie SUPABASE_DB_URL."
+fi
+ok "Connexion OK"
+
+# --- Liste des migrations ---
+mapfile -t MIGRATIONS < <(find "$MIGRATIONS_DIR" -maxdepth 1 -name "*.sql" -type f | sort)
+[[ ${#MIGRATIONS[@]} -eq 0 ]] && fail "Aucune migration trouvée dans $MIGRATIONS_DIR"
+log "${#MIGRATIONS[@]} migrations trouvées"
+
+# --- Table de suivi (évite de rejouer) ---
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+CREATE TABLE IF NOT EXISTS public._migrations (
+  filename  TEXT PRIMARY KEY,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  checksum  TEXT
+);
+SQL
+
+# --- Extensions requises (toutes idempotentes) ---
+log "Activation des extensions Postgres..."
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+-- pgsodium : prévu pour le chiffrement des colonnes sensibles (à activer quand dispo)
+-- CREATE EXTENSION IF NOT EXISTS pgsodium;
+SQL
+ok "Extensions prêtes"
+
+# --- Rejeu des migrations ---
+APPLIED=0
+SKIPPED=0
+FAILED=0
+
+for f in "${MIGRATIONS[@]}"; do
+  name="$(basename "$f")"
+
+  already_applied=$(psql "$SUPABASE_DB_URL" -t -A -c \
+    "SELECT 1 FROM public._migrations WHERE filename='$name' LIMIT 1;" 2>/dev/null || true)
+
+  if [[ "$already_applied" == "1" ]]; then
+    warn "Skip  $name (déjà appliquée)"
+    SKIPPED=$((SKIPPED+1))
+    continue
+  fi
+
+  log "Apply $name"
+  checksum=$(sha256sum "$f" | awk '{print $1}')
+
+  if psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 --single-transaction \
+       -f "$f" >/dev/null 2>/tmp/migration_err; then
+    psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -c \
+      "INSERT INTO public._migrations (filename, checksum) VALUES ('$name', '$checksum');" >/dev/null
+    ok    "      $name"
+    APPLIED=$((APPLIED+1))
+  else
+    echo -e "${R}✗${N} Échec $name. Détail :"
+    cat /tmp/migration_err >&2
+    FAILED=$((FAILED+1))
+    break
+  fi
+done
+
+# --- Résumé ---
+echo
+echo "────────────────────────────────────────"
+ok    "Appliquées : $APPLIED"
+[[ $SKIPPED -gt 0 ]] && warn "Skippées   : $SKIPPED"
+[[ $FAILED  -gt 0 ]] && fail "Échouées   : $FAILED (arrêt)"
+ok    "Migrations terminées"
+echo "────────────────────────────────────────"


### PR DESCRIPTION
## Summary

Ajout de 4 fichiers de documentation/outillage liés à la migration Supabase self-host et à des plans de features.

### Changements

- **`docs/SUPABASE_SELFHOST_OVH.md`** (309 lignes) — guide complet de migration Supabase self-host sur VPS OVH Debian 13 (SSH hardening, Docker, génération secrets JWT/Postgres, Caddy, dumps/restore)
- **`scripts/supabase-selfhost-init.sh`** (112 lignes) — script d'initialisation VPS
- **`docs/FEEDBACK_REUNION_2026-04-16.md`** (238 lignes) — feedback réunion du 16/04/2026
- **`docs/VOICE_WHISPER_IMPLEMENTATION.md`** (140 lignes) — plan d'implémentation des notes vocales via Whisper

### Contexte

Ces fichiers étaient untracked depuis plusieurs sessions. Pas de secrets en dur (tous les credentials sont en placeholder dans la doc). Ils servent de référence pour les équipes et pour les futures migrations.

## Test plan

- [x] Aucun code applicatif modifié
- [x] Pas de secrets en dur dans les fichiers committés
- [x] Les commandes SSH/Docker du guide ont été exécutées avec succès lors de la migration du 21/04

🤖 Generated with [Claude Code](https://claude.com/claude-code)