### PR TITLE
chore(i18n): fix French strings across UI

### DIFF
--- a/src/components/analytics/AuxiliaryBreakdownWidget.tsx
+++ b/src/components/analytics/AuxiliaryBreakdownWidget.tsx
@@ -25,10 +25,10 @@ export function AuxiliaryBreakdownWidget({ data }: AuxiliaryBreakdownWidgetProps
         boxShadow="sm"
       >
         <Text fontSize="lg" fontWeight="semibold" color="text.default" mb={4}>
-          Repartition par auxiliaire
+          Répartition par auxiliaire
         </Text>
         <Text fontSize="sm" color="text.muted" textAlign="center" py={4}>
-          Aucune donnee ce mois
+          Aucune donnée ce mois
         </Text>
       </Box>
     )
@@ -49,7 +49,7 @@ export function AuxiliaryBreakdownWidget({ data }: AuxiliaryBreakdownWidgetProps
       <Flex justify="space-between" align="center" mb={4}>
         <Box>
           <Text fontSize="lg" fontWeight="semibold" color="text.default">
-            Repartition par auxiliaire
+            Répartition par auxiliaire
           </Text>
           <Text fontSize="sm" color="text.muted">
             Mois en cours

--- a/src/components/analytics/MonthlyChart.tsx
+++ b/src/components/analytics/MonthlyChart.tsx
@@ -103,11 +103,11 @@ export function MonthlyChart({ data, metric, title }: MonthlyChartProps) {
         <Flex gap={4} mt={4} justify="center">
           <Flex align="center" gap={1}>
             <Box w={3} h={3} borderRadius="sm" bg="brand.500" />
-            <Text fontSize="xs" color="text.muted">Effectuees</Text>
+            <Text fontSize="xs" color="text.muted">Effectuées</Text>
           </Flex>
           <Flex align="center" gap={1}>
             <Box w={3} h={3} borderRadius="sm" bg="brand.100" />
-            <Text fontSize="xs" color="text.muted">Planifiees</Text>
+            <Text fontSize="xs" color="text.muted">Planifiées</Text>
           </Flex>
         </Flex>
       )}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -110,6 +110,15 @@ export function SignupForm() {
   } = useForm<SignupFormData>({
     resolver: zodResolver(signupSchema),
     mode: 'onBlur',
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      email: '',
+      phone: '',
+      role: '',
+      password: '',
+      confirmPassword: '',
+    },
   })
 
   const watchedRole = watch('role')

