### PR TITLE
feat(planning): defer shopping list to later with reminder pastille

### DIFF
--- a/src/components/planning/MonthView.tsx
+++ b/src/components/planning/MonthView.tsx
@@ -17,6 +17,7 @@ import {
   ABSENCE_STATUS_COLORS as absenceStatusColors,
   ABSENCE_TYPE_LABELS as absenceTypeLabels,
 } from '@/lib/constants/statusMaps'
+import { getShoppingState } from '@/lib/constants/taskDefaults'
 
 interface MonthViewProps {
   currentDate: Date
@@ -198,8 +199,12 @@ interface MonthShiftCardProps {
 }
 
 function MonthShiftCard({ shift, isContinuation, onClick }: MonthShiftCardProps) {
+  const shopping = getShoppingState(shift.tasks)
+  const showShoppingReminder = shopping.hasCoursesTask && shopping.itemCount === 0 && !isContinuation
+
   return (
     <Box
+      position="relative"
       px={1}
       py={0.5}
       bg={`${statusColors[shift.status]}.100`}
@@ -220,6 +225,19 @@ function MonthShiftCard({ shift, isContinuation, onClick }: MonthShiftCardProps)
         }
       }}
     >
+      {showShoppingReminder && (
+        <Box
+          position="absolute"
+          top="2px"
+          right="2px"
+          w="6px"
+          h="6px"
+          borderRadius="full"
+          bg="orange.400"
+          title="Liste de courses à compléter"
+          aria-label="Liste de courses à compléter"
+        />
+      )}
       <Text fontSize="2xs" fontWeight="medium" color={`${statusColors[shift.status]}.700`} lineClamp={1}>
         {isContinuation ? `...${shift.endTime}` : `${shift.startTime}-${shift.endTime}`}
       </Text>

--- a/src/components/planning/ShiftDetailView.tsx
+++ b/src/components/planning/ShiftDetailView.tsx
@@ -13,7 +13,7 @@ import { PresenceResponsibleNightSection } from './PresenceResponsibleNightSecti
 import { NightActionToggle } from './NightActionToggle'
 import { Guard24hRecap } from './Guard24hRecap'
 import { sanitizeText } from '@/lib/sanitize'
-import { COURSES_PREFIX, parseShoppingItemString } from '@/lib/constants/taskDefaults'
+import { COURSES_PREFIX, parseShoppingItemString, getShoppingState } from '@/lib/constants/taskDefaults'
 import { SHIFT_TYPE_LABELS } from '@/lib/constants/statusMaps'
 import type { Shift, Contract } from '@/types'
 
