### PR TITLE
feat(planning): unify presence responsible day/night in shift modal

### DIFF
--- a/src/components/planning/Guard24hSection.tsx
+++ b/src/components/planning/Guard24hSection.tsx
@@ -5,10 +5,10 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { AccessibleInput, AccessibleButton } from '@/components/ui'
-import { calculateShiftDuration, calculateNightHours } from '@/lib/compliance/utils'
 import { REQUALIFICATION_THRESHOLD } from '@/hooks/useShiftRequalification'
 import type { GuardSegment } from '@/types'
 import { formatHoursCompact } from '@/lib/formatHours'
+import { detectPresenceType } from '@/lib/presence/detectPresenceType'
 
 interface Guard24hSectionProps {
   guardSegments: GuardSegment[]
@@ -37,13 +37,6 @@ const SEG_COLORS: Record<string, string> = {
 /** Map DB type to select value */
 function toSelectValue(type: GuardSegment['type']): string {
   return type === 'presence_day' || type === 'presence_night' ? 'presence' : type
-}
-
-/** Auto-detect presence_day or presence_night based on segment time range */
-function detectPresenceType(startTime: string, endTime: string): GuardSegment['type'] {
-  const nightHours = calculateNightHours(new Date(), startTime, endTime)
-  const totalHours = calculateShiftDuration(startTime, endTime, 0) / 60
-  return nightHours > totalHours / 2 ? 'presence_night' : 'presence_day'
 }
 
 export function Guard24hSection({

--- a/src/components/planning/NewShiftModal.test.tsx
+++ b/src/components/planning/NewShiftModal.test.tsx
@@ -228,7 +228,7 @@ describe('NewShiftModal', () => {
 
     // Vérifier que les options clés sont présentes dans le DOM
     expect(screen.getByText('Travail effectif')).toBeInTheDocument()
-    expect(screen.getByText(/présence responsable \(jour\)/i)).toBeInTheDocument()
+    expect(screen.getByText(/^présence responsable$/i)).toBeInTheDocument()
   })
 
   // 8. createShift est appelée lors de la soumission d'un formulaire valide

--- a/src/components/planning/NewShiftModal.tsx
+++ b/src/components/planning/NewShiftModal.tsx
@@ -26,7 +26,8 @@ import { TaskSelector } from './TaskSelector'
 import { logger } from '@/lib/logger'
 import { toaster } from '@/lib/toaster'
 import { formatHoursCompact } from '@/lib/formatHours'
-import { detectPresenceType } from '@/lib/presence/detectPresenceType'
+import { detectPresenceType, getPresenceMix } from '@/lib/presence/detectPresenceType'
+import { PresenceMixedWarning } from './PresenceMixedWarning'
 
 const SHIFT_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
@@ -349,6 +350,14 @@ export function NewShiftModal({
                       {...register('breakDuration')}
                     />
                   )}
+
+                  {/* Avertissement présence à cheval jour/nuit */}
+                  {isPresenceType(shiftType) && watchedValues.startTime && watchedValues.endTime && (() => {
+                    const mix = getPresenceMix(watchedValues.startTime, watchedValues.endTime)
+                    return mix.isMixed ? (
+                      <PresenceMixedWarning dayHours={mix.dayHours} nightHours={mix.nightHours} />
+                    ) : null
+                  })()}
 
                   {/* Section présence responsable JOUR */}
                   {shiftType === 'presence_day' && (

--- a/src/components/planning/NewShiftModal.tsx
+++ b/src/components/planning/NewShiftModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import {
   Box,
   Stack,
@@ -26,13 +26,18 @@ import { TaskSelector } from './TaskSelector'
 import { logger } from '@/lib/logger'
 import { toaster } from '@/lib/toaster'
 import { formatHoursCompact } from '@/lib/formatHours'
+import { detectPresenceType } from '@/lib/presence/detectPresenceType'
 
 const SHIFT_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
-  { value: 'presence_day', label: 'Présence responsable (jour)' },
-  { value: 'presence_night', label: 'Présence responsable (nuit)' },
+  { value: 'presence', label: 'Présence responsable' },
   { value: 'guard_24h', label: 'Garde 24h' },
 ]
+
+const isPresenceType = (t: ShiftType): t is 'presence_day' | 'presence_night' =>
+  t === 'presence_day' || t === 'presence_night'
+
+const toSelectValue = (t: ShiftType): string => (isPresenceType(t) ? 'presence' : t)
 
 interface NewShiftModalProps {
   isOpen: boolean
@@ -93,6 +98,18 @@ export function NewShiftModal({
 
   const baseDate = watchedValues.date ? new Date(watchedValues.date) : defaultDate
   const repeatConfig = useRepeatConfig(baseDate)
+
+  // Re-détecter presence_day / presence_night quand les horaires changent
+  useEffect(() => {
+    if (!isPresenceType(shiftType)) return
+    if (!watchedValues.startTime || !watchedValues.endTime) return
+    const detected = detectPresenceType(watchedValues.startTime, watchedValues.endTime)
+    if (detected !== shiftType) {
+      setShiftType(detected)
+      setValue('shiftType', detected)
+      if (detected !== 'presence_night') setNightInterventionsCount(0)
+    }
+  }, [watchedValues.startTime, watchedValues.endTime, shiftType, setShiftType, setValue, setNightInterventionsCount])
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
   const [isBatchSubmitting, setIsBatchSubmitting] = useState(false)
@@ -236,9 +253,17 @@ export function NewShiftModal({
                   <AccessibleSelect
                     label="Type d'intervention"
                     options={SHIFT_TYPE_OPTIONS}
-                    value={shiftType}
+                    value={toSelectValue(shiftType)}
                     onChange={(e) => {
-                      const newType = e.target.value as ShiftType
+                      const selected = e.target.value
+                      // "presence" = choix unifié → auto-détection jour/nuit selon horaires
+                      const newType: ShiftType =
+                        selected === 'presence'
+                          ? detectPresenceType(
+                              watchedValues.startTime ?? '09:00',
+                              watchedValues.endTime ?? '12:00',
+                            )
+                          : (selected as ShiftType)
                       setShiftType(newType)
                       setValue('shiftType', newType)
                       if (newType !== 'presence_night' && newType !== 'guard_24h') {
@@ -247,10 +272,11 @@ export function NewShiftModal({
                       if (newType !== 'effective') {
                         setHasNightAction(false)
                       }
-                      if (newType === 'presence_night') {
-                        setValue('startTime', '21:00')
-                        setValue('endTime', '07:00')
-                      } else if (newType !== 'guard_24h') {
+                      if (newType === 'guard_24h') {
+                        // géré par useEffect du hook
+                      } else if (selected === 'presence') {
+                        // on garde les horaires courants (l'auto-détection s'en occupe)
+                      } else {
                         setValue('startTime', '09:00')
                         setValue('endTime', '12:00')
                       }

--- a/src/components/planning/PresenceMixedWarning.tsx
+++ b/src/components/planning/PresenceMixedWarning.tsx
@@ -1,0 +1,38 @@
+import { Box, Text } from '@chakra-ui/react'
+import { formatHoursCompact } from '@/lib/formatHours'
+
+interface PresenceMixedWarningProps {
+  dayHours: number
+  nightHours: number
+}
+
+/**
+ * Avertissement affiché quand une intervention "Présence responsable" chevauche
+ * le jour et la nuit. Les régimes de paie sont radicalement différents
+ * (jour : équivalent ×2/3 — nuit : indemnité ×1/4, Art. 137 & 148 IDCC 3239),
+ * donc un seul type ne peut refléter fidèlement la rémunération.
+ */
+export function PresenceMixedWarning({ dayHours, nightHours }: PresenceMixedWarningProps) {
+  return (
+    <Box
+      p={3}
+      bg="warm.50"
+      borderRadius="10px"
+      borderWidth="1px"
+      borderColor="warm.300"
+    >
+      <Text fontSize="sm" fontWeight="bold" color="warm.800" mb={1}>
+        Présence à cheval entre jour et nuit
+      </Text>
+      <Text fontSize="sm" color="warm.800">
+        {formatHoursCompact(dayHours)} de jour + {formatHoursCompact(nightHours)} de nuit.
+        Les régimes de paie diffèrent (×2/3 jour vs ×1/4 nuit, Art. 137 & 148 IDCC 3239).
+      </Text>
+      <Text fontSize="xs" color="warm.700" mt={2}>
+        Pour un calcul juste, créez plutôt <Text as="strong">deux interventions</Text>{' '}
+        (une jour, une nuit) ou utilisez une <Text as="strong">garde 24h</Text> qui
+        gère les segments jour/nuit automatiquement.
+      </Text>
+    </Box>
+  )
+}

--- a/src/components/planning/ShiftDetailModal.tsx
+++ b/src/components/planning/ShiftDetailModal.tsx
@@ -467,6 +467,8 @@ export function ShiftDetailModal({
           register={register}
           errors={errors}
           watchedBreakDuration={watchedValues.breakDuration}
+          watchedStartTime={watchedValues.startTime}
+          watchedEndTime={watchedValues.endTime}
           onSubmit={handleSubmit(onSubmit)}
           shiftType={shiftType}
           hasNightAction={hasNightAction}

--- a/src/components/planning/ShiftEditForm.tsx
+++ b/src/components/planning/ShiftEditForm.tsx
@@ -16,7 +16,8 @@ import { TaskSelector } from './TaskSelector'
 import type { Shift, Contract, ComplianceResult, ComputedPay } from '@/types'
 import type { ShiftDetailFormData } from '@/lib/validation/shiftSchemas'
 import { formatHoursCompact } from '@/lib/formatHours'
-import { detectPresenceType } from '@/lib/presence/detectPresenceType'
+import { detectPresenceType, getPresenceMix } from '@/lib/presence/detectPresenceType'
+import { PresenceMixedWarning } from './PresenceMixedWarning'
 
 const SHIFT_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
@@ -195,6 +196,14 @@ export function ShiftEditForm({
             onShiftTypeChange(newType)
           }}
         />
+
+        {/* Avertissement présence à cheval jour/nuit */}
+        {isPresenceType(shiftType) && watchedStartTime && watchedEndTime && (() => {
+          const mix = getPresenceMix(watchedStartTime, watchedEndTime)
+          return mix.isMixed ? (
+            <PresenceMixedWarning dayHours={mix.dayHours} nightHours={mix.nightHours} />
+          ) : null
+        })()}
 
         {/* Section présence responsable JOUR */}
         {shiftType === 'presence_day' && (

--- a/src/components/planning/ShiftEditForm.tsx
+++ b/src/components/planning/ShiftEditForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import type React from 'react'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Box, Stack, Flex, Text, Textarea, Separator } from '@chakra-ui/react'
 import type { UseFormRegister, UseFormSetValue, FieldErrors } from 'react-hook-form'
 import { AccessibleInput, AccessibleSelect } from '@/components/ui'
@@ -16,12 +16,17 @@ import { TaskSelector } from './TaskSelector'
 import type { Shift, Contract, ComplianceResult, ComputedPay } from '@/types'
 import type { ShiftDetailFormData } from '@/lib/validation/shiftSchemas'
 import { formatHoursCompact } from '@/lib/formatHours'
+import { detectPresenceType } from '@/lib/presence/detectPresenceType'
 
 const SHIFT_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
-  { value: 'presence_day', label: 'Présence responsable (jour)' },
-  { value: 'presence_night', label: 'Présence responsable (nuit)' },
+  { value: 'presence', label: 'Présence responsable' },
 ]
+
+const isPresenceType = (t: Shift['shiftType']): t is 'presence_day' | 'presence_night' =>
+  t === 'presence_day' || t === 'presence_night'
+
+const toSelectValue = (t: Shift['shiftType']): string => (isPresenceType(t) ? 'presence' : t)
 
 const STATUS_OPTIONS = [
   { value: 'planned', label: 'Planifié' },
@@ -35,6 +40,8 @@ interface ShiftEditFormProps {
   register: UseFormRegister<ShiftDetailFormData>
   errors: FieldErrors<ShiftDetailFormData>
   watchedBreakDuration: number | undefined
+  watchedStartTime: string | undefined
+  watchedEndTime: string | undefined
   onSubmit: React.FormEventHandler<HTMLFormElement>
   // Reducer state (champs métier hors form)
   shiftType: Shift['shiftType']
@@ -69,6 +76,8 @@ export function ShiftEditForm({
   register,
   errors,
   watchedBreakDuration,
+  watchedStartTime,
+  watchedEndTime,
   onSubmit,
   shiftType,
   hasNightAction,
@@ -98,6 +107,16 @@ export function ShiftEditForm({
     setTasksArray(tasks)
     setValue('tasks', tasks.join('\n'))
   }, [setValue])
+
+  // Re-détecter presence_day / presence_night quand les horaires changent
+  useEffect(() => {
+    if (!isPresenceType(shiftType)) return
+    if (!watchedStartTime || !watchedEndTime) return
+    const detected = detectPresenceType(watchedStartTime, watchedEndTime)
+    if (detected !== shiftType) {
+      onShiftTypeChange(detected)
+    }
+  }, [watchedStartTime, watchedEndTime, shiftType, onShiftTypeChange])
 
   return (
     <form id="edit-shift-form" onSubmit={onSubmit}>
@@ -165,9 +184,15 @@ export function ShiftEditForm({
         <AccessibleSelect
           label="Type d'intervention"
           options={SHIFT_TYPE_OPTIONS}
-          value={shiftType}
+          value={toSelectValue(shiftType)}
           onChange={(e) => {
-            onShiftTypeChange(e.target.value as Shift['shiftType'])
+            const selected = e.target.value
+            // "presence" = choix unifié → auto-détection jour/nuit selon horaires
+            const newType =
+              selected === 'presence'
+                ? detectPresenceType(watchedStartTime ?? '09:00', watchedEndTime ?? '12:00')
+                : (selected as Shift['shiftType'])
+            onShiftTypeChange(newType)
           }}
         />
 

--- a/src/lib/presence/detectPresenceType.test.ts
+++ b/src/lib/presence/detectPresenceType.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { detectPresenceType, getPresenceMix } from './detectPresenceType'
+
+describe('detectPresenceType', () => {
+  it('retourne presence_day pour une plage 100% jour', () => {
+    expect(detectPresenceType('09:00', '12:00')).toBe('presence_day')
+  })
+
+  it('retourne presence_night pour une plage 100% nuit', () => {
+    expect(detectPresenceType('21:00', '06:00')).toBe('presence_night')
+  })
+
+  it('retourne presence_day quand majorité de jour (18h-23h)', () => {
+    // 18h-23h = 5h total, 2h de nuit (21h-23h), 3h de jour → majorité jour
+    expect(detectPresenceType('18:00', '23:00')).toBe('presence_day')
+  })
+
+  it('retourne presence_night quand majorité de nuit (19h-02h)', () => {
+    // 19h-02h = 7h total, 5h de nuit (21h-02h), 2h de jour → majorité nuit
+    expect(detectPresenceType('19:00', '02:00')).toBe('presence_night')
+  })
+
+  it('fallback presence_day si horaires invalides', () => {
+    expect(detectPresenceType('', '12:00')).toBe('presence_day')
+    expect(detectPresenceType('09:00', '')).toBe('presence_day')
+  })
+})
+
+describe('getPresenceMix', () => {
+  it('détecte un chevauchement jour+nuit (18h-23h)', () => {
+    const mix = getPresenceMix('18:00', '23:00')
+    expect(mix.isMixed).toBe(true)
+    expect(mix.dayHours).toBeCloseTo(3, 1)
+    expect(mix.nightHours).toBeCloseTo(2, 1)
+    expect(mix.totalHours).toBeCloseTo(5, 1)
+  })
+
+  it('pas de chevauchement pour 100% jour', () => {
+    const mix = getPresenceMix('09:00', '12:00')
+    expect(mix.isMixed).toBe(false)
+    expect(mix.nightHours).toBe(0)
+  })
+
+  it('pas de chevauchement pour 100% nuit', () => {
+    const mix = getPresenceMix('22:00', '05:00')
+    expect(mix.isMixed).toBe(false)
+    expect(mix.dayHours).toBe(0)
+  })
+
+  it('horaires invalides → valeurs à zéro', () => {
+    expect(getPresenceMix('', '12:00')).toEqual({
+      totalHours: 0,
+      dayHours: 0,
+      nightHours: 0,
+      isMixed: false,
+    })
+  })
+})

--- a/src/lib/presence/detectPresenceType.ts
+++ b/src/lib/presence/detectPresenceType.ts
@@ -1,0 +1,18 @@
+import { calculateShiftDuration, calculateNightHours } from '@/lib/compliance/utils'
+import type { ShiftType } from '@/types'
+
+/**
+ * Détermine `presence_day` ou `presence_night` selon les horaires.
+ * Règle : si plus de la moitié des heures tombent sur la plage nuit (21h–6h),
+ * on considère la présence responsable comme "nuit".
+ */
+export function detectPresenceType(
+  startTime: string,
+  endTime: string,
+): Extract<ShiftType, 'presence_day' | 'presence_night'> {
+  if (!startTime || !endTime) return 'presence_day'
+  const totalHours = calculateShiftDuration(startTime, endTime, 0) / 60
+  if (totalHours <= 0) return 'presence_day'
+  const nightHours = calculateNightHours(new Date(), startTime, endTime)
+  return nightHours > totalHours / 2 ? 'presence_night' : 'presence_day'
+}

--- a/src/lib/presence/detectPresenceType.ts
+++ b/src/lib/presence/detectPresenceType.ts
@@ -16,3 +16,29 @@ export function detectPresenceType(
   const nightHours = calculateNightHours(new Date(), startTime, endTime)
   return nightHours > totalHours / 2 ? 'presence_night' : 'presence_day'
 }
+
+/**
+ * Détaille la répartition jour/nuit d'une plage horaire.
+ * Utile pour avertir quand une présence responsable chevauche les deux
+ * régimes (calculs de paie différents : ×2/3 jour vs ×1/4 nuit).
+ */
+export function getPresenceMix(
+  startTime: string,
+  endTime: string,
+): { totalHours: number; dayHours: number; nightHours: number; isMixed: boolean } {
+  if (!startTime || !endTime) {
+    return { totalHours: 0, dayHours: 0, nightHours: 0, isMixed: false }
+  }
+  const totalHours = calculateShiftDuration(startTime, endTime, 0) / 60
+  if (totalHours <= 0) {
+    return { totalHours: 0, dayHours: 0, nightHours: 0, isMixed: false }
+  }
+  const nightHours = calculateNightHours(new Date(), startTime, endTime)
+  const dayHours = Math.max(0, totalHours - nightHours)
+  return {
+    totalHours,
+    dayHours,
+    nightHours,
+    isMixed: dayHours > 0 && nightHours > 0,
+  }
+}


### PR DESCRIPTION
## Summary

Retour réunion 16/04 (Marie) : fusionner dans la modale intervention les deux options **"Présence responsable (jour)"** et **"(nuit)"** en une seule entrée **"Présence responsable"**, comme déjà fait dans la garde 24h.

### Changements

**Fusion du select (commit 1)**
- `NewShiftModal` & `ShiftEditForm` : select à 3 options (Travail effectif / Présence responsable / Garde 24h)
- Auto-détection `presence_day` / `presence_night` selon les horaires (`detectPresenceType`)
- Re-détection automatique si les horaires changent
- Util `detectPresenceType` extrait dans `src/lib/presence/` (dédoublonné depuis `Guard24hSection`)
- Les types DB restent inchangés — pas de migration

**Avertissement "à cheval" (commit 2)**
Cas limite identifié : **18h–23h** = 3h jour + 2h nuit. La règle "majorité" classe en `presence_day` alors que les régimes ×2/3 (jour) et ×1/4 (nuit) diffèrent radicalement.
- Nouveau composant `PresenceMixedWarning` affiché automatiquement quand la présence chevauche jour et nuit
- Suggère de créer deux interventions ou d'utiliser une garde 24h
- Non bloquant : l'utilisateur peut quand même valider

### Tests
- 9 nouveaux tests unitaires pour `detectPresenceType` + `getPresenceMix`
- 151/151 tests planning passent
- 2274/2274 tests suite complète

## Test plan
- [x] `npm run lint` (2 warnings préexistants, non liés)
- [x] `npm run test:run` : 2274 tests passent
- [x] Modale "Nouvelle intervention" : 3 options dans le select
- [x] Choix "Présence responsable" + horaires 09h-12h → section jour
- [x] Choix "Présence responsable" + horaires 21h-07h → section nuit
- [x] Horaires 18h-23h → avertissement "à cheval" affiché
- [x] Édition d'un shift `presence_day` existant : select affiche "Présence responsable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)