--- a/src/components/dashboard/widgets/OnboardingWidget.tsx
+++ b/src/components/dashboard/widgets/OnboardingWidget.tsx
@@ -44,9 +44,9 @@ export function OnboardingWidget({ profile, userRole }: OnboardingWidgetProps) {
         const newSteps: OnboardingStep[] = [
           {
             id: 'profile',
-            label: 'Completer votre profil',
+            label: 'Compléter votre profil',
             description: profileDone
-              ? 'Profil complete'
+              ? 'Profil complété'
               : 'Ajoutez vos informations personnelles et votre adresse',
             href: '/profil',
             done: profileDone,
@@ -56,8 +56,8 @@ export function OnboardingWidget({ profile, userRole }: OnboardingWidgetProps) {
                 id: 'team',
                 label: 'Ajouter un auxiliaire',
                 description: teamDone
-                  ? 'Equipe configuree'
-                  : 'Ajoutez votre premier auxiliaire de vie et creez son contrat',
+                  ? 'Équipe configurée'
+                  : 'Ajoutez votre premier auxiliaire de vie et créez son contrat',
                 href: '/equipe',
                 done: teamDone,
               }
@@ -67,7 +67,7 @@ export function OnboardingWidget({ profile, userRole }: OnboardingWidgetProps) {
                   label: 'Lien avec votre employeur',
                   description: teamDone
                     ? 'Contrat actif'
-                    : "Demandez a votre employeur de vous ajouter depuis son espace",
+                    : "Demandez à votre employeur de vous ajouter depuis son espace",
                   href: '/profil',
                   done: teamDone,
                 }
@@ -75,21 +75,21 @@ export function OnboardingWidget({ profile, userRole }: OnboardingWidgetProps) {
                   id: 'team',
                   label: 'Lien avec votre proche',
                   description: teamDone
-                    ? 'Lie a un employeur'
-                    : "Demandez a votre proche de vous ajouter comme aidant",
+                    ? 'Lié à un employeur'
+                    : "Demandez à votre proche de vous ajouter comme aidant",
                   href: '/profil',
                   done: teamDone,
                 },
           {
             id: 'shifts',
             label: userRole === 'employer'
-              ? 'Creer une intervention'
-              : 'Premiere intervention',
+              ? 'Créer une intervention'
+              : 'Première intervention',
             description: shiftsDone
-              ? 'Interventions enregistrees'
+              ? 'Interventions enregistrées'
               : userRole === 'employer'
-                ? 'Planifiez votre premiere intervention depuis le planning'
-                : "Une fois lie, vos interventions apparaitront ici",
+                ? 'Planifiez votre première intervention depuis le planning'
+                : "Une fois lié, vos interventions apparaîtront ici",
             href: '/planning',
             done: shiftsDone,
           },

--- a/src/components/documents/CesuDeclarationSection.tsx
+++ b/src/components/documents/CesuDeclarationSection.tsx
@@ -87,7 +87,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
     setDialogError(null)
 
     if (!isMonthClosed(selectedYear, selectedMonth)) {
-      setDialogError('Ce mois n\'est pas encore termine. La declaration CESU sera disponible a partir du 1er du mois suivant.')
+      setDialogError('Ce mois n\'est pas encore terminé. La déclaration CESU sera disponible à partir du 1er du mois suivant.')
       setIsGenerating(false)
       return
     }
@@ -100,12 +100,12 @@ export function CesuDeclarationSection({ employerId }: Props) {
       })
 
       if (!data) {
-        setDialogError('Aucune donnee disponible pour cette periode')
+        setDialogError('Aucune donnée disponible pour cette période')
         return
       }
 
       if (data.employees.length === 0) {
-        setDialogError('Aucune intervention enregistree pour cette periode')
+        setDialogError('Aucune intervention enregistrée pour cette période')
         return
       }
 
@@ -119,7 +119,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
       // Persister en base (upsert) avec le chemin du PDF
       const saved = await saveCesuDeclaration(employerId, data, storagePath)
       if (!saved) {
-        setDialogError('Erreur lors de la sauvegarde de la declaration')
+        setDialogError('Erreur lors de la sauvegarde de la déclaration')
         return
       }
 
@@ -135,13 +135,13 @@ export function CesuDeclarationSection({ employerId }: Props) {
 
       setShowDialog(false)
       toaster.create({
-        title: 'Declaration CESU',
-        description: `${saved.periodLabel} — ${saved.totalEmployees} employe${saved.totalEmployees > 1 ? 's' : ''}, ${formatHoursCompact(saved.totalHours)}`,
+        title: 'Déclaration CESU',
+        description: `${saved.periodLabel} — ${saved.totalEmployees} employé${saved.totalEmployees > 1 ? 's' : ''}, ${formatHoursCompact(saved.totalHours)}`,
         type: 'success',
       })
     } catch (err) {
-      logger.error('Erreur generation CESU:', err)
-      setDialogError('Erreur lors de la generation des donnees')
+      logger.error('Erreur génération CESU:', err)
+      setDialogError('Erreur lors de la génération des données')
     } finally {
       setIsGenerating(false)
     }
@@ -156,8 +156,8 @@ export function CesuDeclarationSection({ employerId }: Props) {
       if (url) {
         window.open(url, '_blank')
         toaster.create({
-          title: 'Declaration CESU',
-          description: `${declaration.periodLabel} telecharge en PDF`,
+          title: 'Déclaration CESU',
+          description: `${declaration.periodLabel} téléchargé en PDF`,
           type: 'success',
         })
         return
@@ -181,14 +181,14 @@ export function CesuDeclarationSection({ employerId }: Props) {
     if (result.success) {
       downloadExport(result)
       toaster.create({
-        title: 'Declaration CESU',
-        description: `${declaration.periodLabel} telecharge en ${format.toUpperCase()}`,
+        title: 'Déclaration CESU',
+        description: `${declaration.periodLabel} téléchargé en ${format.toUpperCase()}`,
         type: 'success',
       })
     } else {
       toaster.create({
         title: 'Erreur',
-        description: result.error || 'Erreur lors du telechargement',
+        description: result.error || 'Erreur lors du téléchargement',
         type: 'error',
       })
     }
@@ -199,14 +199,14 @@ export function CesuDeclarationSection({ employerId }: Props) {
     if (success) {
       setDeclarations((prev) => prev.filter((r) => r.id !== record.id))
       toaster.create({
-        title: 'Declaration supprimee',
+        title: 'Déclaration supprimée',
         description: record.periodLabel,
         type: 'info',
       })
     } else {
       toaster.create({
         title: 'Erreur',
-        description: 'Impossible de supprimer la declaration',
+        description: 'Impossible de supprimer la déclaration',
         type: 'error',
       })
     }
@@ -218,7 +218,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
       <HStack justify="space-between" flexWrap="wrap" gap={3}>
         <HStack gap={3}>
           <Text fontSize="sm" color="text.muted">
-            {declarations.length} declaration{declarations.length > 1 ? 's' : ''} generee{declarations.length > 1 ? 's' : ''}
+            {declarations.length} déclaration{declarations.length > 1 ? 's' : ''} générée{declarations.length > 1 ? 's' : ''}
           </Text>
         </HStack>
 
@@ -230,27 +230,27 @@ export function CesuDeclarationSection({ employerId }: Props) {
             setShowDialog(true)
           }}
         >
-          Generer une declaration
+          Générer une déclaration
         </Button>
       </HStack>
 
       {/* ── Status hint ── */}
       <Text fontSize="xs" color="text.muted">
-        Generez un recapitulatif mensuel pour chaque periode, puis telechargez-le en PDF ou CSV pour votre declaration sur cesu.urssaf.fr.
+        Générez un récapitulatif mensuel pour chaque période, puis téléchargez-le en PDF ou CSV pour votre déclaration sur cesu.urssaf.fr.
       </Text>
 
       {/* ── Tableau ── */}
       {isLoading ? (
         <HStack justify="center" py={8}>
           <Spinner size="sm" />
-          <Text fontSize="sm" color="text.muted">Chargement des declarations…</Text>
+          <Text fontSize="sm" color="text.muted">Chargement des déclarations…</Text>
         </HStack>
       ) : declarations.length === 0 ? (
         <EmptyState.Root>
           <EmptyState.Content>
-            <EmptyState.Title>Aucune declaration</EmptyState.Title>
+            <EmptyState.Title>Aucune déclaration</EmptyState.Title>
             <EmptyState.Description>
-              Generez votre premiere declaration CESU avec le bouton ci-dessus.
+              Générez votre première déclaration CESU avec le bouton ci-dessus.
             </EmptyState.Description>
           </EmptyState.Content>
         </EmptyState.Root>
@@ -259,7 +259,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
           <Table.Root size="sm">
             <Table.Header>
               <Table.Row>
-                <Table.ColumnHeader>Periode</Table.ColumnHeader>
+                <Table.ColumnHeader>Période</Table.ColumnHeader>
                 <Table.ColumnHeader textAlign="right">Employes</Table.ColumnHeader>
                 <Table.ColumnHeader textAlign="right">Heures</Table.ColumnHeader>
                 <Table.ColumnHeader textAlign="right">Total brut</Table.ColumnHeader>
@@ -331,7 +331,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
         <Dialog.Positioner>
           <Dialog.Content maxW="lg">
             <Dialog.Header>
-              <Dialog.Title>Generer une declaration CESU</Dialog.Title>
+              <Dialog.Title>Générer une déclaration CESU</Dialog.Title>
               <Dialog.CloseTrigger asChild>
                 <CloseButton />
               </Dialog.CloseTrigger>
@@ -355,7 +355,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
                     </NativeSelect.Root>
                   </Box>
                   <Box flex={1}>
-                    <Text fontSize="sm" fontWeight="medium" mb={2}>Annee</Text>
+                    <Text fontSize="sm" fontWeight="medium" mb={2}>Année</Text>
                     <NativeSelect.Root>
                       <NativeSelect.Field
                         value={selectedYear}
@@ -374,7 +374,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
                   <Alert.Root status="info">
                     <Alert.Indicator />
                     <Alert.Title>
-                      Ce mois n'est pas encore termine. Vous pourrez generer la declaration a partir du {new Date(selectedYear, selectedMonth, 1).toLocaleDateString('fr-FR')}.
+                      Ce mois n'est pas encore terminé. Vous pourrez générer la déclaration à partir du {new Date(selectedYear, selectedMonth, 1).toLocaleDateString('fr-FR')}.
                     </Alert.Title>
                   </Alert.Root>
                 )}
@@ -397,10 +397,10 @@ export function CesuDeclarationSection({ employerId }: Props) {
                   colorPalette="brand"
                   onClick={handleGenerate}
                   loading={isGenerating}
-                  loadingText="Generation…"
+                  loadingText="Génération…"
                   disabled={!isMonthClosed(selectedYear, selectedMonth)}
                 >
-                  Generer l'apercu pour {MONTHS_FR[selectedMonth - 1]} {selectedYear}
+                  Générer l'aperçu pour {MONTHS_FR[selectedMonth - 1]} {selectedYear}
                 </Button>
               </HStack>
             </Dialog.Footer>

--- a/src/components/documents/ContractsSection.tsx
+++ b/src/components/documents/ContractsSection.tsx
@@ -157,10 +157,10 @@ export function ContractsSection({ employerId }: Props) {
               <Button
                 size="sm"
                 variant="ghost"
-                aria-label={`Telecharger contrat ${contract.employee?.firstName ?? ''} ${contract.employee?.lastName ?? ''}`}
+                aria-label={`Télécharger contrat ${contract.employee?.firstName ?? ''} ${contract.employee?.lastName ?? ''}`}
               >
                 <DownloadIcon />
-                Telecharger
+                Télécharger
               </Button>
               <Badge
                 colorPalette={STATUS_COLORS[contract.status] || 'gray'}

--- a/src/components/documents/PlanningExportSection.test.tsx
+++ b/src/components/documents/PlanningExportSection.test.tsx
@@ -117,7 +117,7 @@ describe('PlanningExportSection', () => {
   it('affiche la selection employe pour un employeur', async () => {
     renderWithProviders(<PlanningExportSection {...defaultProps} />)
     await waitFor(() => {
-      expect(screen.getByText('Tous les employes')).toBeInTheDocument()
+      expect(screen.getByText('Tous les employés')).toBeInTheDocument()
       expect(screen.getByText('Marie Curie')).toBeInTheDocument()
     })
   })
@@ -131,7 +131,7 @@ describe('PlanningExportSection', () => {
       />
     )
     await waitFor(() => {
-      expect(screen.queryByText('Tous les employes')).not.toBeInTheDocument()
+      expect(screen.queryByText('Tous les employés')).not.toBeInTheDocument()
     })
   })
 
@@ -164,7 +164,7 @@ describe('PlanningExportSection', () => {
     await userEvent.click(screen.getByText('Exporter'))
 
     await waitFor(() => {
-      expect(screen.getByText('Aucune donnee disponible pour cette periode')).toBeInTheDocument()
+      expect(screen.getByText('Aucune donnée disponible pour cette période')).toBeInTheDocument()
     })
   })
 

--- a/src/components/documents/PlanningExportSection.tsx
+++ b/src/components/documents/PlanningExportSection.tsx
@@ -124,7 +124,7 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
         setEmployees(opts)
       })
       .catch((err) => {
-        logger.error('Erreur chargement employes:', err)
+        logger.error('Erreur chargement employés:', err)
       })
       .finally(() => setIsLoadingEmployees(false))
   }, [employerId, canSelectEmployee])
@@ -145,12 +145,12 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
       }
 
       if (!planningData) {
-        setError('Aucune donnee disponible pour cette periode')
+        setError('Aucune donnée disponible pour cette période')
         return
       }
 
       if (planningData.employees.length === 0) {
-        setError('Aucune intervention ni absence pour cette periode')
+        setError('Aucune intervention ni absence pour cette période')
         return
       }
 
@@ -168,7 +168,7 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
       }
 
       if (!result.success) {
-        setError(result.error ?? 'Erreur lors de la generation')
+        setError(result.error ?? 'Erreur lors de la génération')
         return
       }
 
@@ -176,13 +176,13 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
 
       const formatLabels = { pdf: 'PDF', excel: 'Excel', ical: 'iCal' }
       toaster.create({
-        title: 'Export planning telecharge',
+        title: 'Export planning téléchargé',
         description: `Fichier ${formatLabels[selectedFormat]} pret`,
         type: 'success',
       })
     } catch (err) {
       logger.error('Erreur export planning:', err)
-      setError('Une erreur est survenue lors de la generation')
+      setError('Une erreur est survenue lors de la génération')
     } finally {
       setIsGenerating(false)
     }
@@ -217,7 +217,7 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
                     value={selectedEmployeeId}
                     onChange={(e) => setSelectedEmployeeId(e.target.value)}
                   >
-                    <option value="all">Tous les employes</option>
+                    <option value="all">Tous les employés</option>
                     {employees.map((e) => (
                       <option key={e.value} value={e.value}>{e.label}</option>
                     ))}
@@ -245,7 +245,7 @@ export function PlanningExportSection({ employerId, profileRole, profileId }: Pr
               </Field.Root>
 
               <Field.Root flex={1}>
-                <Field.Label>Annee</Field.Label>
+                <Field.Label>Année</Field.Label>
                 <NativeSelect.Root>
                   <NativeSelect.Field
                     value={selectedYear}

--- a/src/components/logbook/LogbookPage.test.tsx
+++ b/src/components/logbook/LogbookPage.test.tsx
@@ -200,10 +200,10 @@ describe('LogbookPage', () => {
       })
     })
 
