### PR TITLE
chore(clockin): hide clock-in feature behind feature flag for v1

### DIFF
--- a/docs/CLOCK_IN_DISABLED_V1.md
+++ b/docs/CLOCK_IN_DISABLED_V1.md
@@ -1,0 +1,104 @@
+# Pointage désactivé en v1 — note de décision
+
+> Statut : **Actif**
+> Date : 27/04/2026
+> Référence PR : #312
+> Spec de remplacement : [`QR_CLOCKIN_IMPLEMENTATION.md`](./QR_CLOCKIN_IMPLEMENTATION.md) (PR #311)
+
+---
+
+## Contexte
+
+Lors de la réunion du 16/04/2026, Marie a remonté que le pointage actuel n'est **pas fiable** : un auxi peut valider "j'ai commencé à 13h00" alors qu'elle n'est pas encore physiquement chez le bénéficiaire. Aucune vérification de présence.
+
+L'équipe a décidé de **retirer le pointage de la v1** plutôt que de livrer une fonctionnalité que les utilisateurs ne pourront pas utiliser sereinement (paie injuste, pas de preuve en cas de litige, perte de confiance employeur).
+
+Le pointage **réapparaîtra** quand le système de pointage par QR code (cf. `QR_CLOCKIN_IMPLEMENTATION.md`) sera livré.
+
+---
+
+## Ce qui est désactivé
+
+L'UI uniquement, via le feature flag `FEATURES.clockIn` dans `src/lib/featureFlags.ts`.
+
+8 points d'entrée :
+
+| Surface | Fichier | Comportement quand `clockIn = false` |
+|---------|---------|--------------------------------------|
+| Route `/suivi-des-heures` | `src/App.tsx` | N'est plus déclarée (URL directe → 404 / fallback) |
+| Item nav "Suivi des heures" / "Mes heures" | `src/components/dashboard/DashboardLayout.tsx` | Retiré du menu Gestion |
+| `ClockInWidget` dashboard auxi | `src/components/dashboard/EmployeeDashboard.tsx` | Cellule de grille supprimée, Messages + Documents remontent d'une row pour combler le trou |
+| `ClockInWidget` dashboard aidant | `src/components/dashboard/CaregiverDashboard.tsx` | Retiré (desktop + mobile) |
+| Quick action "Pointer" | `src/components/dashboard/widgets/QuickActionsWidget.tsx` | Filtré du tableau d'actions employee (3 actions au lieu de 4) |
+| CTA WelcomeCard | `src/components/dashboard/widgets/WelcomeCard.tsx` | Pointe systématiquement vers `/planning` au lieu de `/suivi-des-heures` |
+| Bouton "Pointer" modal planning | `src/components/planning/ShiftDetailModal.tsx` | Caché sur les interventions `planned` du rôle employee |
+| Section FAQ "Enregistrement des heures" | `src/pages/HelpPage.tsx` | Retirée du sommaire et du contenu |
+| Entrée recherche globale | `src/services/searchService.ts` | Retirée de `NAV_PAGES` |
+
+---
+
+## Ce qui n'est PAS supprimé
+
+Aucun composant, service, hook, type, table DB ou test n'a été supprimé. La réactivation est triviale et ne nécessite aucune migration.
+
+- `src/components/clock-in/` → intact (`ClockInPage`, `EmployeeClockWidget`, `ClockInTodaySection`, `ManualEntryForm`, `MonthSummary`, `DateNavigator`, `RetroactiveEntryForm`, etc.)
+- `src/components/dashboard/widgets/ClockInWidget.tsx` → intact, juste plus rendu
+- `src/services/clockInService.ts` → intact
+- Table `clock_in_entries` Supabase → **inchangée**, données utilisateur préservées
+- Tests `src/components/clock-in/*.test.*` → **continuent de tourner en CI** (couvrent toujours les composants désactivés)
+
+Les seuls tests qui ont été touchés sont ceux qui assertent la **présence** du pointage dans des composants partagés (dashboards, quick actions, route principale). Ils sont en `it.skip` avec un commentaire pointant vers le flag.
+
+---
+
+## Comment réactiver
+
+### Étape 1 — Flip le flag
+
+```ts
+// src/lib/featureFlags.ts
+export const FEATURES = {
+- clockIn: false,
++ clockIn: true,
+} as const
+```
+
+C'est suffisant pour rebrancher toutes les surfaces UI.
+
+### Étape 2 — Réactiver les tests
+
+Retirer les `it.skip` (4 specs) et restaurer les assertions :
+
+| Fichier | Test |
+|---------|------|
+| `src/App.test.tsx` | `affiche /suivi-des-heures pour un employé` |
+| `src/components/dashboard/EmployeeDashboard.test.tsx` | `affiche le ClockInWidget` |
+| `src/components/dashboard/CaregiverDashboard.test.tsx` | `affiche le ClockInWidget avec variant warm` |
+| `src/components/dashboard/widgets/QuickActionsWidget.test.tsx` | `le lien 'Pointer' pointe vers /suivi-des-heures` |
+
+Le test `affiche les actions employee (sans Pointer tant que FEATURES.clockIn = false)` doit également être réécrit pour ré-asserter la présence de "Pointer" et le compteur de 4 actions.
+
+### Étape 3 — Vérifier la grille employee dashboard
+
+Le fix ad hoc dans `EmployeeDashboard.tsx` (lignes `gridRow={{ lg: FEATURES.clockIn ? '5' : '4' }}` etc.) **continue de marcher** dès que le flag passe à `true` — les rows aside reprennent leurs valeurs d'origine. Aucune modification supplémentaire nécessaire à ce niveau.
+
+Si on souhaite simplifier à terme : retirer les conditions ternaires dans les `gridRow` aside et revenir aux valeurs littérales `'5'` et `'6'`.
+
+---
+
+## Si la réactivation est définitive
+
+Une fois le QR code livré et le flag passé à `true` durablement :
+
+1. Supprimer entièrement `src/lib/featureFlags.ts` (ou y ajouter d'autres flags, mais `clockIn` peut disparaître)
+2. Retirer les imports `FEATURES` et les conditions de tous les fichiers listés ci-dessus
+3. Restaurer les `gridRow` littérales dans `EmployeeDashboard.tsx`
+4. Supprimer ce fichier de doc (`CLOCK_IN_DISABLED_V1.md`) — il n'a plus d'utilité
+
+---
+
+## Ne pas se planter
+
+- **Ne jamais supprimer la table `clock_in_entries` côté DB** tant que le flag est en transition. Si des utilisateurs ont déjà pointé avant la désactivation, leurs données doivent être préservées.
+- **Ne pas merger ce flag avec d'autres feature flags futurs sans review** — c'est volontairement minimaliste, ajouter de la logique (env vars, config dynamique) demande un cadrage produit.
+- **Ne pas réactiver partiellement** (par ex. juste le menu sans la route) — soit tout, soit rien, sinon on crée des liens cassés.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -155,7 +155,9 @@ describe('App', () => {
       })
     })
 
