### PR TITLE
chore(planning): keep shift times when changing type in new shift modal

### DIFF
--- a/src/components/planning/NewShiftModal.tsx
+++ b/src/components/planning/NewShiftModal.tsx
@@ -277,14 +277,8 @@ export function NewShiftModal({
                       if (newType !== 'effective') {
                         setHasNightAction(false)
                       }
-                      if (newType === 'guard_24h') {
-                        // géré par useEffect du hook
-                      } else if (selected === 'presence') {
-                        // on garde les horaires courants (l'auto-détection s'en occupe)
-                      } else {
-                        setValue('startTime', '09:00')
-                        setValue('endTime', '12:00')
-                      }
+                      // Horaires conservés quel que soit le type choisi
+                      // (garde_24h : end_time auto à +24h via useEffect du hook)
                     }}
                   />
 


### PR DESCRIPTION
## Summary
Aligne le comportement de `NewShiftModal` sur celui de `ShiftEditForm` : changer le type d'intervention via le select ne réécrit plus les horaires saisis. Marie tape ses horaires une fois, indépendamment du type qu'elle choisit ensuite.

### Changements
- `NewShiftModal.tsx` : suppression du `else { setValue('startTime', '09:00'); setValue('endTime', '12:00') }` qui écrasait les horaires lors du passage à "Travail effectif" ou "Garde 24h"
- Commentaire ajouté pour rappeler que `garde_24h` gère son `end_time` à `+24h` via un autre `useEffect` du hook

### Pourquoi
- Comportement intuitif : changer un champ ne touche pas aux autres
- Symétrie avec `ShiftEditForm` (édition) qui ne reset jamais
- Cas réel : Marie tape 22h–6h en "Présence", change pour "Travail effectif" → elle veut corriger la classification, pas re-saisir ses horaires

## Test plan
- [x] Saisir 22h–6h, choisir "Présence responsable" → "Travail effectif" : horaires conservés
- [x] Saisir 14h–18h, choisir "Garde 24h" : heure de début conservée, heure de fin auto à +24h
- [x] Saisir 9h–12h en "Travail effectif" → "Présence responsable" : horaires conservés (déjà OK avant, vérifier non-régression)
- [x] `npm run lint` (0 erreur)
- [x] `npm run test:run` (2266 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)