-    it('affiche le bouton "Creer la premiere entree" pour un employeur', async () => {
+    it('affiche le bouton "Créer la première entrée" pour un employeur', async () => {
       renderWithProviders(<LogbookPage />)
       await waitFor(() => {
-        expect(screen.getByText('Creer la premiere entree')).toBeInTheDocument()
+        expect(screen.getByText('Créer la première entrée')).toBeInTheDocument()
       })
     })
 
@@ -217,7 +217,7 @@ describe('LogbookPage', () => {
       mockGetLogEntries.mockResolvedValue({ entries: [], totalCount: 0, hasMore: false })
       renderWithProviders(<LogbookPage />)
       await waitFor(() => {
-        expect(screen.queryByText('Creer la premiere entree')).not.toBeInTheDocument()
+        expect(screen.queryByText('Créer la première entrée')).not.toBeInTheDocument()
       })
     })
   })

--- a/src/components/logbook/LogbookPage.tsx
+++ b/src/components/logbook/LogbookPage.tsx
@@ -308,7 +308,7 @@ export function LogbookPage() {
                 variant="outline"
                 onClick={() => setIsNewEntryModalOpen(true)}
               >
-                Creer la premiere entree
+                Créer la première entrée
               </AccessibleButton>
             )}
           </Box>

