### PR TITLE
feat(planning): show presence mix warning in shift view mode

### DIFF
--- a/src/components/planning/PresenceMixedWarning.tsx
+++ b/src/components/planning/PresenceMixedWarning.tsx
@@ -4,6 +4,7 @@ import { formatHoursCompact } from '@/lib/formatHours'
 interface PresenceMixedWarningProps {
   dayHours: number
   nightHours: number
+  mode?: 'edit' | 'view'
 }
 
 /**
@@ -11,8 +12,11 @@ interface PresenceMixedWarningProps {
  * le jour et la nuit. Les régimes de paie sont radicalement différents
  * (jour : équivalent ×2/3 — nuit : indemnité ×1/4, Art. 137 & 148 IDCC 3239),
  * donc un seul type ne peut refléter fidèlement la rémunération.
+ *
+ * - `edit` (défaut) : conseil de créer deux interventions ou une garde 24h.
+ * - `view` : conseil de modifier l'intervention existante pour la diviser.
  */
-export function PresenceMixedWarning({ dayHours, nightHours }: PresenceMixedWarningProps) {
+export function PresenceMixedWarning({ dayHours, nightHours, mode = 'edit' }: PresenceMixedWarningProps) {
   return (
     <Box
       p={3}
@@ -29,9 +33,19 @@ export function PresenceMixedWarning({ dayHours, nightHours }: PresenceMixedWarn
         Les régimes de paie diffèrent (×2/3 jour vs ×1/4 nuit, Art. 137 & 148 IDCC 3239).
       </Text>
       <Text fontSize="xs" color="warm.700" mt={2}>
-        Pour un calcul juste, créez plutôt <Text as="strong">deux interventions</Text>{' '}
-        (une jour, une nuit) ou utilisez une <Text as="strong">garde 24h</Text> qui
-        gère les segments jour/nuit automatiquement.
+        {mode === 'view' ? (
+          <>
+            <Text as="strong">Modifiez</Text> cette intervention pour la diviser
+            en deux régimes (jour + nuit), ou convertissez-la en{' '}
+            <Text as="strong">garde 24h</Text>.
+          </>
+        ) : (
+          <>
+            Pour un calcul juste, créez plutôt <Text as="strong">deux interventions</Text>{' '}
+            (une jour, une nuit) ou utilisez une <Text as="strong">garde 24h</Text> qui
+            gère les segments jour/nuit automatiquement.
+          </>
+        )}
       </Text>
     </Box>
   )

--- a/src/components/planning/ShiftDetailView.tsx
+++ b/src/components/planning/ShiftDetailView.tsx
@@ -10,6 +10,8 @@ import { PaySummary } from '@/components/compliance'
 import { formatHoursCompact } from '@/lib/formatHours'
 import { PresenceResponsibleDaySection } from './PresenceResponsibleDaySection'
 import { PresenceResponsibleNightSection } from './PresenceResponsibleNightSection'
+import { PresenceMixedWarning } from './PresenceMixedWarning'
+import { getPresenceMix } from '@/lib/presence/detectPresenceType'
 import { NightActionToggle } from './NightActionToggle'
 import { Guard24hRecap } from './Guard24hRecap'
 import { sanitizeText } from '@/lib/sanitize'
@@ -124,6 +126,20 @@ export function ShiftDetailView({
           />
         </Box>
       )}
+
+      {/* Avertissement présence à cheval jour/nuit */}
+      {(shift.shiftType === 'presence_day' || shift.shiftType === 'presence_night') && (() => {
+        const mix = getPresenceMix(shift.startTime, shift.endTime)
+        return mix.isMixed ? (
+          <Box py={3} borderBottomWidth="1px" borderColor="border.default">
+            <PresenceMixedWarning
+              dayHours={mix.dayHours}
+              nightHours={mix.nightHours}
+              mode="view"
+            />
+          </Box>
+        ) : null
+      })()}
 
       {/* Détail présence responsable JOUR */}
       {shift.shiftType === 'presence_day' && (


### PR DESCRIPTION
## Summary
Affiche l'avertissement « Présence à cheval entre jour et nuit » aussi en **mode lecture** (`ShiftDetailView`), pas seulement à la saisie/édition. Marie qui consulte un shift `presence_day` 18h–23h voit désormais que les 2h de nuit sont rémunérées au régime jour (×2/3) au lieu du régime nuit (×1/4).

### Changements
- `PresenceMixedWarning` : prop optionnelle `mode: 'edit' | 'view'` (défaut `edit`)
  - `edit` : conseil existant — créer 2 interventions ou une garde 24h
  - `view` : conseil adapté — modifier l'intervention existante pour la diviser
- `ShiftDetailView` : rend le warning au-dessus de la section Présence quand `getPresenceMix(...).isMixed` est vrai (pour `presence_day` ou `presence_night`)

## Test plan
- [x] Ouvrir une intervention `presence_day` 18h–23h en lecture → warning visible avec conseil de modification
- [x] Ouvrir une intervention `presence_day` 9h–17h en lecture → pas de warning
- [x] Ouvrir une intervention `presence_night` 22h–8h en lecture → pas de warning (homogène nuit)
- [x] Saisir une nouvelle présence à cheval → warning affiché avec conseil de création (mode `edit`, inchangé)
- [x] `npm run lint` (0 erreur)
- [x] `npm run test:run` (2266 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)