### PR TITLE
fix(absence): disability announcement leave bumped to 5 days

### DIFF
--- a/src/components/planning/AbsenceRequestModal.test.tsx
+++ b/src/components/planning/AbsenceRequestModal.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@/lib/absence', () => ({
     death_sibling: 'Décès d\'un frère/sœur',
     death_in_law: 'Décès beau-parent',
     child_marriage: 'Mariage d\'un enfant',
-    disability_announcement: 'Annonce handicap enfant',
+    disability_announcement: 'Annonce du handicap d\'un enfant',
   },
   FAMILY_EVENT_DAYS: {
     marriage: 4,
@@ -38,7 +38,7 @@ vi.mock('@/lib/absence', () => ({
     death_sibling: 3,
     death_in_law: 3,
     child_marriage: 1,
-    disability_announcement: 2,
+    disability_announcement: 5,
   },
 }))
 

--- a/src/lib/absence/types.ts
+++ b/src/lib/absence/types.ts
@@ -48,7 +48,7 @@ export const FAMILY_EVENT_DAYS: Record<FamilyEventType, number> = {
   death_sibling: 3,
   death_in_law: 3,
   child_marriage: 1,
-  disability_announcement: 2,
+  disability_announcement: 5,
 }
 
 // Labels français pour les événements familiaux
@@ -63,5 +63,5 @@ export const FAMILY_EVENT_LABELS: Record<FamilyEventType, string> = {
   death_sibling: 'Décès d\'un frère/sœur',
   death_in_law: 'Décès d\'un beau-parent',
   child_marriage: 'Mariage d\'un enfant',
-  disability_announcement: 'Annonce handicap d\'un enfant',
+  disability_announcement: 'Annonce du handicap d\'un enfant',
 }


### PR DESCRIPTION
## Summary
Correction d'une valeur obsolète signalée par Marie : le congé pour "annonce du handicap d'un enfant" était fixé à 2 jours dans l'app alors que la loi du 21 février 2022 l'a porté à **5 jours**.

### Source légale
**Article L3142-4 6° du Code du travail** (dans sa rédaction issue de la loi n° 2022-219) :
> *Cinq jours pour l'annonce de la survenue d'un handicap, d'une pathologie chronique nécessitant un apprentissage thérapeutique ou d'un cancer chez un enfant.*

### Changements
- `FAMILY_EVENT_DAYS.disability_announcement` : `2` → `5`
- Label : `"Annonce handicap d'un enfant"` → `"Annonce du handicap d'un enfant"` (le "du" manquait, rendait le libellé un peu clinique — feedback Marie)
- Mock de test aligné sur les nouvelles valeurs

### Autres valeurs vérifiées (audit complet)
Les 10 autres événements familiaux ont été audités contre L3142-4 : tous corrects au minimum légal. Seul point d'attention documenté pour plus tard : `death_child` est à 5 (minimum légal), mais la loi prévoit 7 jours si l'enfant avait moins de 25 ans ou était lui-même parent — décision de traiter ces cas via la catégorie "Autre" pour l'instant.

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run typecheck` — OK
- [x] `npm run test:run` — 2266/2266 passent
- [x] Vérifier dans l'app : absence → Familial → "Annonce du handicap d'un enfant" affiche bien 5 j ouvrés

🤖 Generated with [Claude Code](https://claude.com/claude-code)