--- a/src/components/profile/ProfilePage.tsx
+++ b/src/components/profile/ProfilePage.tsx
@@ -76,7 +76,7 @@ export function ProfilePage() {
               Profil incomplet
             </Text>
             <Text color="text.muted">
-              Votre profil n'a pas ete trouve dans la base de donnees.
+              Votre profil n'a pas été trouvé dans la base de données.
               Veuillez contacter le support ou vous reconnecter.
             </Text>
           </Box>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1013,16 +1013,16 @@ export function HomePage() {
                 answer="Oui. Unilien vise le niveau WCAG AAA : navigation clavier complete, compatibilite lecteurs d'ecran (NVDA, VoiceOver), commande vocale integree, mode contraste eleve, taille de texte ajustable, reduction de mouvement. Elle est concue par et pour des personnes en situation de handicap."
               />
               <FaqItem
-                question="Puis-je importer mes donnees depuis Excel ?"
-                answer="L'import Excel est en cours de developpement (roadmap Q2 2026). En attendant, vos donnees sont exportables en CSV, JSON et PDF a tout moment depuis la section Parametres."
+                question="Puis-je importer mes données depuis Excel ?"
+                answer="L'import Excel est en cours de développement (roadmap Q2 2026). En attendant, vos données sont exportables en CSV, JSON et PDF à tout moment depuis la section Paramètres."
               />
               <FaqItem
-                question="Mes donnees sont-elles securisees ?"
-                answer="Vos donnees sont hebergees en Europe sur Supabase (PostgreSQL), protegees par des politiques RLS (Row Level Security), chiffrees en transit (TLS) et au repos. Unilien ne vend ni ne partage vos donnees. Vous pouvez les exporter ou les supprimer a tout moment."
+                question="Mes données sont-elles sécurisées ?"
+                answer="Vos données sont hébergées en Europe sur Supabase (PostgreSQL), protégées par des politiques RLS (Row Level Security), chiffrées en transit (TLS) et au repos. Unilien ne vend ni ne partage vos données. Vous pouvez les exporter ou les supprimer à tout moment."
               />
               <FaqItem
                 question="Comment fonctionne la PCH dans Unilien ?"
-                answer="Le widget PCH affiche votre enveloppe mensuelle (heures allouees x tarif 2026), le cout reel employeur, le reste a charge et l'economie realisee grace a l'exoneration patronale SS. Les tarifs sont mis a jour annuellement."
+                answer="Le widget PCH affiche votre enveloppe mensuelle (heures allouées × tarif 2026), le coût réel employeur, le reste à charge et l'économie réalisée grâce à l'exonération patronale SS. Les tarifs sont mis à jour annuellement."
               />
             </Stack>
           </Stack>


### PR DESCRIPTION
## Summary
Nettoyage des chaînes françaises mal accentuées et d'un message d'erreur Zod resté en anglais sur le formulaire d'inscription.

### Changements

**Bug fix** :
- `SignupForm` : ajout des `defaultValues` au `useForm` pour que le champ `role` soit `''` au mount (au lieu de `undefined`). En Zod v4, `.min(1, '...')` ne s'exécute pas sur `undefined` → l'erreur tombait sur le message anglais par défaut "Invalid input" au lieu de "Veuillez sélectionner un type de compte".

**Accents oubliés** :
- `MonthlyChart`, `AuxiliaryBreakdownWidget` : Effectuées / Planifiées / Répartition / donnée
- `OnboardingWidget` : Compléter / complété / Équipe / configurée / créez / Lié / à / Première / enregistrées / lié / apparaîtront
- `ContractsSection` : Télécharger
- `PlanningExportSection` : période / employés / téléchargé / génération / Année
- `CesuDeclarationSection` (~25 strings) : Générer / Générez / déclaration / déclarations / récapitulatif / téléchargé / téléchargez / téléchargement / aperçu / Période / Année / supprimée / employé / générée
- `LogbookPage` : Créer la première entrée
- `ProfilePage` : été trouvé dans la base de données
- `HomePage` (FAQ) : données / sécurisées / hébergées / chiffrées / développement / Paramètres / allouées / coût / réel / économie / réalisée / grâce / exonération

**Tests** : 2 fichiers mis à jour pour matcher les nouvelles chaînes (`LogbookPage.test`, `PlanningExportSection.test`).

## Test plan
- [ ] Inscription : ne pas sélectionner de rôle → message d'erreur en français
- [ ] Dashboard : widget onboarding lisible
- [ ] CESU : générer une déclaration → tous les libellés accentués
- [ ] Tests automatisés passent (2266+ ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)