### PR TITLE
fix(dashboard): use unique keys for QuickActions items

### DIFF
--- a/src/components/dashboard/widgets/QuickActionsWidget.tsx
+++ b/src/components/dashboard/widgets/QuickActionsWidget.tsx
@@ -77,7 +77,7 @@ export function QuickActionsWidget({ userRole, permissions }: QuickActionsWidget
       <SimpleGrid columns={2} gap={2} p={4}>
         {actions.map((action) => (
           <Flex
-            key={action.href}
+            key={action.label}
             as={RouterLink}
             to={action.href}
             direction="column"


### PR DESCRIPTION
## Summary
Corrige le warning React `Encountered two children with the same key, '/documents'` sur le dashboard employeur.

### Changements
- `QuickActionsWidget.tsx` : `key={action.href}` → `key={action.label}`

Les deux actions employeur "Bulletin" et "Exporter" pointent toutes les deux vers `/documents`, donc `href` n'est pas une clé unique. `label` l'est (unique dans chaque liste `actionsByRole`).

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2274/2274 passent
- [ ] Ouvrir le dashboard employeur → plus de warning console React

🤖 Generated with [Claude Code](https://claude.com/claude-code)