### PR TITLE
refactor(planning): unify presence day/night into single filter option

### DIFF
--- a/src/components/planning/PlanningPage.tsx
+++ b/src/components/planning/PlanningPage.tsx
@@ -40,11 +40,11 @@ import {
   generatePlanningIcal,
   downloadExport,
 } from '@/lib/export'
-import type { Shift, Absence, Caregiver, ShiftType } from '@/types'
+import type { Shift, Absence, Caregiver } from '@/types'
 
 type ViewMode = 'week' | 'month'
 type ShiftStatusFilter = 'all' | 'planned' | 'completed' | 'cancelled'
-type ShiftTypeFilter = 'all' | ShiftType
+type ShiftTypeFilter = 'all' | 'effective' | 'presence' | 'guard_24h'
 
 export function PlanningPage() {
   const { profile, isInitialized } = useAuth()
@@ -195,7 +195,11 @@ export function PlanningPage() {
     if (statusFilter !== 'all') {
       result = result.filter((s) => s.status === statusFilter)
     }
-    if (typeFilter !== 'all') {
+    if (typeFilter === 'presence') {
+      result = result.filter(
+        (s) => s.shiftType === 'presence_day' || s.shiftType === 'presence_night',
+      )
+    } else if (typeFilter !== 'all') {
       result = result.filter((s) => s.shiftType === typeFilter)
     }
     if (employeeFilter) {
@@ -528,8 +532,7 @@ export function PlanningPage() {
                 >
                   <option value="all">Tous les types</option>
                   <option value="effective">Travail effectif</option>
-                  <option value="presence_day">Présence jour</option>
-                  <option value="presence_night">Présence nuit</option>
+                  <option value="presence">Présence responsable</option>
                   <option value="guard_24h">Garde 24h</option>
                 </Box>
               </Flex>


### PR DESCRIPTION
## Summary
Aligne le filtre de type d'intervention sur la saisie unifiée (PR #289). Au lieu d'afficher "Présence jour" et "Présence nuit" séparément, le filtre propose une seule option "Présence responsable" qui regroupe les deux. Cohérent avec ce que Marie voit à la saisie.

### Changements
- `PlanningPage.tsx` :
  - Type `ShiftTypeFilter` resserré : `'all' | 'effective' | 'presence' | 'guard_24h'` (au lieu de `'all' | ShiftType`)
  - Filter : nouvelle branche `'presence'` qui matche `presence_day || presence_night`
  - Select : 4 options au lieu de 5
  - Import `ShiftType` retiré (devenu inutile dans le fichier)

### Pourquoi
Marie ne pense plus en termes de "présence jour/nuit" depuis l'unification de la saisie (PR #289) — l'auto-détection s'occupe de la classification interne. Le filtre devait suivre.

## Test plan
- [x] Filtrer par "Présence responsable" → affiche les shifts `presence_day` ET `presence_night`
- [x] Filtrer par "Travail effectif" → uniquement les shifts `effective`
- [x] Filtrer par "Garde 24h" → uniquement les shifts `guard_24h`
- [x] Filtrer par "Tous les types" → tous les shifts visibles
- [x] `npm run lint` (0 erreur)
- [x] `npm run typecheck` (OK)
- [x] `npm run test:run` (2266 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)