### PR TITLE
fix(caddy): unblock prod CSP for Supabase Cloud avatars and RHF/Zod eval

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -9,7 +9,7 @@ unilien.app, www.unilien.app {
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "camera=(), microphone=(self), geolocation=()"
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://*.supabase.co wss://*.supabase.co; img-src 'self' data: blob: https://api.unilien.app https://*.supabase.co; font-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
 
     @assets path /assets/*


### PR DESCRIPTION
## Summary

Deux blocages CSP critiques en prod après la migration self-host :

1. **Avatars bloqués** (img-src) — les URLs `avatar_url` stockées en DB datent de l'ancien projet Cloud (`lczfygydhnyygguvponw.supabase.co`). Le CSP actuel n'autorisait que `api.unilien.app` → toutes les images profil retournaient 0 byte + erreur CSP.
2. **Formulaires cassés** (script-src) — Zod et `react-hook-form` utilisent `new Function()` pour générer des validateurs runtime. Sans `'unsafe-eval'`, toute la validation front échoue.

Conséquence bonus : le chunk dynamique `PlanningPage-*.js` échouait à charger à cause de la cascade d'erreurs CSP.

### Changements (`infra/caddy/Caddyfile`)
- `script-src` : ajoute `'unsafe-eval'`
- `img-src` : ajoute `https://*.supabase.co`
- `connect-src` : ajoute `https://*.supabase.co` + `wss://*.supabase.co` (realtime)

### Déploiement
- Caddyfile déjà appliqué manuellement sur le VPS (`/etc/caddy/Caddyfile` + `systemctl reload caddy`) → prod live OK.
- Cette PR versionne la source de vérité dans le repo.

### Suivi
- Réécrire les URLs `avatar_url` en DB vers `api.unilien.app` (ou refactor `profileService.ts` pour ne stocker que le path storage)
- Ensuite, retirer `*.supabase.co` du CSP

## Test plan
- [x] `caddy validate` OK
- [x] `curl -I https://unilien.app` → header CSP mis à jour
- [ ] Hard refresh navigateur : avatars affichés, formulaires fonctionnels, PlanningPage charge

🤖 Generated with [Claude Code](https://claude.com/claude-code)