### PR TITLE
refactor(db): make payslip computed columns nullable

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -359,10 +359,10 @@ export interface PayslipDbRow {
   contract_id: string
   year: number
   month: number
-  period_label: string
-  gross_pay: number
-  net_pay: number
-  total_hours: number
+  period_label: string | null
+  gross_pay: number | null
+  net_pay: number | null
+  total_hours: number | null
   pas_rate: number
   is_exempt_patronal_ss: boolean
   storage_path: string | null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -444,10 +444,10 @@ export interface Payslip {
   contractId: string
   year: number
   month: number
-  periodLabel: string
-  grossPay: number
-  netPay: number
-  totalHours: number
+  periodLabel: string | null
+  grossPay: number | null
+  netPay: number | null
+  totalHours: number | null
   pasRate: number
   isExemptPatronalSS: boolean
   storagePath: string | null

--- a/supabase/migrations/052_payslip_nullable_computed_columns.sql
+++ b/supabase/migrations/052_payslip_nullable_computed_columns.sql
@@ -1,0 +1,14 @@
+-- ============================================
+-- Migration 052 : payslips — colonnes calculées rendues optionnelles
+-- Contexte : on abandonne la génération du bulletin côté app. L'employeur
+-- upload désormais le bulletin officiel reçu de l'URSSAF (CESU déclaratif).
+-- Les montants dénormalisés ne sont plus extraits d'un PDF importé : ils
+-- deviennent optionnels pour accepter un enregistrement "upload-only"
+-- tout en conservant les bulletins historiquement générés.
+-- ============================================
+
+ALTER TABLE public.payslips
+  ALTER COLUMN gross_pay     DROP NOT NULL,
+  ALTER COLUMN net_pay       DROP NOT NULL,
+  ALTER COLUMN total_hours   DROP NOT NULL,
+  ALTER COLUMN period_label  DROP NOT NULL;


### PR DESCRIPTION
## Summary
Première étape du passage "upload du bulletin URSSAF" au lieu de la génération PDF côté app (1/5 PRs). Rend optionnelles les colonnes qu'on ne pourra plus remplir quand l'employeur upload un PDF externe reçu de l'URSSAF.

### Contexte
Avec le CESU déclaratif, l'URSSAF calcule et envoie le bulletin officiel. L'app ne génèrera plus son propre PDF — l'employeur va uploader celui reçu. On ne peut donc plus extraire `gross_pay` / `net_pay` / `total_hours` / `period_label` d'un PDF importé.

### Changements
- **Migration 052** : `DROP NOT NULL` sur `gross_pay`, `net_pay`, `total_hours`, `period_label`
- `PayslipDbRow` et `Payslip` (TS) : ces 4 champs deviennent `| null`
- `pas_rate` et `is_exempt_patronal_ss` restent `NOT NULL` (ils ont des defaults)
- Les bulletins historiquement générés conservent leurs valeurs

### Ce que ça ne fait PAS encore
Cette PR est purement additive/permissive : elle prépare le schéma. L'UI upload, le service, la suppression de la génération viendront dans les PRs suivantes.

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run typecheck` — OK
- [x] `npm run test:run` — 2274/2274 passent
- [x] Migration appliquée sur l'env self-host (à tester avant merge des PRs suivantes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)