@@ -173,13 +173,30 @@ export function ShiftDetailView({
       {shift.tasks.length > 0 && (
         <DetailRow label="Tâches">
           <Stack gap={1}>
-            {shift.tasks.filter(t => !t.startsWith(COURSES_PREFIX)).map((task, index) => (
+            {shift.tasks.filter(t => !t.startsWith(COURSES_PREFIX)).map((task, index) => {
+              const isCourses = task === 'Courses'
+              const shoppingCount = isCourses ? getShoppingState(shift.tasks).itemCount : 0
+              return (
               <Box key={index}>
                 <Flex align="center" gap={2}>
                   <Box w="5px" h="5px" borderRadius="full" bg="brand.500" flexShrink={0} />
                   <Text fontSize="14px">{sanitizeText(task)}</Text>
+                  {isCourses && (
+                    <Text
+                      as="span"
+                      fontSize="12px"
+                      fontWeight="600"
+                      color={shoppingCount === 0 ? 'orange.600' : 'brand.500'}
+                      bg={shoppingCount === 0 ? 'orange.50' : 'brand.subtle'}
+                      px={2}
+                      py="2px"
+                      borderRadius="full"
+                    >
+                      🛒 {shoppingCount === 0 ? 'à compléter' : `${shoppingCount} article${shoppingCount > 1 ? 's' : ''}`}
+                    </Text>
+                  )}
                 </Flex>
-                {task === 'Courses' && (
+                {isCourses && (
                   <Stack gap={0} ml={5} mt={1} pl={3} borderLeftWidth="2px" borderColor="brand.200">
                     {shift.tasks
                       .filter(t => t.startsWith(COURSES_PREFIX))
@@ -212,7 +229,8 @@ export function ShiftDetailView({
                   </Stack>
                 )}
               </Box>
-            ))}
+              )
+            })}
           </Stack>
         </DetailRow>
       )}

--- a/src/components/planning/TaskSelector.tsx
+++ b/src/components/planning/TaskSelector.tsx
@@ -587,6 +587,12 @@ export function TaskSelector({ value, onChange, prefillFromSettings = false }: T
                       >+</Box>
                     </Flex>
                   </Box>
+
+                  {shoppingCount === 0 && (
+                    <Text fontSize="xs" color="text.muted" fontStyle="italic" px={2} mt={2}>
+                      💡 Pas obligatoire maintenant — vous pourrez compléter la liste plus tard depuis le détail de l&apos;intervention.
+                    </Text>
+                  )}
                 </Box>
               )}
             </Box>

--- a/src/components/planning/TaskSelector.tsx
+++ b/src/components/planning/TaskSelector.tsx
@@ -439,6 +439,12 @@ export function TaskSelector({ value, onChange, prefillFromSettings = false }: T
                     )}
                   </Flex>
 
+                  {shoppingCount === 0 && (
+                    <Text fontSize="xs" color="text.muted" fontStyle="italic" px={2} mb={2}>
+                      💡 Pas obligatoire maintenant — vous pourrez compléter la liste plus tard depuis le détail de l&apos;intervention.
+                    </Text>
+                  )}
+
                   <Stack gap={0}>
                     {allShoppingItems.length === 0 && (
                       <Text fontSize="xs" color="text.muted" px={6} py={1}>
@@ -587,12 +593,6 @@ export function TaskSelector({ value, onChange, prefillFromSettings = false }: T
                       >+</Box>
                     </Flex>
                   </Box>
-
-                  {shoppingCount === 0 && (
-                    <Text fontSize="xs" color="text.muted" fontStyle="italic" px={2} mt={2}>
-                      💡 Pas obligatoire maintenant — vous pourrez compléter la liste plus tard depuis le détail de l&apos;intervention.
-                    </Text>
-                  )}
                 </Box>
               )}
             </Box>

--- a/src/components/planning/WeekView.tsx
+++ b/src/components/planning/WeekView.tsx
@@ -6,6 +6,7 @@ import type { Shift, UserRole, Absence } from '@/types'
 import {
   ABSENCE_TYPE_LABELS as absenceTypeLabels,
 } from '@/lib/constants/statusMaps'
+import { getShoppingState } from '@/lib/constants/taskDefaults'
 
 // ── Config ──
 
@@ -299,6 +300,8 @@ export function WeekView({ weekStart, shifts, absences = [], userRole, onShiftCl
               {dayShifts.map(({ shift, isContinuation }) => {
                 const style = getBlockStyle(shift.startTime, shift.endTime, isContinuation)
                 const colors = SHIFT_BG[shift.shiftType] ?? SHIFT_BG.effective
+                const shopping = getShoppingState(shift.tasks)
+                const showShoppingReminder = shopping.hasCoursesTask && shopping.itemCount === 0 && !isContinuation
 
                 return (
                   <Box
@@ -328,6 +331,19 @@ export function WeekView({ weekStart, shifts, absences = [], userRole, onShiftCl
                       if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onShiftClick?.(shift) }
                     }}
                   >
+                    {showShoppingReminder && (
+                      <Box
+                        position="absolute"
+                        top="3px"
+                        right="3px"
+                        w="8px"
+                        h="8px"
+                        borderRadius="full"
+                        bg="orange.400"
+                        title="Liste de courses à compléter"
+                        aria-label="Liste de courses à compléter"
+                      />
+                    )}
                     {isEmployer && shift.employeeName && !isContinuation && (
                       <Text fontSize="11px" fontWeight="700" color="text.default" lineClamp={1}>
                         {shift.employeeName}

--- a/src/lib/constants/taskDefaults.ts
+++ b/src/lib/constants/taskDefaults.ts
@@ -111,3 +111,21 @@ export function parseShoppingItemString(str: string): ShoppingItem {
 export function shoppingItemKey(item: ShoppingItem): string {
   return `${item.name}::${item.brand}`
 }
+
+/**
+ * Indique si la tâche "Courses" est cochée et combien d'articles ont été saisis.
+ * Utile pour afficher des rappels (pastille calendrier) ou un compteur (détail shift).
+ */
+export function getShoppingState(tasks: string[] | null | undefined): {
+  hasCoursesTask: boolean
+  itemCount: number
+} {
+  if (!tasks || tasks.length === 0) return { hasCoursesTask: false, itemCount: 0 }
+  let hasCoursesTask = false
+  let itemCount = 0
+  for (const t of tasks) {
+    if (t === 'Courses') hasCoursesTask = true
+    else if (t.startsWith(COURSES_PREFIX)) itemCount++
+  }
+  return { hasCoursesTask, itemCount }
+}


### PR DESCRIPTION
## Summary
Suite au feedback John 16/04 : remplir la liste de courses pendant la création d'une intervention est trop tôt — l'employeur ne sait pas encore ce qu'il manquera. Le formulaire pousse à remplir tout de suite, friction UX.

### Changements

**`TaskSelector`** — Quand la tâche "Courses" est cochée mais la liste vide, un message hint apparaît en haut du bloc shopping :
> 💡 Pas obligatoire maintenant — vous pourrez compléter la liste plus tard depuis le détail de l'intervention.

**Calendrier (`WeekView`, `MonthView`)** — Sur les shifts avec "Courses" cochée + liste vide, une pastille orange discrète (8px / 6px) apparaît en haut à droite de la cellule pour rappeler de compléter avant l'arrivée de l'auxi. Disparaît dès qu'au moins un article est saisi.

**`ShiftDetailView`** — Badge à côté du label "Courses" :
- `🛒 à compléter` (orange) quand vide → rappel pour l'employeur
- `🛒 N articles` (brand) quand remplie → info pour l'auxi qui consulte

**Helper** : `getShoppingState(tasks)` factorise la logique de comptage utilisée dans 3 vues.

## Test plan
- [ ] Créer un shift, cocher "Courses" sans rien ajouter → message hint visible en haut du bloc
- [ ] Sauvegarder ce shift → pastille orange sur la cellule WeekView et MonthView
- [ ] Ouvrir le shift en consultation → badge "🛒 à compléter" à côté de "Courses"
- [ ] Ajouter un article via le détail → pastille calendrier disparaît, badge passe en `🛒 1 article`
- [ ] Tests passent (108 ✓ ciblés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)