### PR TITLE
fix(planning): preserve stored shift type on edit modal open

### DIFF
--- a/src/components/planning/ShiftEditForm.tsx
+++ b/src/components/planning/ShiftEditForm.tsx
@@ -4,7 +4,7 @@
  */
 
 import type React from 'react'
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { Box, Stack, Flex, Text, Textarea, Separator } from '@chakra-ui/react'
 import type { UseFormRegister, UseFormSetValue, FieldErrors } from 'react-hook-form'
 import { AccessibleInput, AccessibleSelect } from '@/components/ui'
@@ -113,10 +113,18 @@ export function ShiftEditForm({
     setValue('tasks', tasks.join('\n'))
   }, [setValue])
 
-  // Re-détecter presence_day / presence_night quand les horaires changent
+  // Re-détecter presence_day / presence_night quand l'utilisateur change les horaires.
+  // On skip le premier render pour respecter le type stocké en DB :
+  // un vieux shift `presence_day` (créé avant l'unification PR #289) ne doit pas
+  // basculer silencieusement à l'ouverture du modal d'édition.
+  const isInitialMount = useRef(true)
   useEffect(() => {
     if (!isPresenceType(shiftType)) return
     if (!watchedStartTime || !watchedEndTime) return
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
     const detected = detectPresenceType(watchedStartTime, watchedEndTime)
     if (detected !== shiftType) {
       onShiftTypeChange(detected)


### PR DESCRIPTION
## Summary
Empêche la re-bascule silencieuse `presence_day` ↔ `presence_night` à l'ouverture du modal d'édition. Un vieux shift créé avant l'unification (PR #289) où Marie avait choisi explicitement le type ne change plus tout seul à l'ouverture — son choix initial est respecté.

L'auto-détection reste active **après** un changement utilisateur des horaires : si Marie passe 9h-17h à 22h-6h, le type suit comme avant.

### Changements
- `ShiftEditForm.tsx` : `useRef(true)` qui skip le premier render du `useEffect` de re-détection
- Le useEffect ne déclenche `onShiftTypeChange` qu'après que l'utilisateur ait effectivement modifié les horaires

### Pourquoi
- **Principe du moindre étonnement** : on ne modifie pas un champ que l'utilisateur n'a pas touché
- Avant PR #289, Marie sélectionnait explicitement "présence jour" ou "présence nuit" — ces choix sont délibérés, pas des bugs à "réparer"
- Si Marie veut reclasser un vieux shift, elle peut le faire via le sélecteur de type

## Test plan
- [ ] Ouvrir un shift `presence_day` 22h–6h en édition → reste classé "présence jour" (avant : basculait silencieusement en "nuit")
- [ ] Ouvrir un shift `presence_night` 9h–17h en édition → reste classé "présence nuit"
- [ ] Modifier les horaires d'un shift `presence_day` 9h–17h pour 22h–6h → bascule auto en `presence_night` (comportement conservé)
- [ ] Modifier le type via le select → fonctionne normalement
- [x] `npm run lint` (0 erreur)
- [x] `npm run test:run` (2266 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)