### PR TITLE
fix(messages,db): repair recent messages widget and account deletion

### DIFF
--- a/src/components/dashboard/widgets/RecentMessagesWidget.tsx
+++ b/src/components/dashboard/widgets/RecentMessagesWidget.tsx
@@ -43,17 +43,13 @@ export function RecentMessagesWidget({ userId }: RecentMessagesWidgetProps) {
 
     async function load() {
       try {
-        // Get recent messages where user is participant
+        // RLS filters liaison_messages to conversations the user can read
         const { data, error } = await supabase
           .from('liaison_messages')
           .select(`
             id, content, created_at, sender_id, read_by,
-            conversation:liaison_conversations!inner(
-              id, employer_id, employee_id
-            ),
             sender:profiles!sender_id(first_name, last_name)
           `)
-          .or(`conversation.employer_id.eq.${userId},conversation.employee_id.eq.${userId}`)
           .neq('sender_id', userId)
           .order('created_at', { ascending: false })
           .limit(3)

--- a/supabase/migrations/055_fix_delete_account_conversations.sql
+++ b/supabase/migrations/055_fix_delete_account_conversations.sql
@@ -1,0 +1,73 @@
+-- Migration 055 : corrige delete_own_account
+-- La table conversation_participants n'existe pas (l'archi conversations stocke
+-- les participants dans un array conversations.participant_ids).
+-- Suppression de la ligne fautive + retrait de l'utilisateur du tableau de
+-- participants pour éviter les UUID orphelins.
+
+CREATE OR REPLACE FUNCTION public.delete_own_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  _uid UUID := auth.uid();
+  _role TEXT;
+BEGIN
+  IF _uid IS NULL THEN
+    RAISE EXCEPTION 'Non authentifié';
+  END IF;
+
+  SELECT role INTO _role FROM public.profiles WHERE id = _uid;
+
+  -- 1. Tables FK vers profiles sans CASCADE
+  DELETE FROM public.leave_balances WHERE employee_id = _uid OR employer_id = _uid;
+  DELETE FROM public.log_entries WHERE author_id = _uid OR recipient_id = _uid;
+  DELETE FROM public.notifications WHERE user_id = _uid;
+
+  -- 2. Nettoyer caregiver_id sur contracts (NO ACTION)
+  UPDATE public.contracts SET caregiver_id = NULL WHERE caregiver_id = _uid;
+
+  -- 3. Absences
+  DELETE FROM public.absences WHERE employee_id = _uid;
+
+  -- 4. Shifts liés aux contrats de l'utilisateur
+  IF _role = 'employer' THEN
+    DELETE FROM public.shifts WHERE contract_id IN (
+      SELECT id FROM public.contracts WHERE employer_id = _uid
+    );
+    DELETE FROM public.contracts WHERE employer_id = _uid;
+    DELETE FROM public.log_entries WHERE employer_id = _uid;
+  ELSIF _role = 'employee' THEN
+    DELETE FROM public.shifts WHERE contract_id IN (
+      SELECT id FROM public.contracts WHERE employee_id = _uid
+    );
+    DELETE FROM public.contracts WHERE employee_id = _uid;
+  END IF;
+
+  -- 5. Caregivers (utilise profile_id, pas caregiver_id)
+  DELETE FROM public.caregivers WHERE profile_id = _uid;
+  DELETE FROM public.caregivers WHERE employer_id = _uid;
+
+  -- 6. Conversations : retirer l'utilisateur du tableau participant_ids
+  --    (les conversations dont il est employer sont supprimées via CASCADE en étape 8)
+  UPDATE public.conversations
+     SET participant_ids = array_remove(participant_ids, _uid)
+   WHERE _uid = ANY(participant_ids);
+
+  -- 7. Données métier
+  DELETE FROM public.employer_health_data WHERE profile_id = _uid;
+  DELETE FROM public.employers WHERE profile_id = _uid;
+  DELETE FROM public.employees WHERE profile_id = _uid;
+
+  -- 8. Profil (CASCADE vers caregivers, intervention_settings, convention_settings,
+  --    cesu_declarations, payslips, push_subscriptions, notification_preferences,
+  --    shopping_article_history, liaison_messages, conversations…)
+  DELETE FROM public.profiles WHERE id = _uid;
+
+  -- 9. Compte auth (CASCADE vers audit_logs, user_consents)
+  DELETE FROM auth.users WHERE id = _uid;
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_own_account() IS 'Supprime le compte et toutes les données associées (RGPD art. 17 - droit à l effacement)';


### PR DESCRIPTION
## Summary
Corrige deux bugs distincts révélés par les logs DevTools :

1. **`RecentMessagesWidget`** : la query référençait `liaison_conversations` (table inexistante) et `conversation.employee_id` (colonne inexistante) → PostgREST retournait `failed to parse logic tree`.
2. **`delete_own_account` RPC** : référençait `public.conversation_participants` (table inexistante — les participants sont stockés dans le tableau `conversations.participant_ids`) → suppression de compte cassée à nouveau.

### Changements

**Frontend** :
- `RecentMessagesWidget` : retire le embed cassé et le filtre `.or()`. La RLS de `conversations` filtre déjà les messages que l'utilisateur peut lire.

**DB** :
- Migration `055_fix_delete_account_conversations.sql` : remplace le `DELETE FROM conversation_participants` par un `UPDATE conversations SET participant_ids = array_remove(participant_ids, _uid)` pour éviter les UUID orphelins dans le tableau.

### Application

Migration **déjà appliquée en prod** via `psql` sur le VPS pour débloquer le flux de suppression. Présente dans le repo pour traçabilité.

## Test plan
- [ ] Dashboard → widget "Messages récents" se charge sans erreur
- [ ] Paramètres → Zone de danger → Supprimer mon compte → flow complet
- [ ] Tests `accountService` passent (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)