### PR TITLE
fix(absences): filter null employee ids before Supabase in() query

### DIFF
--- a/src/services/absenceService.ts
+++ b/src/services/absenceService.ts
@@ -58,7 +58,11 @@ export async function getAbsencesForEmployer(
     return []
   }
 
-  const employeeIds = contracts.map((c) => c.employee_id)
+  const employeeIds = contracts
+    .map((c) => c.employee_id)
+    .filter((id): id is string => Boolean(id))
+
+  if (employeeIds.length === 0) return []
 
   const { data, error } = await supabase
     .from('absences')
@@ -91,7 +95,11 @@ export async function getPendingAbsencesForEmployer(
     return []
   }
 
-  const employeeIds = contracts.map((c) => c.employee_id)
+  const employeeIds = contracts
+    .map((c) => c.employee_id)
+    .filter((id): id is string => Boolean(id))
+
+  if (employeeIds.length === 0) return []
 
   const { data, error } = await supabase
     .from('absences')


### PR DESCRIPTION
## Summary
Corrige le 400 `invalid input syntax for type uuid: "null"` sur le fetch des absences côté employeur.

### Problème
`getAbsencesForEmployer` et `getPendingAbsencesForEmployer` passaient directement la liste `contracts.employee_id` à `.in('employee_id', ids)`. Si un contrat actif a un `employee_id` à `null` (contrat créé mais pas encore lié à un employé), PostgREST sérialise `null` en string `"null"` dans le filtre `in.(...)`, ce qui fait échouer toute la requête en 400.

Observé en console prod :
```
XHRGET https://api.unilien.app/rest/v1/absences?...&employee_id=in.(<uuid>,null)  [HTTP/2 400]
[ERROR] Erreur récupération absences employeur: { code: "22P02", message: 'invalid input syntax for type uuid: "null"' }
```

### Changements
- `absenceService.ts` : filtre `null` avec type guard + short-circuit quand la liste est vide (2 fonctions).

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2274/2274 passent
- [ ] Dashboard employeur avec contrat actif + `employee_id` null → plus de 400, liste chargée normalement
- [ ] Dashboard employeur sans contrat actif → retour vide silencieux (déjà géré)

🤖 Generated with [Claude Code](https://claude.com/claude-code)