### PR TITLE
refactor(avatars): store storage paths and sync authStore

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -9,7 +9,7 @@ unilien.app, www.unilien.app {
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "camera=(), microphone=(self), geolocation=()"
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://*.supabase.co wss://*.supabase.co; img-src 'self' data: blob: https://api.unilien.app https://*.supabase.co; font-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://*.supabase.co wss://*.supabase.co; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
 
     @assets path /assets/*

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -390,7 +390,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
               >
                 <Avatar.Root size="xs">
                   <Avatar.Fallback name={profile ? `${profile.firstName} ${profile.lastName}` : undefined} />
-                  {profile?.avatarUrl && <Avatar.Image src={profile.avatarUrl} />}
+                  {profile?.avatarUrl && <Avatar.Image key={profile.avatarUrl} src={profile.avatarUrl} />}
                 </Avatar.Root>
                 <svg
                   width="14" height="14" viewBox="0 0 24 24"
@@ -593,7 +593,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
           <Flex align="center" gap={2}>
             <Avatar.Root size="sm">
               <Avatar.Fallback name={profile ? `${profile.firstName} ${profile.lastName}` : undefined} />
-              {profile?.avatarUrl && <Avatar.Image src={profile.avatarUrl} />}
+              {profile?.avatarUrl && <Avatar.Image key={profile.avatarUrl} src={profile.avatarUrl} />}
             </Avatar.Root>
             <Box flex={1} minW={0}>
               <Text fontSize="sm" fontWeight="bold" color="text.default" truncate>

--- a/src/components/dashboard/widgets/TodayPlanningWidget.tsx
+++ b/src/components/dashboard/widgets/TodayPlanningWidget.tsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react'
 import { AccessibleButton } from '@/components/ui'
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import { SHIFT_STATUS_LABELS, SHIFT_TYPE_LABELS } from '@/lib/constants/statusMaps'
 import type { Shift } from '@/types'
@@ -108,7 +109,7 @@ export function TodayPlanningWidget({ employerId }: TodayPlanningWidgetProps) {
               status: row.status as Shift['status'],
               employeeFirstName: (profile?.first_name as string) ?? '',
               employeeLastName: (profile?.last_name as string) ?? '',
-              employeeAvatarUrl: profile?.avatar_url as string | undefined,
+              employeeAvatarUrl: resolveAvatarUrl(profile?.avatar_url as string | null | undefined),
             }
           })
           setShifts(mapped)

--- a/src/components/profile/ProfileHero.tsx
+++ b/src/components/profile/ProfileHero.tsx
@@ -73,7 +73,7 @@ export function ProfileHero({ profile, isEditing, onToggleEdit, onAvatarClick }:
               fontWeight={800}
               fontSize="1.8rem"
             />
-            {profile.avatarUrl && <Avatar.Image src={profile.avatarUrl} />}
+            {profile.avatarUrl && <Avatar.Image key={profile.avatarUrl} src={profile.avatarUrl} />}
           </Avatar.Root>
           {onAvatarClick && (
             <Box

--- a/src/components/profile/sections/PersonalInfoSection.tsx
+++ b/src/components/profile/sections/PersonalInfoSection.tsx
@@ -167,7 +167,7 @@ export function PersonalInfoSection({ profile, onSave, onAvatarChange }: Persona
           <Box position="relative">
             <Avatar.Root size="xl">
               <Avatar.Fallback name={`${profile.firstName} ${profile.lastName}`} />
-              {displayAvatarUrl && <Avatar.Image src={displayAvatarUrl} />}
+              {displayAvatarUrl && <Avatar.Image key={displayAvatarUrl} src={displayAvatarUrl} />}
             </Avatar.Root>
             {avatarLoading && (
               <Box

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -1,5 +1,6 @@
 import type { ProfileDbRow } from '@/types/database'
 import type { Profile, UserRole } from '@/types'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 
 /**
  * Convertit une ligne profil DB (snake_case) en objet Profile app (camelCase)
@@ -12,7 +13,7 @@ export function mapProfileFromDb(data: ProfileDbRow, emailOverride?: string): Pr
     lastName: data.last_name,
     email: emailOverride || data.email || '',
     phone: data.phone || undefined,
-    avatarUrl: data.avatar_url || undefined,
+    avatarUrl: resolveAvatarUrl(data.avatar_url),
     accessibilitySettings: data.accessibility_settings || {},
     createdAt: new Date(data.created_at),
     updatedAt: new Date(data.updated_at),

--- a/src/lib/supabase/avatars.test.ts
+++ b/src/lib/supabase/avatars.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGetPublicUrl = vi.fn()
+
+vi.mock('./client', () => ({
+  supabase: {
+    storage: {
+      from: vi.fn(() => ({
+        getPublicUrl: mockGetPublicUrl,
+      })),
+    },
+  },
+}))
+
+import { resolveAvatarUrl } from './avatars'
+
+describe('resolveAvatarUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retourne undefined pour null / undefined / chaîne vide', () => {
+    expect(resolveAvatarUrl(null)).toBeUndefined()
+    expect(resolveAvatarUrl(undefined)).toBeUndefined()
+    expect(resolveAvatarUrl('')).toBeUndefined()
+    expect(mockGetPublicUrl).not.toHaveBeenCalled()
+  })
+
+  it('retourne la valeur telle quelle si elle commence par http (rétrocompat legacy)', () => {
+    const legacyUrl = 'https://lczfygydhnyygguvponw.supabase.co/storage/v1/object/public/avatars/user-1/123.jpg'
+    expect(resolveAvatarUrl(legacyUrl)).toBe(legacyUrl)
+    expect(mockGetPublicUrl).not.toHaveBeenCalled()
+  })
+
+  it('résout un path Storage vers une URL publique via getPublicUrl', () => {
+    mockGetPublicUrl.mockReturnValue({
+      data: { publicUrl: 'https://api.unilien.app/storage/v1/object/public/avatars/user-1/123.jpg' },
+    })
+
+    const result = resolveAvatarUrl('user-1/123.jpg')
+
+    expect(mockGetPublicUrl).toHaveBeenCalledWith('user-1/123.jpg')
+    expect(result).toBe('https://api.unilien.app/storage/v1/object/public/avatars/user-1/123.jpg')
+  })
+})

--- a/src/lib/supabase/avatars.ts
+++ b/src/lib/supabase/avatars.ts
@@ -1,0 +1,20 @@
+import { supabase } from './client'
+
+const AVATAR_BUCKET = 'avatars'
+
+/**
+ * Résout une valeur `avatar_url` stockée en DB vers une URL publique utilisable côté client.
+ *
+ * Depuis la migration 053, la colonne `profiles.avatar_url` stocke un **path Storage**
+ * (ex: `<profileId>/<timestamp>.jpg`), plus une URL complète. Cette fonction génère
+ * l'URL publique à la volée via `getPublicUrl()`.
+ *
+ * Rétrocompat : si la valeur commence par `http`, elle est renvoyée telle quelle (sécurité
+ * face à d'éventuelles lignes qui auraient échappé à la migration).
+ */
+export function resolveAvatarUrl(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  if (value.startsWith('http')) return value
+  const { data } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(value)
+  return data.publicUrl || undefined
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -28,7 +28,7 @@ import {
 } from '@chakra-ui/react'
 import { DashboardLayout } from '@/components/dashboard'
 import { useAuth } from '@/hooks/useAuth'
-import { useAccessibilityStore } from '@/stores/authStore'
+import { useAccessibilityStore, useAuthStore } from '@/stores/authStore'
 import { updateProfile, uploadAvatar, deleteAvatar, validateAvatarFile, getEmployer, upsertEmployer, getEmployee, upsertEmployee } from '@/services/profileService'
 import type { Address, UserRole } from '@/types'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
@@ -390,6 +390,7 @@ function ProfilPanel({ profile, userRole }: { profile: { id: string; firstName: 
   const [saving, setSaving] = useState(false)
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; msg: string } | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const setStoreProfile = useAuthStore((s) => s.setProfile)
 
   // Charger l'adresse depuis la table du rôle
   useEffect(() => {
@@ -453,6 +454,11 @@ function ProfilPanel({ profile, userRole }: { profile: { id: string; firstName: 
     try {
       const result = await uploadAvatar(profile.id, file)
       setAvatarUrl(result.url)
+      // Propage au store pour que la navbar/sidebar se re-render
+      const current = useAuthStore.getState().profile
+      if (current) {
+        setStoreProfile({ ...current, avatarUrl: result.url, updatedAt: new Date() })
+      }
       setFeedback({ type: 'success', msg: 'Photo mise à jour.' })
     } catch (err) {
       setFeedback({ type: 'error', msg: err instanceof Error ? err.message : 'Erreur upload.' })
@@ -467,6 +473,10 @@ function ProfilPanel({ profile, userRole }: { profile: { id: string; firstName: 
     try {
       await deleteAvatar(profile.id)
       setAvatarUrl('')
+      const current = useAuthStore.getState().profile
+      if (current) {
+        setStoreProfile({ ...current, avatarUrl: undefined, updatedAt: new Date() })
+      }
       setFeedback({ type: 'success', msg: 'Photo supprimée.' })
     } catch (err) {
       setFeedback({ type: 'error', msg: err instanceof Error ? err.message : 'Erreur suppression.' })

--- a/src/services/auxiliaryService.ts
+++ b/src/services/auxiliaryService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import type { Contract, Employee, Profile } from '@/types'
 import type {
@@ -214,7 +215,7 @@ function mapAuxiliaryFromDb(data: ContractWithEmployeeDbRow): AuxiliarySummary {
     lastName: profile?.last_name || '',
     email: profile?.email || undefined,
     phone: profile?.phone || undefined,
-    avatarUrl: profile?.avatar_url || undefined,
+    avatarUrl: resolveAvatarUrl(profile?.avatar_url),
     qualifications: data.employee_profile?.qualifications || [],
     contractType: data.contract_type,
     contractStatus: data.status,
@@ -271,7 +272,7 @@ function mapProfileFromDb(data: ProfileDbRow | undefined): Profile {
     lastName: data.last_name,
     email: data.email || '',
     phone: data.phone || undefined,
-    avatarUrl: data.avatar_url || undefined,
+    avatarUrl: resolveAvatarUrl(data.avatar_url),
     accessibilitySettings: data.accessibility_settings || {
       highContrast: false,
       largeText: false,

--- a/src/services/caregiverTeamService.ts
+++ b/src/services/caregiverTeamService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import type {
   CaregiverPermissions,
@@ -307,7 +308,7 @@ function mapCaregiverWithProfileFromDb(data: CaregiverDbRow): CaregiverWithProfi
       lastName: data.profile?.last_name || '',
       email: data.profile?.email || '',
       phone: data.profile?.phone || undefined,
-      avatarUrl: data.profile?.avatar_url || undefined,
+      avatarUrl: resolveAvatarUrl(data.profile?.avatar_url),
     },
   }
 }

--- a/src/services/complianceService.ts
+++ b/src/services/complianceService.ts
@@ -3,6 +3,7 @@
  */
 
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import type { ShiftForValidation } from '@/lib/compliance/types'
 import {
@@ -153,7 +154,7 @@ async function getActiveEmployees(employerId: string): Promise<
   return (data as ContractRow[] || []).map((c) => ({
     employeeId: c.employee_id,
     employeeName: `${c.employee_profile?.profile?.first_name || ''} ${c.employee_profile?.profile?.last_name || ''}`.trim(),
-    avatarUrl: c.employee_profile?.profile?.avatar_url ?? undefined,
+    avatarUrl: resolveAvatarUrl(c.employee_profile?.profile?.avatar_url),
     contractId: c.id,
     weeklyHours: c.weekly_hours,
   }))

--- a/src/services/liaisonService.ts
+++ b/src/services/liaisonService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import { sanitizeText } from '@/lib/sanitize'
 import type { Attachment, Conversation, LiaisonMessage, LiaisonMessageWithSender, UserRole } from '@/types'
@@ -66,7 +67,7 @@ export async function getConversations(
             id: profile.id,
             firstName: profile.first_name,
             lastName: profile.last_name,
-            avatarUrl: profile.avatar_url || undefined,
+            avatarUrl: resolveAvatarUrl(profile.avatar_url),
           }
         }
       }
@@ -137,7 +138,7 @@ export async function getOrCreatePrivateConversation(
             id: profile.id,
             firstName: profile.first_name,
             lastName: profile.last_name,
-            avatarUrl: profile.avatar_url || undefined,
+            avatarUrl: resolveAvatarUrl(profile.avatar_url),
           }
         : undefined,
       unreadCount: 0,
@@ -172,7 +173,7 @@ export async function getOrCreatePrivateConversation(
           id: profile.id,
           firstName: profile.first_name,
           lastName: profile.last_name,
-          avatarUrl: profile.avatar_url || undefined,
+          avatarUrl: resolveAvatarUrl(profile.avatar_url),
         }
       : undefined,
     unreadCount: 0,
@@ -727,7 +728,7 @@ function mapMessageFromDb(data: LiaisonMessageDbRow | Record<string, unknown>): 
       ? {
           firstName: row.sender.first_name,
           lastName: row.sender.last_name,
-          avatarUrl: row.sender.avatar_url || undefined,
+          avatarUrl: resolveAvatarUrl(row.sender.avatar_url),
         }
       : undefined,
   }

--- a/src/services/profileService.test.ts
+++ b/src/services/profileService.test.ts
@@ -59,6 +59,14 @@ vi.mock('@/lib/mappers', () => ({
   createDefaultProfile: vi.fn(),
 }))
 
+vi.mock('@/lib/supabase/avatars', () => ({
+  resolveAvatarUrl: vi.fn((value: string | null | undefined) => {
+    if (!value) return undefined
+    if (value.startsWith('http')) return value
+    return `https://api.unilien.app/storage/v1/object/public/avatars/${value}`
+  }),
+}))
+
 describe('profileService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -193,21 +201,27 @@ describe('profileService', () => {
   })
 
   describe('uploadAvatar', () => {
-    it('devrait uploader un avatar avec succès', async () => {
+    it('stocke le path (pas l\'URL) en DB et retourne une URL résolue', async () => {
       const file = new File(['content'], 'avatar.jpg', { type: 'image/jpeg' })
       Object.defineProperty(file, 'size', { value: 500 * 1024 })
 
       mockList.mockResolvedValue({ data: [], error: null })
       mockUpload.mockResolvedValue({ error: null })
-      mockGetPublicUrl.mockReturnValue({
-        data: { publicUrl: 'https://storage.example.com/avatars/profile-123/123.jpg' },
-      })
       mockEq.mockResolvedValue({ error: null })
 
       const result = await uploadAvatar('profile-123', file)
 
-      expect(result.url).toContain('avatars')
+      // Le payload envoyé à .update() doit contenir un PATH, pas une URL complète
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          avatar_url: expect.stringMatching(/^profile-123\/\d+\.jpg$/),
+        })
+      )
+      // L'URL retournée au caller est résolue (préfixe self-host)
+      expect(result.url).toMatch(/^https:\/\/api\.unilien\.app\/.+profile-123\/\d+\.jpg$/)
       expect(mockUpload).toHaveBeenCalled()
+      // getPublicUrl n'est plus appelé dans uploadAvatar (on passe par le helper)
+      expect(mockGetPublicUrl).not.toHaveBeenCalled()
     })
 
     it('devrait lancer une erreur pour un fichier invalide', async () => {
@@ -230,9 +244,6 @@ describe('profileService', () => {
       })
       mockRemove.mockResolvedValue({ error: null })
       mockUpload.mockResolvedValue({ error: null })
-      mockGetPublicUrl.mockReturnValue({
-        data: { publicUrl: 'https://storage.example.com/new.jpg' },
-      })
       mockEq.mockResolvedValue({ error: null })
 
       await uploadAvatar('profile-123', file)

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import { sanitizeText, sanitizeFileExtension } from '@/lib/sanitize'
 import { logAudit } from '@/services/auditService'
@@ -175,18 +176,11 @@ export async function uploadAvatar(
     throw new Error('Erreur lors de l\'upload de l\'image.')
   }
 
-  // Obtenir l'URL publique
-  const { data: urlData } = supabase.storage
-    .from(AVATAR_BUCKET)
-    .getPublicUrl(fileName)
-
-  const avatarUrl = urlData.publicUrl
-
-  // Mettre à jour le profil avec la nouvelle URL
+  // Stocker le path dans la DB (pas l'URL publique — immuable face aux migrations)
   const { error: updateError } = await supabase
     .from('profiles')
     .update({
-      avatar_url: avatarUrl,
+      avatar_url: fileName,
       updated_at: new Date().toISOString(),
     })
     .eq('id', profileId)
@@ -196,7 +190,11 @@ export async function uploadAvatar(
     throw new Error('Erreur lors de la mise à jour du profil.')
   }
 
-  return { url: avatarUrl }
+  const resolved = resolveAvatarUrl(fileName)
+  if (!resolved) {
+    throw new Error('Impossible de résoudre l\'URL de l\'avatar uploadé.')
+  }
+  return { url: resolved }
 }
 
 /**

--- a/src/services/shiftService.ts
+++ b/src/services/shiftService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase/client'
+import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import { sanitizeText } from '@/lib/sanitize'
 import type { Shift, ShiftType, GuardSegment, UserRole } from '@/types'
@@ -102,7 +103,7 @@ export async function getShifts(
     if (contractJoin?.employee?.profile) {
       const p = contractJoin.employee.profile
       shift.employeeName = `${p.first_name || ''} ${p.last_name || ''}`.trim() || undefined
-      shift.employeeAvatarUrl = p.avatar_url || undefined
+      shift.employeeAvatarUrl = resolveAvatarUrl(p.avatar_url)
     }
     // Pour les contrats aidants PCH, récupérer le nom depuis caregiver_profile
     if (contractJoin?.caregiver_id && contractJoin?.caregiver_profile) {
@@ -110,7 +111,7 @@ export async function getShifts(
       if (!shift.employeeId) shift.employeeId = contractJoin.caregiver_id
       if (!shift.employeeName) {
         shift.employeeName = `${p.first_name || ''} ${p.last_name || ''}`.trim() || undefined
-        shift.employeeAvatarUrl = p.avatar_url || undefined
+        shift.employeeAvatarUrl = resolveAvatarUrl(p.avatar_url)
       }
     }
     return shift

--- a/supabase/migrations/053_avatar_url_to_path.sql
+++ b/supabase/migrations/053_avatar_url_to_path.sql
@@ -1,0 +1,42 @@
+-- ============================================
+-- Migration 053 : profiles.avatar_url passe de URL complète à Storage path
+-- ============================================
+--
+-- Contexte
+-- --------
+-- Avant cette migration, `uploadAvatar()` stockait en DB l'URL publique complète
+-- générée via `getPublicUrl()`, ex :
+--   https://lczfygydhnyygguvponw.supabase.co/storage/v1/object/public/avatars/<profileId>/<ts>.jpg
+--
+-- Conséquences post-migration self-host (21/04/2026) :
+--   1. Les URLs pointent vers l'ancien projet Cloud → avatars cassés
+--   2. Le bucket self-host `avatars` est vide (fichiers non migrés)
+--   3. Le CSP a dû être élargi à `https://*.supabase.co` pour éviter un
+--      blocage `img-src` sur ces URLs legacy (voir PR #288)
+--
+-- Nouvelle sémantique
+-- -------------------
+-- `avatar_url` stocke désormais un **path Storage** relatif au bucket `avatars`,
+-- au format `<profile_id>/<timestamp>.<ext>`. L'URL publique est générée côté
+-- client via `resolveAvatarUrl()` (`src/lib/supabase/avatars.ts`).
+--
+-- Avantage : immuable face aux migrations de projet/infra.
+--
+-- Effet de cette migration
+-- ------------------------
+-- Tous les `avatar_url` existants sont mis à NULL car les fichiers d'origine
+-- n'existent plus dans le bucket self-host. Les utilisateurs devront
+-- ré-uploader leur avatar via Paramètres > Profil.
+-- ============================================
+
+-- 1. Nettoyer les URLs legacy
+UPDATE profiles
+SET avatar_url = NULL,
+    updated_at = NOW()
+WHERE avatar_url IS NOT NULL;
+
+-- 2. Documenter le nouveau contrat de la colonne
+COMMENT ON COLUMN profiles.avatar_url IS
+  'Storage path dans le bucket "avatars" (ex: <profile_id>/<timestamp>.jpg). '
+  'URL publique générée côté client via resolveAvatarUrl (src/lib/supabase/avatars.ts). '
+  'Historique : contenait l''URL publique complète avant migration 053 (2026-04-24).';


### PR DESCRIPTION
## Summary

Refactor du stockage des avatars : la colonne `profiles.avatar_url` stocke désormais un **path Storage** (`<uid>/<ts>.ext`), plus l'URL publique complète. L'URL est générée à la volée côté client via un helper `resolveAvatarUrl()`. Fin de la dette technique post-migration self-host : les URLs ne sont plus liées à un projet Supabase particulier, et le CSP peut être resserré.

Fixe aussi un bug UX connexe : après changement d'avatar depuis Paramètres, la navbar et la sidebar ne se mettaient à jour qu'après rechargement de la page.

### Changements

- **Nouveau helper** `src/lib/supabase/avatars.ts` — `resolveAvatarUrl(value)` : `null`/vide → `undefined`, valeur commençant par `http` → retournée telle quelle (rétrocompat), sinon → `getPublicUrl(path)`
- **`profileService.uploadAvatar`** persiste le path au lieu de l'URL publique, retourne l'URL résolue au caller (backward compat)
- **Migration 053** : `UPDATE profiles SET avatar_url = NULL` (les fichiers legacy n'ayant pas été migrés vers le bucket self-host, les URLs pointent vers du vide — les utilisateurs devront ré-uploader). Commentaire SQL sur la colonne documente la nouvelle sémantique
- **7 services** qui lisent `avatar_url` passent par le helper : `profile`, `auxiliary`, `caregiverTeam`, `compliance`, `liaison`, `shift`, `mappers` + le composant `TodayPlanningWidget`
- **Caddyfile** : retrait de `https://*.supabase.co` de `img-src` (plus aucune URL legacy après migration)
- **Fix re-render** : `SettingsPage.ProfilPanel` propage désormais les changements d'avatar à `useAuthStore` pour que `useAuth()` dans `DashboardLayout` reçoive la nouvelle valeur → navbar + sidebar se mettent à jour sans reload
- **Défensif** : `key={avatarUrl}` sur `<Avatar.Image>` force un remount du `<img>` sous-jacent si la src change

### Tests

- **Nouveau** `src/lib/supabase/avatars.test.ts` — 3 cas (null / legacy URL / path)
- **Adapté** `src/services/profileService.test.ts` — asserte que la DB reçoit un path (regex `profile-123/\d+\.jpg`), pas une URL, et que la valeur retournée au caller est l'URL résolue

## Déploiement (ordre)

1. Merge cette PR
2. Appliquer la migration 053 en prod Supabase self-host
3. Déployer le Caddyfile manuellement sur le VPS (workflow habituel : `scp` → `caddy validate` → `systemctl reload`)
4. Informer les utilisateurs qu'ils devront ré-uploader leur avatar via Paramètres > Profil

## Test plan

- [x] `npm run lint` — 0 erreur
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 2269/2269
- [x] Test manuel : upload avatar depuis Paramètres → navbar + sidebar mises à jour sans reload
- [x] Migration 053 appliquée en prod
- [x] Caddyfile déployé et rechargé
- [x] Vérifier qu'un upload stocke bien un path en DB (pas une URL)
- [x] Vérifier que la suppression d'avatar remet à `NULL` en DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)