### PR TITLE
fix(auth): repair magic link invitation flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,11 +97,14 @@ function App() {
   const navigate = useNavigate()
   const location = useLocation()
 
-  // Rediriger vers /reinitialisation si le flux recovery arrive sur une autre page
+  // Rediriger vers /reinitialisation si le flux recovery/invite arrive sur une autre page
   // (ex. Supabase redirige vers / car redirect_to n'est pas dans la whitelist)
   useEffect(() => {
-    // Cas 1: hash contient type=recovery au chargement (Supabase a redirigé vers /)
-    if (location.pathname !== '/reinitialisation' && location.hash.includes('type=recovery')) {
+    const isAuthSetupHash =
+      location.hash.includes('type=recovery') || location.hash.includes('type=invite')
+
+    // Cas 1: hash contient type=recovery|invite au chargement (Supabase a redirigé vers /)
+    if (location.pathname !== '/reinitialisation' && isAuthSetupHash) {
       navigate(`/reinitialisation${location.hash}`, { replace: true })
       return
     }

--- a/supabase/functions/invite-caregiver/index.ts
+++ b/supabase/functions/invite-caregiver/index.ts
@@ -17,9 +17,8 @@ interface InvitePayload {
 }
 
 const ALLOWED_ORIGINS = [
-  'https://unilien.fr',
-  'https://www.unilien.fr',
-  'https://unilien.netlify.app',
+  'https://unilien.app',
+  'https://www.unilien.app',
 ]
 
 function getCorsOrigin(req: Request): string {
@@ -113,7 +112,7 @@ serve(async (req: Request) => {
           role: 'caregiver',
           invited_by: employerId,
         },
-        redirectTo: `${Deno.env.get('SITE_URL') || 'https://unilien.netlify.app'}/reinitialisation`,
+        redirectTo: `${Deno.env.get('SITE_URL') || 'https://unilien.app'}/reinitialisation`,
       },
     )
 

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -17,9 +17,8 @@ interface InvitePayload {
 }
 
 const ALLOWED_ORIGINS = [
-  'https://unilien.fr',
-  'https://www.unilien.fr',
-  'https://unilien.netlify.app',
+  'https://unilien.app',
+  'https://www.unilien.app',
 ]
 
 function getCorsOrigin(req: Request): string {
@@ -113,7 +112,7 @@ serve(async (req: Request) => {
           role: 'employee',
           invited_by: employerId,
         },
-        redirectTo: `${Deno.env.get('SITE_URL') || 'https://unilien.netlify.app'}/reinitialisation`,
+        redirectTo: `${Deno.env.get('SITE_URL') || 'https://unilien.app'}/reinitialisation`,
       },
     )
 

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -11,9 +11,8 @@ interface PushPayload {
 }
 
 const ALLOWED_ORIGINS = [
-  'https://unilien.fr',
-  'https://www.unilien.fr',
-  'https://unilien.netlify.app',
+  'https://unilien.app',
+  'https://www.unilien.app',
 ]
 
 function getCorsOrigin(req: Request): string {


### PR DESCRIPTION
## Summary
Corrige le flux d'invitation par magic link cassé : les utilisateurs invités étaient redirigés vers `unilien.netlify.app` (domaine mort) ou atterrissaient sur la racine sans pouvoir définir leur mot de passe.

### Changements

**Edge Functions** :
- `invite-caregiver` & `invite-employee` : fallback `redirectTo` `https://unilien.netlify.app` → `https://unilien.app`
- CORS allowlists nettoyées (retire `unilien.netlify.app` + `unilien.fr` obsolètes des 3 fonctions invite/employee/push)

**Front** :
- `App.tsx` : redirige aussi `type=invite` vers `/reinitialisation` (auparavant uniquement `type=recovery`). Permet à un utilisateur invité de définir son mot de passe initial.

**Action prod (déjà appliquée manuellement)** :
- `/opt/supabase/docker/.env` : `ADDITIONAL_REDIRECT_URLS=https://unilien.app/**,http://localhost:5173/**` (le path `/reinitialisation` n'était pas autorisé par GoTrue → fallback sur Site URL)
- Container `auth` recréé et healthy
- Backup `.env` : `.env.bak-magic-link-20260428-115522`

## Test plan
- [ ] Inviter un nouvel auxiliaire (admin → équipe → ajouter)
- [ ] Cliquer le magic link reçu par email
- [ ] Atterrir sur `https://unilien.app/reinitialisation` (et non sur `/` ou domaine Netlify)
- [ ] Définir le mot de passe → connexion réussie

🤖 Generated with [Claude Code](https://claude.com/claude-code)