### PR TITLE
fix(documents): dedupe employees in PlanningExportSection select

### DIFF
--- a/src/components/documents/PlanningExportSection.tsx
+++ b/src/components/documents/PlanningExportSection.tsx
@@ -109,12 +109,18 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
     setIsLoadingEmployees(true)
     getContractsForEmployer(employerId)
       .then((contracts) => {
-        const opts: EmployeeOption[] = contracts.map((c) => ({
-          value: c.employeeId,
-          label: c.employee
-            ? `${c.employee.firstName} ${c.employee.lastName}`
-            : `Employe (${c.contractType})`,
-        }))
+        const seen = new Set<string>()
+        const opts: EmployeeOption[] = []
+        for (const c of contracts) {
+          if (!c.employeeId || seen.has(c.employeeId)) continue
+          seen.add(c.employeeId)
+          opts.push({
+            value: c.employeeId,
+            label: c.employee
+              ? `${c.employee.firstName} ${c.employee.lastName}`
+              : `Employe (${c.contractType})`,
+          })
+        }
         setEmployees(opts)
       })
       .catch((err) => {


### PR DESCRIPTION
## Summary
Corrige le warning React `Each child in a list should have a unique "key" prop` émis par `PlanningExportSection` dans la page Documents.

### Problème
`getContractsForEmployer` renvoie à la fois les contrats `employment` et `caregiver_pch`. Un même employé peut donc apparaître sur plusieurs lignes (deux contrats de catégories différentes, ou contrats successifs), et les contrats `caregiver_pch` peuvent avoir `employeeId = null`. Le `.map()` transformait ça en `<option value={c.employeeId}>` avec des clés dupliquées ou vides.

### Changements
- `PlanningExportSection.tsx` : dédup via `Set` sur `employeeId` + skip des ids falsy pour ne garder qu'une option par employé.

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2274/2274 passent
- [ ] Page Documents → "Export du planning" : la liste déroulante "Employé" ne montre chaque employé qu'une seule fois, plus de warning console

🤖 Generated with [Claude Code](https://claude.com/claude-code)