-    it('affiche /suivi-des-heures pour un employé', async () => {
+    // Désactivé tant que FEATURES.clockIn = false (v1).
+    // Réactiver quand le flag passe à true (cf. docs/QR_CLOCKIN_IMPLEMENTATION.md).
+    it.skip('affiche /suivi-des-heures pour un employé', async () => {
       mockUseAuth.mockReturnValue({
         isAuthenticated: true,
         isLoading: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { RouteAnnouncer } from '@/components/accessibility/RouteAnnouncer'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccessibilityStore } from '@/stores/authStore'
 import { supabase } from '@/lib/supabase/client'
+import { FEATURES } from '@/lib/featureFlags'
 import type { UserRole } from '@/types'
 
 // Pages chargées dynamiquement (code splitting)
@@ -185,7 +186,9 @@ function App() {
           <Route path="/messagerie" element={<ProtectedRoute><ErrorBoundary><LiaisonPage /></ErrorBoundary></ProtectedRoute>} />
 
           {/* Routes protégées avec restriction de rôle */}
-          <Route path="/suivi-des-heures" element={<ProtectedRoute allowedRoles={['employer', 'employee', 'caregiver']}><ErrorBoundary><ClockInPage /></ErrorBoundary></ProtectedRoute>} />
+          {FEATURES.clockIn && (
+            <Route path="/suivi-des-heures" element={<ProtectedRoute allowedRoles={['employer', 'employee', 'caregiver']}><ErrorBoundary><ClockInPage /></ErrorBoundary></ProtectedRoute>} />
+          )}
           <Route path="/equipe" element={<ProtectedRoute allowedRoles={['employer', 'caregiver']}><ErrorBoundary><TeamPage /></ErrorBoundary></ProtectedRoute>} />
           <Route path="/conformite" element={<ProtectedRoute allowedRoles={['employer', 'caregiver']}><ErrorBoundary><CompliancePage /></ErrorBoundary></ProtectedRoute>} />
           <Route path="/documents" element={<ProtectedRoute allowedRoles={['employer', 'employee', 'caregiver']}><ErrorBoundary><DocumentsPage /></ErrorBoundary></ProtectedRoute>} />

--- a/src/components/dashboard/CaregiverDashboard.test.tsx
+++ b/src/components/dashboard/CaregiverDashboard.test.tsx
@@ -199,7 +199,8 @@ describe('CaregiverDashboard', () => {
       })
     })
 
-    it('affiche le ClockInWidget avec variant warm', async () => {
+    // Désactivé tant que FEATURES.clockIn = false (v1).
+    it.skip('affiche le ClockInWidget avec variant warm', async () => {
       renderWithProviders(<CaregiverDashboard profile={profile} />)
       await waitFor(() => {
         const widgets = screen.getAllByTestId('clockin-widget')

--- a/src/components/dashboard/CaregiverDashboard.tsx
+++ b/src/components/dashboard/CaregiverDashboard.tsx
@@ -28,6 +28,7 @@ import {
   getCaregiver,
   getUpcomingShiftsForCaregiver,
 } from '@/services/caregiverService'
+import { FEATURES } from '@/lib/featureFlags'
 import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 
@@ -165,7 +166,7 @@ export function CaregiverDashboard({ profile }: CaregiverDashboardProps) {
             </GridItem>
             <GridItem minW={0}>
               <Stack gap={6}>
-                <ClockInWidget variant="warm" />
+                {FEATURES.clockIn && <ClockInWidget variant="warm" />}
                 <PchMiniWidget employerId={caregiver.employerId} />
                 <RecentMessagesWidget userId={profile.id} />
                 <QuickActionsWidget userRole="caregiver" permissions={caregiver.permissions} />
@@ -180,7 +181,7 @@ export function CaregiverDashboard({ profile }: CaregiverDashboardProps) {
         {caregiver.permissions.canViewPlanning && (
           <CaregiverShiftTimeline profileId={profile.id} employerName={employerName} />
         )}
-        <ClockInWidget variant="warm" />
+        {FEATURES.clockIn && <ClockInWidget variant="warm" />}
         <RecentMessagesWidget userId={profile.id} />
         <PchEnvelopeWidget employerId={caregiver.employerId} />
         <QuickActionsWidget userRole="caregiver" permissions={caregiver.permissions} />

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -18,6 +18,7 @@ import { SpotlightSearch } from '@/components/dashboard/SpotlightSearch'
 import { useSpotlightSearch } from '@/hooks/useSpotlightSearch'
 import { getCaregiver } from '@/services/caregiverService'
 import { logger } from '@/lib/logger'
+import { FEATURES } from '@/lib/featureFlags'
 
 import type { UserRole, CaregiverPermissions } from '@/types'
 
@@ -54,7 +55,9 @@ const NAV_SECTIONS: NavSection[] = [
     items: [
       { label: 'Conformité', href: '/conformite', icon: 'shield', ariaLabel: 'Voir la conformité', roles: ['employer'] },
       { label: 'Documents', href: '/documents', icon: 'file', ariaLabel: 'Gérer les documents', roles: ['employer', 'employee'] },
-      { label: 'Suivi des heures', href: '/suivi-des-heures', icon: 'clock', ariaLabel: 'Accéder au suivi des heures' },
+      ...(FEATURES.clockIn
+        ? [{ label: 'Suivi des heures', href: '/suivi-des-heures', icon: 'clock', ariaLabel: 'Accéder au suivi des heures' } as NavItem]
+        : []),
       { label: 'Analytique', href: '/analytique', icon: 'barchart', ariaLabel: 'Voir les statistiques détaillées' },
     ],
   },

--- a/src/components/dashboard/EmployeeDashboard.test.tsx
+++ b/src/components/dashboard/EmployeeDashboard.test.tsx
@@ -112,7 +112,8 @@ describe('EmployeeDashboard', () => {
       })
     })
 
-    it('affiche le ClockInWidget', async () => {
+    // Désactivé tant que FEATURES.clockIn = false (v1).
+    it.skip('affiche le ClockInWidget', async () => {
       renderWithProviders(<EmployeeDashboard profile={profile} />)
       await waitFor(() => {
         expect(screen.getByTestId('clock-in-widget')).toBeInTheDocument()

--- a/src/components/dashboard/EmployeeDashboard.tsx
+++ b/src/components/dashboard/EmployeeDashboard.tsx
@@ -118,8 +118,8 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
         <EmployeeHoursProgress employeeId={profile.id} />
       </GridItem>
 
-      {/* 5. Messages — aside col */}
-      <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '5' }}>
+      {/* 5. Messages — aside col (remonte d'une row si clock-in désactivé) */}
+      <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: FEATURES.clockIn ? '5' : '4' }}>
         <RecentMessagesWidget userId={profile.id} />
       </GridItem>
 
@@ -128,8 +128,8 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
         <EmployeeLeaveWidget employeeId={profile.id} />
       </GridItem>
 
-      {/* 6. Mes documents — aside col */}
-      <GridItem order={{ base: 7, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '6' }}>
+      {/* 6. Mes documents — aside col (remonte d'une row si clock-in désactivé) */}
+      <GridItem order={{ base: 7, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: FEATURES.clockIn ? '6' : '5' }}>
         <EmployeeDocumentsWidget employeeId={profile.id} />
       </GridItem>
     </Grid>

--- a/src/components/dashboard/EmployeeDashboard.tsx
+++ b/src/components/dashboard/EmployeeDashboard.tsx
@@ -14,6 +14,7 @@ import {
 } from './widgets'
 import { getShifts } from '@/services/shiftService'
 import { logger } from '@/lib/logger'
+import { FEATURES } from '@/lib/featureFlags'
 
 interface EmployeeDashboardProps {
   profile: Profile
@@ -103,12 +104,14 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
       </GridItem>
 
       {/* 4. Clock-in — aside col */}
-      <GridItem order={{ base: 4, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '4' }}>
-        <ClockInWidget
-          hasActiveShift={!!activeShift}
-          activeShiftLabel={activeShift ? `Intervention ${activeShift.startTime.slice(0, 5)} – ${activeShift.endTime.slice(0, 5)}` : undefined}
-        />
-      </GridItem>
+      {FEATURES.clockIn && (
+        <GridItem order={{ base: 4, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '4' }}>
+          <ClockInWidget
+            hasActiveShift={!!activeShift}
+            activeShiftLabel={activeShift ? `Intervention ${activeShift.startTime.slice(0, 5)} – ${activeShift.endTime.slice(0, 5)}` : undefined}
+          />
+        </GridItem>
+      )}
 
       {/* 5. Heures du mois — main col */}
       <GridItem order={{ base: 5, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '5' }}>

--- a/src/components/dashboard/widgets/QuickActionsWidget.test.tsx
+++ b/src/components/dashboard/widgets/QuickActionsWidget.test.tsx
@@ -52,15 +52,16 @@ describe('QuickActionsWidget', () => {
   })
 
   describe('Rôle employee', () => {
-    it('affiche les 4 actions employee', () => {
+    it('affiche les actions employee (sans Pointer tant que FEATURES.clockIn = false)', () => {
       renderWithProviders(<QuickActionsWidget userRole="employee" />)
-      expect(screen.getByText('Pointer')).toBeInTheDocument()
+      expect(screen.queryByText('Pointer')).not.toBeInTheDocument()
       expect(screen.getByText('Planning')).toBeInTheDocument()
       expect(screen.getByText('Cahier')).toBeInTheDocument()
       expect(screen.getByText('Absence')).toBeInTheDocument()
     })
 
-    it("le lien 'Pointer' pointe vers /suivi-des-heures", () => {
+    // Désactivé tant que FEATURES.clockIn = false (v1).
+    it.skip("le lien 'Pointer' pointe vers /suivi-des-heures", () => {
       renderWithProviders(<QuickActionsWidget userRole="employee" />)
       const links = screen.getAllByRole('link')
       const hrefs = links.map((l) => l.getAttribute('href'))

--- a/src/components/dashboard/widgets/QuickActionsWidget.tsx
+++ b/src/components/dashboard/widgets/QuickActionsWidget.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Box, SimpleGrid, Text, Flex } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
 import { NavIcon } from '@/components/ui'
+import { FEATURES } from '@/lib/featureFlags'
 import type { UserRole, CaregiverPermissions } from '@/types'
 
 interface QuickAction {
@@ -40,7 +41,11 @@ interface QuickActionsWidgetProps {
 export function QuickActionsWidget({ userRole, permissions }: QuickActionsWidgetProps) {
   // Filtrer les actions selon les permissions pour les aidants
   const actions = useMemo(() => {
-    const roleActions = actionsByRole[userRole]
+    let roleActions = actionsByRole[userRole]
+
+    if (!FEATURES.clockIn) {
+      roleActions = roleActions.filter((a) => a.href !== '/suivi-des-heures')
+    }
 
     if (userRole !== 'caregiver' || !permissions) {
       return roleActions

--- a/src/components/dashboard/widgets/WelcomeCard.tsx
+++ b/src/components/dashboard/widgets/WelcomeCard.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Text, Skeleton } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
+import { FEATURES } from '@/lib/featureFlags'
 import type { Profile, Shift } from '@/types'
 
 interface WelcomeCardProps {
@@ -184,8 +185,8 @@ export function WelcomeCard({
       <Box flexShrink={0}>
         <Box
           as={RouterLink}
-          to={profile.role === 'employee'
-            ? (todayShiftCount ? '/suivi-des-heures' : '/planning')
+          to={profile.role === 'employee' && FEATURES.clockIn && todayShiftCount
+            ? '/suivi-des-heures'
             : '/planning'}
           display="inline-flex"
           alignItems="center"

--- a/src/components/planning/ShiftDetailModal.tsx
+++ b/src/components/planning/ShiftDetailModal.tsx
@@ -20,6 +20,7 @@ import { PlanningModal } from './PlanningModal'
 import { updateShift, deleteShift, validateShift } from '@/services/shiftService'
 import { toaster } from '@/lib/toaster'
 import { logger } from '@/lib/logger'
+import { FEATURES } from '@/lib/featureFlags'
 import type { Shift, UserRole } from '@/types'
 import { SHIFT_STATUS_VARIANTS as statusVariants, SHIFT_STATUS_LABELS as statusLabels } from '@/lib/constants/statusMaps'
 import { useShiftDetailData } from '@/hooks/useShiftDetailData'
@@ -449,7 +450,7 @@ export function ShiftDetailModal({
         {canValidate && hasValidated && (
           <Text fontSize="sm" color="green.600" alignSelf="center">Vous avez validé cette intervention</Text>
         )}
-        {userRole === 'employee' && shift && shift.status === 'planned' && (
+        {FEATURES.clockIn && userRole === 'employee' && shift && shift.status === 'planned' && (
           <PrimaryButton onClick={() => navigate('/suivi-des-heures')} accessibleLabel="Aller au pointage pour cette intervention">
             Pointer
           </PrimaryButton>

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,16 @@
+/**
+ * Feature flags applicatifs.
+ *
+ * Permet d'activer/désactiver des fonctionnalités sans supprimer le code.
+ * À utiliser uniquement pour des décisions produit binaires (ON/OFF).
+ * Pour de la config runtime, passer par les paramètres utilisateur ou les env vars.
+ */
+export const FEATURES = {
+  /**
+   * Pointage / Suivi des heures.
+   * Désactivé pour la v1 le temps de livrer le pointage par QR code
+   * (cf. docs/QR_CLOCKIN_IMPLEMENTATION.md). Le code, les services et
+   * la table DB `clock_in_entries` restent intacts pour réactivation rapide.
+   */
+  clockIn: false,
+} as const

--- a/src/pages/HelpPage.tsx
+++ b/src/pages/HelpPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { Box, Container, Flex, Stack, Text, Link, Collapsible } from '@chakra-ui/react'
 import { DashboardLayout } from '@/components/dashboard/DashboardLayout'
+import { FEATURES } from '@/lib/featureFlags'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -439,6 +440,7 @@ function AccordionItem({ question, answer, isOpen, onToggle }: {
 
 export default function HelpPage() {
   const [openItems, setOpenItems] = useState<Set<string>>(new Set())
+  const sections = FEATURES.clockIn ? GUIDE_SECTIONS : GUIDE_SECTIONS.filter(s => s.id !== 'hours')
 
   const toggleItem = (id: string) => {
     setOpenItems(prev => {
@@ -476,7 +478,7 @@ export default function HelpPage() {
             Sommaire
           </Text>
           <Flex gap={2} flexWrap="wrap">
-            {GUIDE_SECTIONS.map((section) => (
+            {sections.map((section) => (
               <Link
                 key={section.id}
                 href={`#${section.id}`}
@@ -498,7 +500,7 @@ export default function HelpPage() {
 
         {/* Sections */}
         <Stack gap={8}>
-          {GUIDE_SECTIONS.map((section) => (
+          {sections.map((section) => (
             <Box
               key={section.id}
               id={section.id}

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -7,6 +7,7 @@ import type { Shift, Conversation, UserRole, CaregiverPermissions } from '@/type
 import type { AuxiliarySummary } from '@/services/auxiliaryService'
 import type { LogEntryWithAuthor } from '@/services/logbookService'
 import type { DocumentWithEmployee } from '@/services/documentService'
+import { FEATURES } from '@/lib/featureFlags'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -73,7 +74,9 @@ const NAV_PAGES: NavPage[] = [
   { label: 'Cahier de liaison', href: '/cahier-de-liaison', icon: 'book' },
   { label: 'Conformité', href: '/conformite', icon: 'shield', roles: ['employer'] },
   { label: 'Documents', href: '/documents', icon: 'file', roles: ['employer', 'employee'] },
-  { label: 'Suivi des heures', href: '/suivi-des-heures', icon: 'clock' },
+  ...(FEATURES.clockIn
+    ? [{ label: 'Suivi des heures', href: '/suivi-des-heures', icon: 'clock' } as NavPage]
+    : []),
   { label: 'Analytique', href: '/analytique', icon: 'barchart' },
   { label: 'Mon profil', href: '/profil', icon: 'user' },
   { label: 'Paramètres', href: '/parametres', icon: 'settings' },


### PR DESCRIPTION
## Summary

Suite à la décision produit de l'équipe : **on retire le pointage de la v1** le temps de livrer le pointage par QR code (cf. `docs/QR_CLOCKIN_IMPLEMENTATION.md`, PR #311).

Cette PR débranche l'UI sans rien supprimer — composants, services, hooks, table DB `clock_in_entries` restent intacts. Réactivation = un seul flip à `true` dans le module de feature flags.

### Changements

**Nouveau module**
- `src/lib/featureFlags.ts` (5 lignes utiles) — expose `FEATURES.clockIn = false`

**8 points d'entrée conditionnés**
- `App.tsx` — route `/suivi-des-heures`
- `DashboardLayout.tsx` — item de menu "Suivi des heures" / "Mes heures"
- `EmployeeDashboard.tsx` — `ClockInWidget` (aside col)
- `CaregiverDashboard.tsx` — `ClockInWidget variant="warm"` (desktop + mobile)
- `QuickActionsWidget.tsx` — action "Pointer" pour le rôle employee
- `WelcomeCard.tsx` — lien CTA conditionnel
- `ShiftDetailModal.tsx` — bouton "Pointer" sur intervention planifiée
- `HelpPage.tsx` — section FAQ "Enregistrement des heures"
- `searchService.ts` — entrée recherche globale

**Fix layout**
- `EmployeeDashboard` utilisait des `gridRow` fixes — quand le `ClockInWidget` (row 4 colonne droite) disparaît, la grille gardait un trou. Messages + Documents remontent d'une row quand `FEATURES.clockIn = false`.

**Tests adaptés**
- 4 specs `it.skip` avec commentaire pointant vers le flag (App, EmployeeDashboard, CaregiverDashboard, QuickActions "Pointer pointe vers")
- 1 spec rewrite : `QuickActionsWidget` → "affiche les actions employee (sans Pointer tant que FEATURES.clockIn = false)" — Planning / Cahier / Absence présents, "Pointer" absent

**Réactivation future**

```ts
// src/lib/featureFlags.ts
export const FEATURES = {
- clockIn: false,
+ clockIn: true,
} as const
```

Retirer aussi les `it.skip` correspondants.

## Test plan

- [x] `npm run lint` : 0 erreur (2 warnings préexistants)
- [x] `npm run typecheck` : OK
- [x] `npm run test:run` : 2266 passed / 4 skipped
- [x] Test manuel auxi : aucun lien vers /suivi-des-heures dans le menu, dashboard, modal planning, FAQ, recherche
- [x] Test manuel auxi : pas de trou visuel sur le dashboard (Messages remonté en row 4)
- [x] Test manuel employeur : "Suivi des heures" absent du menu Gestion
- [x] Tentative URL directe `/suivi-des-heures` : route inexistante → fallback (404 ou redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)