### PR TITLE
fix(dashboard): drop strike-through on completed onboarding labels

### DIFF
--- a/src/components/dashboard/widgets/OnboardingWidget.tsx
+++ b/src/components/dashboard/widgets/OnboardingWidget.tsx
@@ -227,7 +227,6 @@ export function OnboardingWidget({ profile, userRole }: OnboardingWidgetProps) {
                   fontWeight="600"
                   fontSize="sm"
                   color={step.done ? 'text.muted' : 'text.default'}
-                  textDecoration={step.done ? 'line-through' : 'none'}
                   transition="color 0.15s"
                 >
                   {step.label}


### PR DESCRIPTION
## Summary
Retire la barre rayée sur les labels des étapes d'onboarding complétées. La pastille verte ✓ + la couleur atténuée suffisent pour signaler l'état "fait" — la barre par-dessus rendait le texte dur à lire.

### Changements
- `OnboardingWidget.tsx` : suppression de `textDecoration={step.done ? 'line-through' : 'none'}`

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run typecheck` — OK
- [x] `npm run test:run` — 2266/2266 passent
- [x] Dashboard employeur → widget onboarding : étapes complétées en gris sans barre

🤖 Generated with [Claude Code](https://claude.com/claude-code)