### PR TITLE
feat(planning): enforce 20-min mandatory break above 6h of work

### DIFF
--- a/src/components/planning/NewShiftModal.tsx
+++ b/src/components/planning/NewShiftModal.tsx
@@ -28,6 +28,10 @@ import { toaster } from '@/lib/toaster'
 import { formatHoursCompact } from '@/lib/formatHours'
 import { detectPresenceType, getPresenceMix } from '@/lib/presence/detectPresenceType'
 import { PresenceMixedWarning } from './PresenceMixedWarning'
+import {
+  MANDATORY_BREAK_MINIMUM_MINUTES,
+  MANDATORY_BREAK_THRESHOLD_MINUTES,
+} from '@/lib/validation/shiftSchemas'
 
 const SHIFT_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
@@ -341,15 +345,26 @@ export function NewShiftModal({
                   )}
 
                   {/* Pause globale — masquée pour guard_24h */}
-                  {shiftType !== 'guard_24h' && (
-                    <AccessibleInput
-                      label="Pause (minutes)"
-                      type="number"
-                      helperText="Durée de la pause en minutes (20 min obligatoire si > 6h)"
-                      error={errors.breakDuration?.message}
-                      {...register('breakDuration')}
-                    />
-                  )}
+                  {shiftType !== 'guard_24h' && (() => {
+                    const breakRequired = durationHours * 60 > MANDATORY_BREAK_THRESHOLD_MINUTES
+                    return (
+                      <Box>
+                        <AccessibleInput
+                          label="Pause (minutes)"
+                          type="number"
+                          min={breakRequired ? MANDATORY_BREAK_MINIMUM_MINUTES : 0}
+                          step={5}
+                          helperText={
+                            breakRequired
+                              ? `Intervention > 6 h : ${MANDATORY_BREAK_MINIMUM_MINUTES} min minimum obligatoire (art. L3121-16).`
+                              : 'Durée de la pause en minutes.'
+                          }
+                          error={errors.breakDuration?.message}
+                          {...register('breakDuration')}
+                        />
+                      </Box>
+                    )
+                  })()}
 
                   {/* Avertissement présence à cheval jour/nuit */}
                   {isPresenceType(shiftType) && watchedValues.startTime && watchedValues.endTime && (() => {

--- a/src/components/planning/ShiftDetailModal.tsx
+++ b/src/components/planning/ShiftDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useMemo, useCallback } from 'react'
+import { useReducer, useMemo, useCallback, useEffect } from 'react'
 import {
   Flex,
   Text,
@@ -6,7 +6,12 @@ import {
 import { useNavigate } from 'react-router-dom'
 import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { shiftDetailSchema as shiftSchema, type ShiftDetailFormData as ShiftFormData } from '@/lib/validation/shiftSchemas'
+import {
+  shiftDetailSchema as shiftSchema,
+  type ShiftDetailFormData as ShiftFormData,
+  MANDATORY_BREAK_MINIMUM_MINUTES,
+  MANDATORY_BREAK_THRESHOLD_MINUTES,
+} from '@/lib/validation/shiftSchemas'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
 import { AccessibleButton, StatusPill, GhostButton, PrimaryButton } from '@/components/ui'
@@ -206,6 +211,23 @@ export function ShiftDetailModal({
   })
 
   const watchedValues = useWatch({ control })
+
+  // Auto-bump pause à 20 min quand la durée dépasse 6 h (art. L3121-16).
+  // La garde 24h n'entre pas ici (shiftType est 'effective' | 'presence_*').
+  useEffect(() => {
+    if (!watchedValues.startTime || !watchedValues.endTime) return
+    const [sh, sm] = watchedValues.startTime.split(':').map(Number)
+    const [eh, em] = watchedValues.endTime.split(':').map(Number)
+    if ([sh, sm, eh, em].some((v) => Number.isNaN(v))) return
+    const startTotal = sh * 60 + sm
+    let endTotal = eh * 60 + em
+    if (endTotal <= startTotal) endTotal += 24 * 60
+    const durationMinutes = endTotal - startTotal
+    const current = watchedValues.breakDuration ?? 0
+    if (durationMinutes > MANDATORY_BREAK_THRESHOLD_MINUTES && current < MANDATORY_BREAK_MINIMUM_MINUTES) {
+      setValue('breakDuration', MANDATORY_BREAK_MINIMUM_MINUTES, { shouldValidate: true })
+    }
+  }, [watchedValues.startTime, watchedValues.endTime, watchedValues.breakDuration, setValue])
 
   // Callback stable pour le reset du formulaire (passé à useShiftDetailData)
   const handleResetForm = useCallback(

--- a/src/components/planning/ShiftEditForm.tsx
+++ b/src/components/planning/ShiftEditForm.tsx
@@ -18,6 +18,10 @@ import type { ShiftDetailFormData } from '@/lib/validation/shiftSchemas'
 import { formatHoursCompact } from '@/lib/formatHours'
 import { detectPresenceType, getPresenceMix } from '@/lib/presence/detectPresenceType'
 import { PresenceMixedWarning } from './PresenceMixedWarning'
+import {
+  MANDATORY_BREAK_MINIMUM_MINUTES,
+  MANDATORY_BREAK_THRESHOLD_MINUTES,
+} from '@/lib/validation/shiftSchemas'
 
 const SHIFT_TYPE_OPTIONS = [
   { value: 'effective', label: 'Travail effectif' },
@@ -164,13 +168,24 @@ export function ShiftEditForm({
         )}
 
         {/* Pause */}
-        <AccessibleInput
-          label="Pause (minutes)"
-          type="number"
-          helperText="Durée de la pause en minutes"
-          error={errors.breakDuration?.message}
-          {...register('breakDuration')}
-        />
+        {(() => {
+          const breakRequired = durationHours * 60 > MANDATORY_BREAK_THRESHOLD_MINUTES
+          return (
+            <AccessibleInput
+              label="Pause (minutes)"
+              type="number"
+              min={breakRequired ? MANDATORY_BREAK_MINIMUM_MINUTES : 0}
+              step={5}
+              helperText={
+                breakRequired
+                  ? `Intervention > 6 h : ${MANDATORY_BREAK_MINIMUM_MINUTES} min minimum obligatoire (art. L3121-16).`
+                  : 'Durée de la pause en minutes.'
+              }
+              error={errors.breakDuration?.message}
+              {...register('breakDuration')}
+            />
+          )
+        })()}
 
         {/* Statut */}
         <AccessibleSelect

--- a/src/hooks/useNewShiftForm.ts
+++ b/src/hooks/useNewShiftForm.ts
@@ -1,7 +1,12 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { newShiftSchema as shiftSchema, type NewShiftFormData as ShiftFormData } from '@/lib/validation/shiftSchemas'
+import {
+  newShiftSchema as shiftSchema,
+  type NewShiftFormData as ShiftFormData,
+  MANDATORY_BREAK_MINIMUM_MINUTES,
+  MANDATORY_BREAK_THRESHOLD_MINUTES,
+} from '@/lib/validation/shiftSchemas'
 import { format } from 'date-fns'
 import { createShift } from '@/services/shiftService'
 import { useComplianceCheck } from '@/hooks/useComplianceCheck'
@@ -97,6 +102,24 @@ export function useNewShiftForm({
       setValue('breakDuration', totalBreak)
     }
   }, [shiftType, guardSegments, setValue])
+
+  // Auto-bump de la pause à 20 min quand la durée dépasse 6 h (art. L3121-16).
+  // Skip pour guard_24h : règle gérée segment par segment via useGuardSegments.
+  useEffect(() => {
+    if (shiftType === 'guard_24h') return
+    if (!watchedValues.startTime || !watchedValues.endTime) return
+    const [sh, sm] = watchedValues.startTime.split(':').map(Number)
+    const [eh, em] = watchedValues.endTime.split(':').map(Number)
+    if ([sh, sm, eh, em].some((v) => Number.isNaN(v))) return
+    const startTotal = sh * 60 + sm
+    let endTotal = eh * 60 + em
+    if (endTotal <= startTotal) endTotal += 24 * 60
+    const durationMinutes = endTotal - startTotal
+    const current = watchedValues.breakDuration ?? 0
+    if (durationMinutes > MANDATORY_BREAK_THRESHOLD_MINUTES && current < MANDATORY_BREAK_MINIMUM_MINUTES) {
+      setValue('breakDuration', MANDATORY_BREAK_MINIMUM_MINUTES, { shouldValidate: true })
+    }
+  }, [shiftType, watchedValues.startTime, watchedValues.endTime, watchedValues.breakDuration, setValue])
 
   const { nightHoursCount, hasNightHours } = useShiftNightHours({
     startTime: watchedValues.startTime,

--- a/src/lib/validation/shiftSchemas.test.ts
+++ b/src/lib/validation/shiftSchemas.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  newShiftSchema,
+  shiftDetailSchema,
+  MANDATORY_BREAK_MINIMUM_MINUTES,
+} from './shiftSchemas'
+
+const baseNewShift = {
+  date: '2026-05-10',
+  startTime: '09:00',
+  endTime: '12:00',
+  breakDuration: 0,
+  contractId: 'contract-1',
+  shiftType: 'effective' as const,
+}
+
+const baseShiftDetail = {
+  date: '2026-05-10',
+  startTime: '09:00',
+  endTime: '12:00',
+  breakDuration: 0,
+  status: 'planned' as const,
+}
+
+describe('shiftSchemas — règle pause L3121-16', () => {
+  describe('newShiftSchema', () => {
+    it('accepte une intervention ≤ 6h avec pause 0', () => {
+      const result = newShiftSchema.safeParse({
+        ...baseNewShift,
+        startTime: '09:00',
+        endTime: '15:00', // 6h pile
+        breakDuration: 0,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejette une intervention > 6h avec pause < 20 min', () => {
+      const result = newShiftSchema.safeParse({
+        ...baseNewShift,
+        startTime: '09:00',
+        endTime: '17:00', // 8h
+        breakDuration: 15,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].path).toContain('breakDuration')
+        expect(result.error.issues[0].message).toMatch(/L3121-16/)
+      }
+    })
+
+    it('accepte une intervention > 6h avec pause ≥ 20 min', () => {
+      const result = newShiftSchema.safeParse({
+        ...baseNewShift,
+        startTime: '09:00',
+        endTime: '17:00',
+        breakDuration: MANDATORY_BREAK_MINIMUM_MINUTES,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('ignore la règle pour shiftType = guard_24h', () => {
+      const result = newShiftSchema.safeParse({
+        ...baseNewShift,
+        shiftType: 'guard_24h',
+        startTime: '09:00',
+        endTime: '09:00', // garde = 24h = début = fin
+        breakDuration: 0,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('gère correctement les shifts qui passent minuit', () => {
+      // 22:00 → 06:00 = 8h, pas de pause → refus
+      const result = newShiftSchema.safeParse({
+        ...baseNewShift,
+        startTime: '22:00',
+        endTime: '06:00',
+        breakDuration: 0,
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('shiftDetailSchema', () => {
+    it('applique la règle pause sur l\'édition d\'un shift', () => {
+      const result = shiftDetailSchema.safeParse({
+        ...baseShiftDetail,
+        startTime: '08:00',
+        endTime: '18:00', // 10h
+        breakDuration: 10,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('laisse passer une édition avec pause suffisante', () => {
+      const result = shiftDetailSchema.safeParse({
+        ...baseShiftDetail,
+        startTime: '08:00',
+        endTime: '18:00',
+        breakDuration: 30,
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/src/lib/validation/shiftSchemas.ts
+++ b/src/lib/validation/shiftSchemas.ts
@@ -2,6 +2,13 @@ import { z } from 'zod'
 
 export const SHIFT_TYPE_VALUES = ['effective', 'presence_day', 'presence_night', 'guard_24h'] as const
 
+/**
+ * Pause légale — Art. L3121-16 du Code du travail.
+ * Au-delà de 6 h de travail effectif : 20 min de pause minimum obligatoires.
+ */
+export const MANDATORY_BREAK_THRESHOLD_MINUTES = 6 * 60
+export const MANDATORY_BREAK_MINIMUM_MINUTES = 20
+
 const shiftBaseFields = {
   date: z.string().min(1, 'La date est requise'),
   startTime: z.string().min(1, "L'heure de début est requise"),
@@ -11,6 +18,28 @@ const shiftBaseFields = {
   notes: z.string().optional(),
 }
 
+/** Durée totale d'un shift en minutes, en tenant compte d'un passage de minuit. */
+function shiftDurationMinutes(startTime: string, endTime: string): number {
+  const [sh, sm] = startTime.split(':').map(Number)
+  const [eh, em] = endTime.split(':').map(Number)
+  if ([sh, sm, eh, em].some((v) => Number.isNaN(v))) return 0
+  const startTotal = sh * 60 + sm
+  let endTotal = eh * 60 + em
+  if (endTotal <= startTotal) endTotal += 24 * 60
+  return endTotal - startTotal
+}
+
+function breakRuleRefine(data: { startTime: string; endTime: string; breakDuration: number; shiftType?: string }) {
+  // La règle des 20 min s'applique au travail effectif simple. La garde 24h
+  // est validée segment par segment via useGuardSegments / validateBreak.
+  if (data.shiftType === 'guard_24h') return true
+  const duration = shiftDurationMinutes(data.startTime, data.endTime)
+  if (duration <= MANDATORY_BREAK_THRESHOLD_MINUTES) return true
+  return (data.breakDuration ?? 0) >= MANDATORY_BREAK_MINIMUM_MINUTES
+}
+
+const breakRuleMessage = `Pause de ${MANDATORY_BREAK_MINIMUM_MINUTES} min minimum obligatoire au-delà de 6 h (art. L3121-16).`
+
 /** Schema used by ShiftDetailModal (editing an existing shift). */
 export const shiftDetailSchema = z.object({
   ...shiftBaseFields,
@@ -18,6 +47,9 @@ export const shiftDetailSchema = z.object({
 }).refine((data) => data.startTime !== data.endTime, {
   message: "L'heure de fin doit être différente de l'heure de début",
   path: ['endTime'],
+}).refine(breakRuleRefine, {
+  message: breakRuleMessage,
+  path: ['breakDuration'],
 })
 
 /** Schema used by NewShiftModal (creating a shift). */
@@ -32,6 +64,9 @@ export const newShiftSchema = z.object({
 }, {
   message: "L'heure de fin doit être différente de l'heure de début",
   path: ['endTime'],
+}).refine(breakRuleRefine, {
+  message: breakRuleMessage,
+  path: ['breakDuration'],
 })
 
 export type ShiftDetailFormData = z.infer<typeof shiftDetailSchema>


### PR DESCRIPTION
## Summary
Feedback Marie 16/04 : "Pause obligatoire en info fixe mais doit être modifiable > 6h minimum 20 mn peut pas en dessous."

Le formulaire actuel laisse créer une intervention de 8h avec 0 min (ou 10 min) de pause avec juste un avertissement greyé — contraire à l'art. L3121-16 du Code du travail.

### Changements

**Schéma Zod** (`shiftSchemas.ts`)
- Nouvelles constantes `MANDATORY_BREAK_THRESHOLD_MINUTES` (6 h) et `MANDATORY_BREAK_MINIMUM_MINUTES` (20)
- Cross-field refine sur `newShiftSchema` et `shiftDetailSchema` : rejette toute soumission avec durée > 6 h et pause < 20 min
- Gère correctement les shifts qui passent minuit (22h → 06h)
- Exclu pour `guard_24h` (règle appliquée segment par segment via `useGuardSegments.getMinBreakForSegment`)

**UI** (`NewShiftModal` + `ShiftEditForm`)
- `min={20}` dynamique sur l'input quand durée > 6 h → la flèche ↓ du navigateur ne descend plus sous 20
- Helper text bascule sur un rappel explicite de l'article L3121-16 quand la règle s'active

**Auto-bump** (`useNewShiftForm` + `ShiftDetailModal`)
- Dès que la durée franchit 6 h, la pause passe automatiquement à 20 min si elle était < 20 — plus besoin d'une étape manuelle pour réparer l'état invalide
- L'utilisateur reste libre de monter au-dessus (le champ reste éditable)

### Tests
- 7 nouveaux tests `shiftSchemas.test.ts` : ≤6h OK sans pause, >6h refusé sous 20, >6h OK à 20+, guard_24h exempté, overnight shifts, édition

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run typecheck` — OK
- [x] `npm run test:run` — 2266/2266 passent (+7 nouveaux)
- [x] **Test manuel à valider** :
  - Créer un shift 09:00 → 17:00 (8h) : la pause passe auto à 20, input bloque sous 20
  - Shift 09:00 → 15:00 (6h) : pause libre à 0
  - Modifier un shift existant de 4h → 8h : auto-bump à 20
  - Garde 24h : pas d'auto-bump global (gardé par segment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)