### PR TITLE
feat(legal): add terms & privacy pages, sweep unilien.fr and personal name

### DIFF
--- a/docs/ANALYTICS_IMPLEMENTATION.md
+++ b/docs/ANALYTICS_IMPLEMENTATION.md
@@ -57,7 +57,7 @@ export function Analytics() {
   return (
     <script
       defer
-      data-domain="app.unilien.fr"
+      data-domain="app.unilien.app"
       src="https://plausible.ton-domaine.fr/js/script.js"
     />
   )
@@ -136,4 +136,4 @@ Le toggle "Cookies de performance" n'a de sens que si un outil futur en pose (ex
 ## Prérequis
 
 - Un serveur/VPS pour héberger Plausible (ou utiliser le cloud à 9€/mois)
-- Un domaine/sous-domaine pour le dashboard (ex: `plausible.unilien.fr`)
+- Un domaine/sous-domaine pour le dashboard (ex: `plausible.unilien.app`)

--- a/docs/SECURITY_ANALYSIS.md
+++ b/docs/SECURITY_ANALYSIS.md
@@ -162,7 +162,7 @@ Cette note synthétise les points de sécurité observés dans le code front-end
 
 #### 6. ~~CORS permissif sur les fonctions edge~~ ✅ Corrigé
 
-Les fonctions `send-push-notification` et `invite-employee` restreignent déjà les origines via `ALLOWED_ORIGINS` (unilien.fr, netlify.app, localhost).
+Les fonctions `send-push-notification` et `invite-employee` restreignent déjà les origines via `ALLOWED_ORIGINS` (unilien.app, netlify.app, localhost).
 
 #### 7. ~~Cache PWA sur endpoints API~~ ✅ Corrigé
 

--- a/docs/SECURITY_PENTEST_REPORT.md
+++ b/docs/SECURITY_PENTEST_REPORT.md
@@ -511,7 +511,7 @@ Un employeur ou tuteur malveillant pourrait :
 | **XSS via `dangerouslySetInnerHTML`** | Une seule utilisation dans `NavIcon.tsx` avec données statiques (PATHS) |
 | **Sanitisation** | 8 services utilisent `sanitizeText` ; `action_url` et `invite-employee` sont les exceptions |
 | **Storage justifications** | Policy "Public read" supprimée en migration 021 — accès restreint |
-| **CORS Edge Functions** | Restreint à unilien.fr, netlify.app, localhost |
+| **CORS Edge Functions** | Restreint à unilien.app, netlify.app, localhost |
 | **Rate limiting** | `send-push-notification` : 30 req/min par userId |
 | **serialize-javascript** | Override vers 7.0.3+ appliqué |
 | **xlsx** | Remplacé par `@e965/xlsx@0.20.3` (CVE corrigées) |

--- a/docs/SEO_LINKS_ANALYSIS.md
+++ b/docs/SEO_LINKS_ANALYSIS.md
@@ -142,11 +142,11 @@ Dans `ContactPage.tsx`, les coordonnées sont affichées en texte pur sans attri
 
 ```tsx
 // Actuellement — texte pur
-<Text>contact@unilien.fr</Text>
+<Text>contact@unilien.app</Text>
 <Text>01 23 45 67 89</Text>
 
 // À corriger
-<Link href="mailto:contact@unilien.fr">contact@unilien.fr</Link>
+<Link href="mailto:contact@unilien.app">contact@unilien.app</Link>
 <Link href="tel:+33123456789">01 23 45 67 89</Link>
 ```
 
@@ -247,14 +247,14 @@ cp public/pwa-192x192.png public/apple-touch-icon.png
 <title>Unilien — Gestion des auxiliaires de vie</title>
 <meta name="description" content="Application de gestion pour employeurs particuliers et auxiliaires de vie. Plannings, déclarations CESU, bulletins de paie, conformité IDCC 3239." />
 <meta name="theme-color" content="#2B6CB0" />
-<link rel="canonical" href="https://unilien.fr/" />
+<link rel="canonical" href="https://unilien.app/" />
 
 <!-- Open Graph -->
 <meta property="og:type" content="website" />
-<meta property="og:url" content="https://unilien.fr/" />
+<meta property="og:url" content="https://unilien.app/" />
 <meta property="og:title" content="Unilien — Gestion des auxiliaires de vie" />
 <meta property="og:description" content="Application de gestion pour employeurs particuliers et auxiliaires de vie. Plannings, déclarations CESU, bulletins de paie, conformité IDCC 3239." />
-<meta property="og:image" content="https://unilien.fr/og-image.png" />
+<meta property="og:image" content="https://unilien.app/og-image.png" />
 <meta property="og:locale" content="fr_FR" />
 <meta property="og:site_name" content="Unilien" />
 
@@ -262,7 +262,7 @@ cp public/pwa-192x192.png public/apple-touch-icon.png
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Unilien — Gestion des auxiliaires de vie" />
 <meta name="twitter:description" content="Application de gestion pour employeurs particuliers et auxiliaires de vie." />
-<meta name="twitter:image" content="https://unilien.fr/og-image.png" />
+<meta name="twitter:image" content="https://unilien.app/og-image.png" />
 ```
 
 Créer également `public/og-image.png` (1200×630px).
@@ -288,7 +288,7 @@ Disallow: /signup
 Disallow: /forgot-password
 Disallow: /reset-password
 
-Sitemap: https://unilien.fr/sitemap.xml
+Sitemap: https://unilien.app/sitemap.xml
 ```
 
 #### P5 — Corriger les liens morts dans `QuickActionsWidget.tsx`
@@ -377,12 +377,12 @@ Créer les 3 pages manquantes et mettre à jour le footer :
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://unilien.fr/</loc>
+    <loc>https://unilien.app/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://unilien.fr/contact</loc>
+    <loc>https://unilien.app/contact</loc>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -401,7 +401,7 @@ import Sitemap from 'vite-plugin-sitemap'
 
 plugins: [
   Sitemap({
-    hostname: 'https://unilien.fr',
+    hostname: 'https://unilien.app',
     dynamicRoutes: ['/', '/contact'],
     exclude: ['/dashboard', '/settings', '/planning', /* ... */],
   }),
@@ -433,7 +433,7 @@ export function NotFoundPage() {
 #### P13 — Coordonnées cliquables dans `ContactPage.tsx`
 
 ```tsx
-<Link href="mailto:contact@unilien.fr">contact@unilien.fr</Link>
+<Link href="mailto:contact@unilien.app">contact@unilien.app</Link>
 <Link href="tel:+33123456789">01 23 45 67 89</Link>
 ```
 

--- a/docs/SUPABASE_AUTH_REDIRECT_URLS.md
+++ b/docs/SUPABASE_AUTH_REDIRECT_URLS.md
@@ -17,7 +17,7 @@ Si le lien de réinitialisation dans l’email renvoie vers la racine (`https://
 3. Aller dans **Authentication** → **URL Configuration**
 4. Dans **Redirect URLs**, ajouter :
    - `https://unilien.netlify.app/reinitialisation`
-   - `https://unilien.fr/reinitialisation` (si domaine custom utilisé)
+   - `https://unilien.app/reinitialisation` (si domaine custom utilisé)
    - `http://localhost:5173/reinitialisation` (développement local, souvent déjà présent)
 
 5. Vérifier que **Site URL** pointe bien vers l’origine de production, par ex. `https://unilien.netlify.app`

--- a/docs/SUPABASE_SELFHOST_OVH.md
+++ b/docs/SUPABASE_SELFHOST_OVH.md
@@ -122,16 +122,16 @@ SERVICE_ROLE_KEY=<généré>
 DASHBOARD_USERNAME=admin
 DASHBOARD_PASSWORD=<strong>
 
-SITE_URL=https://test.unilien.fr       # ton front de test
-API_EXTERNAL_URL=https://api-test.unilien.fr
-SUPABASE_PUBLIC_URL=https://api-test.unilien.fr
+SITE_URL=https://test.unilien.app       # ton front de test
+API_EXTERNAL_URL=https://api-test.unilien.app
+SUPABASE_PUBLIC_URL=https://api-test.unilien.app
 
 # SMTP (optionnel, pour reset password etc.)
 SMTP_HOST=smtp.resend.com
 SMTP_PORT=465
 SMTP_USER=resend
 SMTP_PASS=<resend_api_key>
-SMTP_ADMIN_EMAIL=noreply@unilien.fr
+SMTP_ADMIN_EMAIL=noreply@unilien.app
 SMTP_SENDER_NAME=Unilien
 ```
 
@@ -175,18 +175,18 @@ sudo apt update && sudo apt install caddy
 ### DNS OVH
 
 Crée deux enregistrements A pointant vers l'IP du VPS :
-- `api-test.unilien.fr` → `<IP_VPS>`
-- `studio-test.unilien.fr` → `<IP_VPS>`
+- `api-test.unilien.app` → `<IP_VPS>`
+- `studio-test.unilien.app` → `<IP_VPS>`
 
 ### `/etc/caddy/Caddyfile`
 
 ```caddy
-api-test.unilien.fr {
+api-test.unilien.app {
     reverse_proxy localhost:8000
     encode gzip
 }
 
-studio-test.unilien.fr {
+studio-test.unilien.app {
     # Protection additionnelle basique (Studio n'a pas d'auth built-in robuste)
     basicauth {
         admin <hash_bcrypt>
@@ -213,7 +213,7 @@ Caddy récupère automatiquement les certificats Let's Encrypt au premier hit.
 
 Dans `.env.local` du front (pour un build de test) :
 ```bash
-VITE_SUPABASE_URL=https://api-test.unilien.fr
+VITE_SUPABASE_URL=https://api-test.unilien.app
 VITE_SUPABASE_ANON_KEY=<ANON_KEY générée à l'étape 5>
 ```
 

--- a/docs/TODO_NOTIFICATIONS.md
+++ b/docs/TODO_NOTIFICATIONS.md
@@ -144,7 +144,7 @@ function NotificationSettings() {
 ### Variables d'environnement
 ```env
 RESEND_API_KEY=re_xxxxx
-EMAIL_FROM=notifications@unilien.fr
+EMAIL_FROM=notifications@unilien.app
 ```
 
 ### Coût estimé

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://unilien.fr/sitemap.xml
+Sitemap: https://unilien.app/sitemap.xml

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ const CompliancePage = lazy(() => import('@/pages/CompliancePage'))
 const DocumentsPage = lazy(() => import('@/pages/DocumentsPage'))
 const AnalyticsPage = lazy(() => import('@/pages/AnalyticsPage'))
 const LegalPage = lazy(() => import('@/pages/LegalPage'))
+const TermsPage = lazy(() => import('@/pages/TermsPage'))
+const PrivacyPage = lazy(() => import('@/pages/PrivacyPage'))
 const HelpPage = lazy(() => import('@/pages/HelpPage'))
 const AuthCallbackPage = lazy(() => import('@/pages/AuthCallbackPage'))
 const OnboardingRolePage = lazy(() => import('@/pages/OnboardingRolePage'))
@@ -130,6 +132,8 @@ function App() {
           {/* Pages publiques */}
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/mentions-legales" element={<LegalPage />} />
+          <Route path="/conditions-utilisation" element={<TermsPage />} />
+          <Route path="/politique-confidentialite" element={<PrivacyPage />} />
 
           {/* Routes publiques */}
           <Route

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -332,9 +332,9 @@ export function SignupForm() {
               <input type="checkbox" required style={{ width: 'auto' }} />
               <Text fontSize="sm">
                 J&apos;accepte les{' '}
-                <Link href="#" color="brand.500" fontWeight="700">Conditions d&apos;utilisation</Link>
+                <Link as={RouterLink} to="/conditions-utilisation" target="_blank" rel="noopener noreferrer" color="brand.500" fontWeight="700">Conditions d&apos;utilisation</Link>
                 {' '}et la{' '}
-                <Link href="#" color="brand.500" fontWeight="700">Politique de confidentialité</Link>
+                <Link as={RouterLink} to="/politique-confidentialite" target="_blank" rel="noopener noreferrer" color="brand.500" fontWeight="700">Politique de confidentialité</Link>
               </Text>
             </Flex>
 

--- a/src/pages/ContactPage.test.tsx
+++ b/src/pages/ContactPage.test.tsx
@@ -90,7 +90,7 @@ describe('ContactPage', () => {
 
     it('affiche l\'adresse email de contact', () => {
       renderWithProviders(<ContactPage />)
-      expect(screen.getByText('contact@unilien.fr')).toBeInTheDocument()
+      expect(screen.getByText('contact@unilien.app')).toBeInTheDocument()
     })
 
     it('affiche la section FAQ', () => {

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -244,7 +244,7 @@ export function ContactPage() {
                     <ContactInfo
                       icon="📧"
                       title="Email"
-                      content="contact@unilien.fr"
+                      content="contact@unilien.app"
                     />
                     <ContactInfo
                       icon="📞"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1105,16 +1105,16 @@ export function HomePage() {
               Légal
             </Text>
             <Stack gap={2}>
-              <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
+              <Link as={RouterLink} to="/mentions-legales" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
                 Mentions légales
               </Link>
-              <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
+              <Link as={RouterLink} to="/politique-confidentialite" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
                 Politique de confidentialité
               </Link>
-              <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
+              <Link as={RouterLink} to="/conditions-utilisation" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
                 CGU
               </Link>
-              <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
+              <Link as={RouterLink} to="/politique-confidentialite" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
                 RGPD
               </Link>
             </Stack>

--- a/src/pages/LegalPage.tsx
+++ b/src/pages/LegalPage.tsx
@@ -45,22 +45,21 @@ export default function LegalPage() {
               Statut : en cours de développement — projet personnel.
             </Text>
             <Text>
-              Responsable de la publication : Vincent Zepharren<br />
+              Responsable de la publication : l&apos;équipe Unilien<br />
               Contact : <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>
             </Text>
           </Section>
 
           <Section title="2. Hébergement">
             <Text>
-              L&apos;application est hébergée par :<br />
-              <strong>Vercel Inc.</strong> — 340 S Lemon Ave #4133, Walnut, CA 91789, États-Unis<br />
-              Site : <Link href="https://vercel.com" color="brand.solid" target="_blank" rel="noopener noreferrer">vercel.com</Link>
+              L&apos;application et la base de données sont hébergées en France par :<br />
+              <strong>OVH SAS</strong> — 2 rue Kellermann, 59100 Roubaix, France<br />
+              Site : <Link href="https://www.ovhcloud.com" color="brand.solid" target="_blank" rel="noopener noreferrer">ovhcloud.com</Link>
             </Text>
             <Text>
-              Les données sont stockées par :<br />
-              <strong>Supabase Inc.</strong> — 970 Toa Payoh North #07-04, Singapore 318992<br />
-              Infrastructure : Amazon Web Services (région eu-west).<br />
-              Site : <Link href="https://supabase.com" color="brand.solid" target="_blank" rel="noopener noreferrer">supabase.com</Link>
+              La pile applicative s&apos;appuie sur <strong>Supabase</strong> (PostgreSQL, Auth, Storage,
+              Edge Functions) déployé en auto-hébergement sur le VPS OVH ci-dessus. Aucune donnée
+              n&apos;est transférée vers les serveurs cloud de Supabase.
             </Text>
           </Section>
 
@@ -71,7 +70,7 @@ export default function LegalPage() {
               à protéger vos données personnelles.
             </Text>
             <Box as="ul" pl={5} listStyleType="disc">
-              <Box as="li"><strong>Responsable du traitement :</strong> Vincent Zepharren</Box>
+              <Box as="li"><strong>Responsable du traitement :</strong> l&apos;équipe Unilien</Box>
               <Box as="li"><strong>Finalité :</strong> gestion des interventions, plannings, suivi des heures et communication entre employeurs particuliers, employés et auxiliaires de vie</Box>
               <Box as="li"><strong>Base légale :</strong> exécution du contrat (article 6.1.b RGPD) et consentement explicite pour les données de santé (article 9.2.a RGPD)</Box>
               <Box as="li"><strong>Durée de conservation :</strong> les données sont conservées pendant la durée de la relation contractuelle, puis supprimées dans un délai de 12 mois après clôture du compte</Box>

--- a/src/pages/LegalPage.tsx
+++ b/src/pages/LegalPage.tsx
@@ -46,7 +46,7 @@ export default function LegalPage() {
             </Text>
             <Text>
               Responsable de la publication : Vincent Zepharren<br />
-              Contact : <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>
+              Contact : <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>
             </Text>
           </Section>
 
@@ -109,7 +109,7 @@ export default function LegalPage() {
             </Box>
             <Text>
               Pour exercer ces droits, contactez-nous à{' '}
-              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+              <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>.
               Nous répondrons dans un délai de 30 jours.
             </Text>
             <Text>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -55,7 +55,7 @@ export default function PrivacyPage() {
           <Section title="1. Responsable du traitement">
             <Text>
               Le responsable du traitement des données est Vincent Zepharren, éditeur du Service.<br />
-              Contact : <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>
+              Contact : <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>
             </Text>
             <Text>
               <em>
@@ -135,7 +135,7 @@ export default function PrivacyPage() {
             </Box>
             <Text>
               Pour exercer ces droits, contactez-nous à{' '}
-              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+              <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>.
               Nous répondrons dans un délai d&apos;un mois maximum.
             </Text>
             <Text>
@@ -200,7 +200,7 @@ export default function PrivacyPage() {
           <Section title="11. Contact">
             <Text>
               Pour toute question relative à cette politique ou à vos données personnelles :{' '}
-              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>
+              <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>
             </Text>
           </Section>
 

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -54,7 +54,7 @@ export default function PrivacyPage() {
 
           <Section title="1. Responsable du traitement">
             <Text>
-              Le responsable du traitement des données est Vincent Zepharren, éditeur du Service.<br />
+              Le responsable du traitement des données est l&apos;équipe Unilien, éditrice du Service.<br />
               Contact : <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>
             </Text>
             <Text>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -1,0 +1,211 @@
+import { Link as RouterLink } from 'react-router-dom'
+import { Box, Container, Flex, Stack, Text, Link } from '@chakra-ui/react'
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Text fontSize="lg" fontWeight="700" color="text.default" mb={3}>
+        {title}
+      </Text>
+      <Stack gap={3} fontSize="sm" color="text.inactive" lineHeight="1.8">
+        {children}
+      </Stack>
+    </Box>
+  )
+}
+
+export default function PrivacyPage() {
+  return (
+    <Box minH="100vh" bg="bg.page">
+      {/* Header */}
+      <Box bg="bg.surface" borderBottomWidth="1px" borderColor="border.default" py={6}>
+        <Container maxW="800px">
+          <Flex align="center" gap={3} mb={2}>
+            <Link as={RouterLink} to="/" fontSize="sm" color="brand.solid" fontWeight="600" _hover={{ textDecoration: 'underline' }}>
+              ← Retour
+            </Link>
+          </Flex>
+          <Text fontSize="2xl" fontWeight="800" color="text.default">
+            Politique de confidentialité
+          </Text>
+          <Text fontSize="sm" color="text.inactive" mt={1}>
+            Dernière mise à jour : avril 2026 — brouillon, projet en développement
+          </Text>
+        </Container>
+      </Box>
+
+      {/* Content */}
+      <Container maxW="800px" py={8}>
+        <Stack gap={8}>
+
+          <Section title="Préambule">
+            <Text>
+              La présente politique de confidentialité décrit la manière dont <strong>Unilien</strong>{' '}
+              (ci-après « le Service ») collecte, utilise et protège les données personnelles de ses
+              utilisateurs, conformément au Règlement Général sur la Protection des Données
+              (UE 2016/679, ci-après « RGPD ») et à la loi Informatique et Libertés du 6 janvier 1978
+              modifiée.
+            </Text>
+            <Text>
+              Pour les coordonnées de l&apos;éditeur et l&apos;hébergement, voir les{' '}
+              <Link as={RouterLink} to="/mentions-legales" color="brand.solid">mentions légales</Link>.
+            </Text>
+          </Section>
+
+          <Section title="1. Responsable du traitement">
+            <Text>
+              Le responsable du traitement des données est Vincent Zepharren, éditeur du Service.<br />
+              Contact : <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>
+            </Text>
+            <Text>
+              <em>
+                Compte tenu du caractère personnel et expérimental du projet, aucun délégué à la
+                protection des données (DPO) n&apos;est désigné. L&apos;éditeur assure directement
+                cette fonction.
+              </em>
+            </Text>
+          </Section>
+
+          <Section title="2. Données collectées">
+            <Text>Le Service collecte les catégories de données suivantes :</Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li"><strong>Données d&apos;identification :</strong> nom, prénom, adresse email, numéro de téléphone (facultatif)</Box>
+              <Box as="li"><strong>Données de profil :</strong> rôle (employeur / employé / aidant), avatar (facultatif), adresse postale</Box>
+              <Box as="li"><strong>Données contractuelles :</strong> contrats de travail, planning des interventions, heures travaillées, congés, absences</Box>
+              <Box as="li"><strong>Données de communication :</strong> messages échangés via le cahier de liaison</Box>
+              <Box as="li"><strong>Données techniques :</strong> logs d&apos;accès, adresse IP (uniquement pour la sécurité), préférences UI</Box>
+              <Box as="li"><strong>Données de santé (sensibles, art. 9 RGPD) :</strong> type de handicap, besoins spécifiques, informations PCH — uniquement avec consentement explicite</Box>
+            </Box>
+          </Section>
+
+          <Section title="3. Finalités et bases légales">
+            <Text>Vos données sont traitées pour les finalités suivantes :</Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li"><strong>Gestion du compte et fourniture du Service</strong> — base légale : exécution du contrat (art. 6.1.b RGPD)</Box>
+              <Box as="li"><strong>Gestion des interventions, plannings et paie</strong> — base légale : exécution du contrat (art. 6.1.b RGPD)</Box>
+              <Box as="li"><strong>Communication entre utilisateurs liés</strong> — base légale : intérêt légitime (art. 6.1.f RGPD)</Box>
+              <Box as="li"><strong>Sécurité et prévention des abus</strong> — base légale : intérêt légitime (art. 6.1.f RGPD)</Box>
+              <Box as="li"><strong>Notifications email</strong> — base légale : exécution du contrat et consentement (art. 6.1.a et 6.1.b RGPD)</Box>
+              <Box as="li"><strong>Données de santé</strong> — base légale : consentement explicite (art. 9.2.a RGPD)</Box>
+            </Box>
+          </Section>
+
+          <Section title="4. Destinataires et sous-traitants">
+            <Text>
+              Vos données ne sont <strong>jamais vendues ni partagées</strong> avec des tiers à des
+              fins commerciales. Elles sont accessibles :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">À vous-même, depuis votre compte</Box>
+              <Box as="li">Aux utilisateurs avec lesquels vous êtes liés (employeur ↔ employé ↔ aidant), dans la limite de leurs droits définis par les politiques RLS</Box>
+              <Box as="li">À l&apos;éditeur du Service, pour les besoins de support et maintenance, uniquement sur demande ou en cas d&apos;incident</Box>
+            </Box>
+            <Text>Sous-traitants techniques :</Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li"><strong>OVH</strong> (hébergement VPS, France) — infrastructure</Box>
+              <Box as="li"><strong>Resend</strong> (envoi des emails transactionnels) — données traitées : adresse email, contenu de la notification</Box>
+            </Box>
+          </Section>
+
+          <Section title="5. Durée de conservation">
+            <Text>
+              Vos données sont conservées pendant la durée d&apos;utilisation du Service. À la
+              suppression du compte :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">Les données personnelles et métier sont <strong>supprimées immédiatement</strong> de la base de production</Box>
+              <Box as="li">Les sauvegardes contenant ces données sont conservées au maximum 30 jours, puis effacées par roulement</Box>
+              <Box as="li">Les logs techniques anonymisés peuvent être conservés jusqu&apos;à 12 mois pour des raisons de sécurité</Box>
+              <Box as="li">Les obligations légales (comptabilité, paie) peuvent imposer une conservation plus longue de certains documents</Box>
+            </Box>
+          </Section>
+
+          <Section title="6. Vos droits">
+            <Text>
+              Conformément au RGPD (articles 15 à 22), vous disposez des droits suivants :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li"><strong>Droit d&apos;accès</strong> — obtenir une copie de vos données (Paramètres → Données → Exporter)</Box>
+              <Box as="li"><strong>Droit de rectification</strong> — modifier vos informations depuis votre profil</Box>
+              <Box as="li"><strong>Droit à l&apos;effacement</strong> — supprimer votre compte (Paramètres → Zone de danger)</Box>
+              <Box as="li"><strong>Droit à la portabilité</strong> — exporter vos données aux formats JSON ou CSV</Box>
+              <Box as="li"><strong>Droit d&apos;opposition</strong> — vous opposer à un traitement fondé sur l&apos;intérêt légitime</Box>
+              <Box as="li"><strong>Droit à la limitation</strong> — demander la suspension temporaire d&apos;un traitement</Box>
+              <Box as="li"><strong>Droit de retirer votre consentement</strong> — à tout moment, sans affecter la licéité des traitements antérieurs</Box>
+            </Box>
+            <Text>
+              Pour exercer ces droits, contactez-nous à{' '}
+              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+              Nous répondrons dans un délai d&apos;un mois maximum.
+            </Text>
+            <Text>
+              Vous pouvez également introduire une réclamation auprès de la{' '}
+              <Link href="https://www.cnil.fr" color="brand.solid" target="_blank" rel="noopener noreferrer">CNIL</Link>{' '}
+              (Commission Nationale de l&apos;Informatique et des Libertés).
+            </Text>
+          </Section>
+
+          <Section title="7. Données de santé">
+            <Text>
+              Le Service permet la saisie de données de santé, considérées comme sensibles au sens
+              de l&apos;article 9 du RGPD. Ces données font l&apos;objet de mesures de protection
+              renforcées :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">Collecte uniquement après <strong>consentement explicite</strong> de l&apos;utilisateur</Box>
+              <Box as="li">Isolation dans une table dédiée avec contrôles d&apos;accès stricts (RLS)</Box>
+              <Box as="li">Audit des accès enregistré pour traçabilité</Box>
+              <Box as="li">Transit uniquement via connexions chiffrées HTTPS/TLS</Box>
+              <Box as="li">Aucun partage avec des tiers</Box>
+            </Box>
+            <Text>
+              <em>
+                Note : l&apos;hébergement actuel n&apos;est pas certifié HDS (Hébergeur de Données
+                de Santé). Les données de santé saisies le sont sous la responsabilité de l&apos;utilisateur.
+              </em>
+            </Text>
+          </Section>
+
+          <Section title="8. Sécurité">
+            <Text>
+              Nous mettons en œuvre les mesures techniques et organisationnelles suivantes :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">Chiffrement TLS pour toutes les communications</Box>
+              <Box as="li">Authentification forte avec mots de passe robustes et 2FA optionnelle (TOTP)</Box>
+              <Box as="li">Contrôle d&apos;accès basé sur les rôles (RBAC) et politiques RLS</Box>
+              <Box as="li">Sauvegardes régulières chiffrées</Box>
+              <Box as="li">Mises à jour de sécurité appliquées rapidement</Box>
+              <Box as="li">Aucun cookie de tracking ou publicitaire</Box>
+            </Box>
+          </Section>
+
+          <Section title="9. Cookies et stockage local">
+            <Text>
+              Unilien utilise uniquement des <strong>cookies strictement nécessaires</strong> au
+              fonctionnement (session, préférences). Aucun cookie publicitaire ou analytique n&apos;est
+              déposé. Le détail des cookies est disponible dans les{' '}
+              <Link as={RouterLink} to="/mentions-legales" color="brand.solid">mentions légales</Link>.
+            </Text>
+          </Section>
+
+          <Section title="10. Modifications">
+            <Text>
+              La présente politique peut être modifiée pour refléter les évolutions du Service ou
+              de la réglementation. Les utilisateurs seront informés des modifications substantielles
+              par email. La date de dernière mise à jour est indiquée en haut de cette page.
+            </Text>
+          </Section>
+
+          <Section title="11. Contact">
+            <Text>
+              Pour toute question relative à cette politique ou à vos données personnelles :{' '}
+              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>
+            </Text>
+          </Section>
+
+        </Stack>
+      </Container>
+    </Box>
+  )
+}

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -117,7 +117,7 @@ export default function TermsPage() {
               <strong>Note :</strong> Unilien est actuellement en phase de développement.
               Des évolutions, corrections et changements de fonctionnalités peuvent intervenir
               régulièrement. Les utilisateurs sont invités à signaler tout dysfonctionnement à{' '}
-              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+              <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>.
             </Text>
           </Section>
 
@@ -178,7 +178,7 @@ export default function TermsPage() {
           <Section title="11. Contact">
             <Text>
               Pour toute question relative aux présentes CGU, vous pouvez nous contacter à{' '}
-              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+              <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>.
             </Text>
           </Section>
 

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,0 +1,189 @@
+import { Link as RouterLink } from 'react-router-dom'
+import { Box, Container, Flex, Stack, Text, Link } from '@chakra-ui/react'
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Text fontSize="lg" fontWeight="700" color="text.default" mb={3}>
+        {title}
+      </Text>
+      <Stack gap={3} fontSize="sm" color="text.inactive" lineHeight="1.8">
+        {children}
+      </Stack>
+    </Box>
+  )
+}
+
+export default function TermsPage() {
+  return (
+    <Box minH="100vh" bg="bg.page">
+      {/* Header */}
+      <Box bg="bg.surface" borderBottomWidth="1px" borderColor="border.default" py={6}>
+        <Container maxW="800px">
+          <Flex align="center" gap={3} mb={2}>
+            <Link as={RouterLink} to="/" fontSize="sm" color="brand.solid" fontWeight="600" _hover={{ textDecoration: 'underline' }}>
+              ← Retour
+            </Link>
+          </Flex>
+          <Text fontSize="2xl" fontWeight="800" color="text.default">
+            Conditions d&apos;utilisation
+          </Text>
+          <Text fontSize="sm" color="text.inactive" mt={1}>
+            Dernière mise à jour : avril 2026 — brouillon, projet en développement
+          </Text>
+        </Container>
+      </Box>
+
+      {/* Content */}
+      <Container maxW="800px" py={8}>
+        <Stack gap={8}>
+
+          <Section title="1. Objet">
+            <Text>
+              Les présentes Conditions Générales d&apos;Utilisation (ci-après « CGU ») ont pour objet
+              de définir les modalités d&apos;accès et d&apos;utilisation du service <strong>Unilien</strong>{' '}
+              (ci-après « le Service »), application web de gestion de soins pour personnes en
+              situation de handicap.
+            </Text>
+            <Text>
+              Le Service est édité par Vincent Zepharren et accessible à l&apos;adresse{' '}
+              <Link href="https://unilien.app" color="brand.solid">unilien.app</Link>.
+              Voir les <Link as={RouterLink} to="/mentions-legales" color="brand.solid">mentions légales</Link>{' '}
+              pour les coordonnées complètes de l&apos;éditeur.
+            </Text>
+          </Section>
+
+          <Section title="2. Acceptation des CGU">
+            <Text>
+              L&apos;utilisation du Service implique l&apos;acceptation pleine et entière des présentes CGU.
+              L&apos;utilisateur reconnaît en avoir pris connaissance lors de la création de son compte
+              et s&apos;engage à les respecter.
+            </Text>
+            <Text>
+              L&apos;éditeur se réserve le droit de modifier les CGU à tout moment. Les utilisateurs
+              seront informés des modifications substantielles. La poursuite de l&apos;utilisation du
+              Service après notification vaut acceptation des nouvelles conditions.
+            </Text>
+          </Section>
+
+          <Section title="3. Accès au Service">
+            <Text>
+              Le Service est destiné aux trois profils d&apos;utilisateurs suivants :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li"><strong>Employeurs particuliers</strong> — personnes en situation de handicap ou leur représentant légal, employant un ou plusieurs auxiliaires de vie</Box>
+              <Box as="li"><strong>Auxiliaires de vie / employés</strong> — personnel intervenant au domicile, dans le cadre d&apos;un contrat de travail régi par la convention collective IDCC 3239</Box>
+              <Box as="li"><strong>Aidants familiaux</strong> — proches autorisés à consulter ou gérer le planning au nom de l&apos;employeur</Box>
+            </Box>
+            <Text>
+              La création de compte est gratuite et nécessite la fourniture d&apos;une adresse email
+              valide ainsi que d&apos;informations exactes (nom, prénom, rôle).
+            </Text>
+          </Section>
+
+          <Section title="4. Engagements de l'utilisateur">
+            <Text>L&apos;utilisateur s&apos;engage à :</Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">Fournir des informations exactes, complètes et à jour</Box>
+              <Box as="li">Préserver la confidentialité de ses identifiants de connexion</Box>
+              <Box as="li">Ne pas utiliser le Service à des fins illicites, frauduleuses ou contraires à l&apos;ordre public</Box>
+              <Box as="li">Respecter les droits et la vie privée des autres utilisateurs</Box>
+              <Box as="li">Ne pas tenter de contourner les mesures de sécurité ni d&apos;accéder aux données d&apos;autres utilisateurs sans autorisation</Box>
+              <Box as="li">Recueillir le consentement explicite des personnes concernées avant la saisie de leurs données personnelles</Box>
+            </Box>
+          </Section>
+
+          <Section title="5. Données saisies par l'utilisateur">
+            <Text>
+              L&apos;utilisateur reste responsable des données qu&apos;il saisit dans le Service, notamment
+              concernant les tiers (auxiliaires, aidants, données de santé). Il s&apos;assure d&apos;avoir
+              recueilli les consentements nécessaires.
+            </Text>
+            <Text>
+              Le traitement des données personnelles est détaillé dans la{' '}
+              <Link as={RouterLink} to="/politique-confidentialite" color="brand.solid">
+                politique de confidentialité
+              </Link>.
+            </Text>
+          </Section>
+
+          <Section title="6. Disponibilité du Service">
+            <Text>
+              Le Service est accessible 24h/24 et 7j/7, sous réserve d&apos;interruptions pour maintenance,
+              de pannes éventuelles ou de cas de force majeure. L&apos;éditeur ne saurait être tenu
+              responsable des dommages liés à une indisponibilité temporaire.
+            </Text>
+            <Text>
+              <strong>Note :</strong> Unilien est actuellement en phase de développement.
+              Des évolutions, corrections et changements de fonctionnalités peuvent intervenir
+              régulièrement. Les utilisateurs sont invités à signaler tout dysfonctionnement à{' '}
+              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+            </Text>
+          </Section>
+
+          <Section title="7. Propriété intellectuelle">
+            <Text>
+              L&apos;ensemble des éléments composant le Service (code source, design, marques, textes,
+              images, logos) est protégé par le droit de la propriété intellectuelle. Toute
+              reproduction, représentation ou exploitation sans autorisation préalable est interdite.
+            </Text>
+            <Text>
+              Les données saisies par l&apos;utilisateur lui appartiennent. Il en conserve la propriété
+              et peut les exporter ou les supprimer à tout moment depuis les Paramètres.
+            </Text>
+          </Section>
+
+          <Section title="8. Limitation de responsabilité">
+            <Text>
+              Le Service est fourni « en l&apos;état », sans garantie de fonctionnement parfait. L&apos;éditeur
+              s&apos;efforce de fournir un service fiable mais ne peut garantir une absence totale d&apos;erreurs.
+            </Text>
+            <Text>
+              L&apos;éditeur ne saurait être tenu responsable :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">Des dommages directs ou indirects résultant de l&apos;utilisation du Service</Box>
+              <Box as="li">Des erreurs ou inexactitudes dans les données saisies par les utilisateurs</Box>
+              <Box as="li">Des conséquences juridiques liées à un usage non conforme à la convention collective IDCC 3239 ou à la réglementation du travail</Box>
+              <Box as="li">Des pertes de données dues à un cas de force majeure ou à un usage incorrect</Box>
+            </Box>
+            <Text>
+              Les fonctionnalités d&apos;aide à la conformité (compliance, calcul de paie, génération
+              CESU) sont fournies à titre indicatif. L&apos;utilisateur reste seul responsable du respect
+              de ses obligations légales.
+            </Text>
+          </Section>
+
+          <Section title="9. Suspension et résiliation">
+            <Text>
+              L&apos;utilisateur peut supprimer son compte à tout moment depuis les Paramètres
+              (Zone de danger → Supprimer mon compte). Cette action est irréversible et entraîne
+              la suppression définitive de toutes ses données.
+            </Text>
+            <Text>
+              L&apos;éditeur se réserve le droit de suspendre ou résilier l&apos;accès au Service en cas
+              de manquement grave aux présentes CGU, après notification préalable lorsque cela est
+              possible.
+            </Text>
+          </Section>
+
+          <Section title="10. Droit applicable et juridiction">
+            <Text>
+              Les présentes CGU sont régies par le droit français. Tout litige relatif à
+              l&apos;interprétation ou à l&apos;exécution des CGU sera soumis aux tribunaux français
+              compétents, après tentative de résolution amiable.
+            </Text>
+          </Section>
+
+          <Section title="11. Contact">
+            <Text>
+              Pour toute question relative aux présentes CGU, vous pouvez nous contacter à{' '}
+              <Link href="mailto:contact@unilien.fr" color="brand.solid">contact@unilien.fr</Link>.
+            </Text>
+          </Section>
+
+        </Stack>
+      </Container>
+    </Box>
+  )
+}

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -46,7 +46,7 @@ export default function TermsPage() {
               situation de handicap.
             </Text>
             <Text>
-              Le Service est édité par Vincent Zepharren et accessible à l&apos;adresse{' '}
+              Le Service est édité par l&apos;équipe Unilien et accessible à l&apos;adresse{' '}
               <Link href="https://unilien.app" color="brand.solid">unilien.app</Link>.
               Voir les <Link as={RouterLink} to="/mentions-legales" color="brand.solid">mentions légales</Link>{' '}
               pour les coordonnées complètes de l&apos;éditeur.

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -45,7 +45,7 @@ serve(async (req) => {
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     const vapidPublicKey = Deno.env.get('VAPID_PUBLIC_KEY')
     const vapidPrivateKey = Deno.env.get('VAPID_PRIVATE_KEY')
-    const vapidSubject = Deno.env.get('VAPID_SUBJECT') || 'mailto:contact@unilien.fr'
+    const vapidSubject = Deno.env.get('VAPID_SUBJECT') || 'mailto:contact@unilien.app'
 
     // Vérification interne du JWT : valider que l'appelant est authentifié
     const authHeader = req.headers.get('authorization') || ''


### PR DESCRIPTION
## Summary
Crée les 2 pages légales manquantes (CGU + Politique de confidentialité) et fait le ménage sur les références obsolètes (`unilien.fr`, hébergement Vercel/Supabase Cloud, nom personnel).

### Changements

**Nouvelles pages** (`feat/legal-pages` → 73edced) :
- `/conditions-utilisation` (`TermsPage.tsx`) — 11 sections, brouillon adapté au contexte (IDCC 3239, projet en développement)
- `/politique-confidentialite` (`PrivacyPage.tsx`) — RGPD art. 13/14, sous-traitants OVH + Resend, données de santé art. 9

**Câblage** :
- Checkbox signup → liens fonctionnels (`target="_blank"` pour préserver le formulaire)
- Footer HomePage : 4 liens (Mentions légales / Privacy / CGU / RGPD) tous fonctionnels

**Sweep `unilien.fr` → `unilien.app`** :
- Code : `send-push-notification` (VAPID fallback), `robots.txt` (sitemap), `Contact / Legal / Privacy / Terms` pages
- Docs : `ANALYTICS_IMPLEMENTATION`, `SECURITY_ANALYSIS`, `SECURITY_PENTEST_REPORT`, `SEO_LINKS_ANALYSIS`, `SUPABASE_AUTH_REDIRECT_URLS`, `SUPABASE_SELFHOST_OVH`, `TODO_NOTIFICATIONS`

**Anonymisation + hébergement** (b1cbc45) :
- Publisher nommé → « l'équipe Unilien » dans LegalPage / TermsPage / PrivacyPage
- LegalPage hébergement : Vercel + Supabase Cloud (Singapore/AWS) → **OVH France self-host** (cohérent avec la migration du 21/04)

## Test plan
- [x] Inscription → cliquer "Conditions d'utilisation" → page s'ouvre dans un nouvel onglet
- [x] Inscription → cliquer "Politique de confidentialité" → idem
- [x] HomePage footer → 4 liens cliquables et amenant aux bonnes pages
- [x] Mentions légales : section Hébergement mentionne OVH (pas Vercel)
- [x] `grep -rn "unilien.fr"` retourne vide hors `node_modules` / `coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)