### PR TITLE
fix(pay): split day/night calculation for mixed presence shifts

### DIFF
--- a/src/components/planning/PresenceMixedWarning.tsx
+++ b/src/components/planning/PresenceMixedWarning.tsx
@@ -8,43 +8,36 @@ interface PresenceMixedWarningProps {
 }
 
 /**
- * Avertissement affiché quand une intervention "Présence responsable" chevauche
- * le jour et la nuit. Les régimes de paie sont radicalement différents
- * (jour : équivalent ×2/3 — nuit : indemnité ×1/4, Art. 137 & 148 IDCC 3239),
- * donc un seul type ne peut refléter fidèlement la rémunération.
+ * Information affichée quand une "Présence responsable" chevauche jour et nuit.
+ * Le calcul de paie est splitté automatiquement (jour ×2/3 + nuit ×1/4 forfait,
+ * Art. 137 & 148 IDCC 3239), donc le montant à déclarer à la CESU est juste.
  *
- * - `edit` (défaut) : conseil de créer deux interventions ou une garde 24h.
- * - `view` : conseil de modifier l'intervention existante pour la diviser.
+ * - `edit` : info pédagogique pendant la saisie.
+ * - `view` : info contextualisée à la lecture du shift.
  */
 export function PresenceMixedWarning({ dayHours, nightHours, mode = 'edit' }: PresenceMixedWarningProps) {
   return (
     <Box
       p={3}
-      bg="warm.50"
+      bg="brand.subtle"
       borderRadius="10px"
       borderWidth="1px"
-      borderColor="warm.300"
+      borderColor="brand.200"
     >
-      <Text fontSize="sm" fontWeight="bold" color="warm.800" mb={1}>
-        Présence à cheval entre jour et nuit
+      <Text fontSize="sm" fontWeight="bold" color="brand.700" mb={1}>
+        Présence à cheval jour / nuit — calcul ajusté
       </Text>
-      <Text fontSize="sm" color="warm.800">
+      <Text fontSize="sm" color="brand.700">
         {formatHoursCompact(dayHours)} de jour + {formatHoursCompact(nightHours)} de nuit.
-        Les régimes de paie diffèrent (×2/3 jour vs ×1/4 nuit, Art. 137 & 148 IDCC 3239).
+        La paie est calculée sur les deux régimes :{' '}
+        <Text as="strong">jour ×2/3</Text> + <Text as="strong">nuit ×1/4</Text>{' '}
+        (Art. 137 & 148 IDCC 3239).
       </Text>
-      <Text fontSize="xs" color="warm.700" mt={2}>
+      <Text fontSize="xs" color="brand.600" mt={2}>
         {mode === 'view' ? (
-          <>
-            <Text as="strong">Modifiez</Text> cette intervention pour la diviser
-            en deux régimes (jour + nuit), ou convertissez-la en{' '}
-            <Text as="strong">garde 24h</Text>.
-          </>
+          <>Le détail de la décomposition est visible dans la rubrique « Paie estimée ».</>
         ) : (
-          <>
-            Pour un calcul juste, créez plutôt <Text as="strong">deux interventions</Text>{' '}
-            (une jour, une nuit) ou utilisez une <Text as="strong">garde 24h</Text> qui
-            gère les segments jour/nuit automatiquement.
-          </>
+          <>Pas besoin de splitter en deux interventions — le montant à déclarer à la CESU est ajusté automatiquement.</>
         )}
       </Text>
     </Box>

--- a/src/hooks/useShiftEffectiveHours.ts
+++ b/src/hooks/useShiftEffectiveHours.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { calculateShiftDuration } from '@/lib/compliance'
+import { getPresenceMix } from '@/lib/presence/detectPresenceType'
 import type { ShiftType, GuardSegment } from '@/types'
 
 interface UseShiftEffectiveHoursParams {
@@ -38,6 +39,22 @@ export function useShiftEffectiveHours({
     try {
       const durationMinutes = calculateShiftDuration(startTime, endTime, breakDuration)
       const durationHours = durationMinutes / 60
+
+      // Présence responsable mixte (chevauche jour 21h–6h) : on splitte
+      // pour appliquer les bons coefficients à chaque part (Art. 137 & 148 IDCC 3239).
+      // La pause est répartie au prorata du total brut.
+      if (shiftType === 'presence_day' || shiftType === 'presence_night') {
+        const mix = getPresenceMix(startTime, endTime)
+        if (mix.isMixed && mix.totalHours > 0) {
+          const breakRatio = durationHours / mix.totalHours
+          const dayH = mix.dayHours * breakRatio
+          const nightH = mix.nightHours * breakRatio
+          const effectiveDay = dayH * (2 / 3)
+          // Part nuit : 100% si requalifiée, sinon forfait (pas une heure effective)
+          const effectiveNight = isRequalified ? nightH : 0
+          return Math.round((effectiveDay + effectiveNight) * 100) / 100
+        }
+      }
 
       if (shiftType === 'presence_day') {
         return Math.round(durationHours * (2 / 3) * 100) / 100

--- a/src/lib/compliance/calculatePay.test.ts
+++ b/src/lib/compliance/calculatePay.test.ts
@@ -311,7 +311,8 @@ describe('calculateShiftPay', () => {
 
   describe('Présence de nuit (presence_night)', () => {
     it('devrait calculer indemnité forfaitaire 1/4 du taux horaire sans requalification', () => {
-      // 10h de présence nuit, 0 interventions
+      // 10h de présence 21:00-07:00 = 9h nuit (21h-6h) + 1h jour (6h-7h)
+      // Calcul splitté : nuit ×1/4 + jour ×2/3 (Art. 137 & 148 IDCC 3239)
       const shift: ShiftForValidation = {
         ...createShift('2025-01-15', '21:00', '07:00'),
         shiftType: 'presence_night',
@@ -321,12 +322,29 @@ describe('calculateShiftPay', () => {
 
       const pay = calculateShiftPay(shift, contract)
 
-      expect(pay.nightPresenceAllowance).toBe(30) // 10h * 12€ * 0.25
-      expect(pay.totalPay).toBe(30)
+      expect(pay.nightPresenceAllowance).toBe(27) // 9h nuit × 12€ × 0.25
+      expect(pay.presenceResponsiblePay).toBe(8) // 1h jour × 2/3 × 12€
+      expect(pay.totalPay).toBe(35)
     })
 
-    it('devrait requalifier en travail effectif à 100% si >= 4 interventions (Art. 148 IDCC 3239)', () => {
-      // 10h de présence nuit, 4 interventions → requalification
+    it('devrait calculer une présence nuit pure (homogène) sans part jour', () => {
+      // 21:00-06:00 = 9h, intégralement sur la plage nuit (21h-6h)
+      const shift: ShiftForValidation = {
+        ...createShift('2025-01-15', '21:00', '06:00'),
+        shiftType: 'presence_night',
+        nightInterventionsCount: 0,
+      }
+      const contract = createContract(12, 35)
+
+      const pay = calculateShiftPay(shift, contract)
+
+      expect(pay.nightPresenceAllowance).toBe(27) // 9h × 12€ × 0.25
+      expect(pay.presenceResponsiblePay).toBe(0)
+      expect(pay.totalPay).toBe(27)
+    })
+
+    it('devrait requalifier la part nuit à 100% si >= 4 interventions (Art. 148 IDCC 3239)', () => {
+      // 10h 21:00-07:00 requalifié = 9h nuit ×100% + 1h jour ×2/3
       const shift: ShiftForValidation = {
         ...createShift('2025-01-15', '21:00', '07:00'),
         shiftType: 'presence_night',
@@ -336,8 +354,64 @@ describe('calculateShiftPay', () => {
 
       const pay = calculateShiftPay(shift, contract)
 
-      expect(pay.nightPresenceAllowance).toBe(120) // 10h * 12€ * 1.00
-      expect(pay.totalPay).toBe(120)
+      expect(pay.nightPresenceAllowance).toBe(108) // 9h × 12€ × 1.00
+      expect(pay.presenceResponsiblePay).toBe(8) // 1h jour × 2/3 × 12€
+      expect(pay.totalPay).toBe(116)
+    })
+  })
+
+  describe('Présence responsable mixte jour/nuit', () => {
+    it('devrait splitter le calcul pour un shift presence_day chevauchant la nuit', () => {
+      // 18h-23h = 3h jour (18-21) + 2h nuit (21-23), classifié presence_day
+      // Calcul attendu : 3h × 2/3 × 12 + 2h × 0.25 × 12 = 24 + 6 = 30€
+      // Avant fix : 5h × 2/3 × 12 = 40€ (surévalué)
+      const shift: ShiftForValidation = {
+        ...createShift('2025-01-15', '18:00', '23:00'),
+        shiftType: 'presence_day',
+      }
+      const contract = createContract(12, 35)
+
+      const pay = calculateShiftPay(shift, contract)
+
+      expect(pay.presenceResponsiblePay).toBe(24) // 3h × 2/3 × 12€
+      expect(pay.nightPresenceAllowance).toBe(6) // 2h × 12€ × 0.25
+      expect(pay.totalPay).toBe(30)
+    })
+
+    it('devrait répartir la pause au prorata jour/nuit', () => {
+      // 18h-23h avec 1h de pause = 4h effectives
+      // Ratio brut : 3h jour + 2h nuit, pause au prorata = 4/5 du brut
+      // dayH effectives = 3 × 0.8 = 2.4 → presence = 2.4 × 2/3 × 12 = 19.2€
+      // nightH effectives = 2 × 0.8 = 1.6 → forfait = 1.6 × 12 × 0.25 = 4.8€
+      const shift: ShiftForValidation = {
+        ...createShift('2025-01-15', '18:00', '23:00'),
+        shiftType: 'presence_day',
+        breakDuration: 60,
+      }
+      const contract = createContract(12, 35)
+
+      const pay = calculateShiftPay(shift, contract)
+
+      expect(pay.presenceResponsiblePay).toBe(19.2)
+      expect(pay.nightPresenceAllowance).toBe(4.8)
+      expect(pay.totalPay).toBe(24)
+    })
+
+    it('devrait appliquer majoration dimanche sur le total (jour + nuit)', () => {
+      // Dimanche 18h-23h presence_day mixte
+      const shift: ShiftForValidation = {
+        ...createShift('2025-01-19', '18:00', '23:00'),
+        shiftType: 'presence_day',
+      }
+      const contract = createContract(12, 35)
+
+      const pay = calculateShiftPay(shift, contract)
+
+      // base : 24 + 6 = 30€, majoration dimanche : 30 × 0.30 = 9€
+      expect(pay.presenceResponsiblePay).toBe(24)
+      expect(pay.nightPresenceAllowance).toBe(6)
+      expect(pay.sundayMajoration).toBe(9)
+      expect(pay.totalPay).toBe(39)
     })
   })
 

--- a/src/lib/compliance/calculatePay.ts
+++ b/src/lib/compliance/calculatePay.ts
@@ -7,6 +7,7 @@ import type { ComputedPay } from '@/types'
 import type { ShiftForValidation, ContractForCalculation } from './types'
 import { isPublicHoliday, isSunday } from './types'
 import { calculateShiftDuration, calculateNightHours, getWeekStart, calculateTotalHours } from './utils'
+import { getPresenceMix } from '@/lib/presence/detectPresenceType'
 
 // Taux de majoration (Convention Collective IDCC 3239)
 export const MAJORATION_RATES = {
@@ -86,29 +87,34 @@ export function calculateShiftPay(
   let nightPresenceAllowance = 0
   const shiftType = shift.shiftType || 'effective'
 
-  if (shiftType === 'presence_day') {
-    // Présence responsable de jour : 1h = 2/3h de travail effectif (Art. 137.1 IDCC 3239)
-    const effectiveHours = durationHours * (2 / 3)
-    presenceResponsiblePay = effectiveHours * hourlyRate
-    // Les majorations s'appliquent sur presenceResponsiblePay (base réelle payée),
-    // et non sur basePay (heures brutes non réduites)
+  if (shiftType === 'presence_day' || shiftType === 'presence_night') {
+    // Décomposition jour/nuit pour appliquer les bons régimes IDCC 3239 :
+    // - jour : 1h = 2/3h effective (Art. 137.1)
+    // - nuit non requalifiée : indemnité forfaitaire ×1/4 (Art. 148)
+    // - nuit requalifiée (≥4 interventions sur presence_night) : 100% effectif
+    // La pause est répartie au prorata du total brut.
+    const mix = getPresenceMix(shift.startTime, shift.endTime)
+    const breakRatio = mix.totalHours > 0 ? durationHours / mix.totalHours : 1
+    const dayH = mix.dayHours * breakRatio
+    const nightH = mix.nightHours * breakRatio
+    const isRequalified =
+      shiftType === 'presence_night' && (shift.nightInterventionsCount ?? 0) >= 4
+
+    presenceResponsiblePay = dayH * (2 / 3) * hourlyRate
+    nightPresenceAllowance = isRequalified
+      ? nightH * hourlyRate
+      : nightH * hourlyRate * 0.25
+
+    // Majorations dimanche/férié sur la base réellement payée
+    const totalPaid = presenceResponsiblePay + nightPresenceAllowance
     if (isSunday(shift.date)) {
-      sundayMajoration = presenceResponsiblePay * MAJORATION_RATES.SUNDAY
+      sundayMajoration = totalPaid * MAJORATION_RATES.SUNDAY
     }
     if (isPublicHoliday(shift.date)) {
       const rate = isHabitualWorkOnHolidays
         ? MAJORATION_RATES.PUBLIC_HOLIDAY_WORKED
         : MAJORATION_RATES.PUBLIC_HOLIDAY_EXCEPTIONAL
-      holidayMajoration = presenceResponsiblePay * rate
-    }
-  } else if (shiftType === 'presence_night') {
-    const isRequalified = (shift.nightInterventionsCount ?? 0) >= 4
-    if (isRequalified) {
-      // Requalification : toute la plage est rémunérée en travail effectif (Art. 148 IDCC 3239)
-      nightPresenceAllowance = durationHours * hourlyRate
-    } else {
-      // Indemnité forfaitaire >= 1/4 du salaire contractuel horaire
-      nightPresenceAllowance = durationHours * hourlyRate * 0.25
+      holidayMajoration = totalPaid * rate
     }
   } else if (shiftType === 'guard_24h' && shift.guardSegments?.length) {
     // ── Garde 24h N segments libres ───────────────────────────────
@@ -164,11 +170,11 @@ export function calculateShiftPay(
   // Total
   const totalPay = shiftType === 'effective'
     ? basePay + sundayMajoration + holidayMajoration + nightMajoration + overtimeMajoration
-    : shiftType === 'presence_day'
-      ? presenceResponsiblePay + sundayMajoration + holidayMajoration
+    : (shiftType === 'presence_day' || shiftType === 'presence_night')
+      ? presenceResponsiblePay + nightPresenceAllowance + sundayMajoration + holidayMajoration
       : shiftType === 'guard_24h'
         ? basePay + presenceResponsiblePay + nightPresenceAllowance + sundayMajoration + holidayMajoration + nightMajoration
-        : nightPresenceAllowance + nightMajoration
+        : 0
 
   return {
     basePay: Math.round(basePay * 100) / 100,


### PR DESCRIPTION
## Summary
Corrige le calcul de paie pour les shifts « Présence responsable » qui chevauchent jour et nuit (ex : 18h-23h). Avant, l'app appliquait un seul coefficient (×2/3 ou ×1/4) sur la totalité, ce qui faussait le montant à déclarer à la CESU. Désormais, chaque part est rémunérée selon son régime IDCC 3239 :
- Part jour (hors 21h-6h) → ×2/3 (Art. 137.1)
- Part nuit (21h-6h) → forfait ×1/4 ou 100% si requalifiée (≥4 interventions, Art. 148)

### Pourquoi
Marie déclare à la CESU le **montant** des heures de présence responsable (rubrique compléments de salaire). Le système CESU n'effectue pas la conversion ×2/3 / ×1/4 — c'est à la charge de l'employeur. Si notre estimation est fausse, sa déclaration est fausse.

**Exemple concret** : shift 18h-23h à 12€/h
- Avant : 5h × 2/3 × 12 = 40€ ❌
- Après : 3h × 2/3 × 12 + 2h × 0,25 × 12 = 24 + 6 = **30€** ✅

Soit ~10€ d'écart par shift mixte (cas fréquent — toute intervention du soir touche la plage nuit).

### Changements
- **`calculatePay.ts`** : fusion des branches `presence_day` et `presence_night` en une seule. Décomposition via `getPresenceMix` + pause au prorata du total brut. Majorations dimanche/férié appliquées sur le total payé (jour + nuit). Total adapté pour additionner les deux composantes.
- **`useShiftEffectiveHours.ts`** : même logique de décomposition pour calculer les heures effectives équivalentes (pour l'affichage et le stockage).
- **`PresenceMixedWarning.tsx`** : refonte du composant — passe d'une **alerte** (« modifiez l'intervention ») à une **info pédagogique** (« calcul ajusté automatiquement »). Plus besoin de splitter le shift, le calcul fait le boulot.
- **`calculatePay.test.ts`** : 2 tests existants mis à jour (les anciennes valeurs étaient mathématiquement incorrectes — un shift 21h-7h n'est pas 100% nuit, il a 1h de jour entre 6h et 7h). 4 nouveaux tests ajoutés pour le cas explicitement mixte.

### Détails techniques
- La requalification (`≥ 4 interventions de nuit`) reste limitée à `presence_night` (cohérent avec `useShiftRequalification.ts`)
- La pause est répartie au prorata du total brut : `breakRatio = durationHours / mix.totalHours`
- La branche `guard_24h` n'est pas touchée (logique segments séparée)

## Test plan
- [x] Saisir un shift 18h-23h en présence responsable → la paie estimée affiche **30€** (au lieu de 40€)
- [x] Vérifier le détail dans « Paie estimée » : 2 lignes (Présence jour + Indemnité présence de nuit)
- [x] Saisir le même shift un dimanche → 39€ (30€ + 9€ majoration)
- [x] Saisir avec 1h de pause → 24€ (proratisation correcte)
- [x] Saisir 21h-6h pure → 27€ (cas homogène nuit, comportement existant)
- [x] Saisir 9h-17h pure → 64€ (cas homogène jour, comportement existant)
- [x] Vérifier le warning en mode édition : message info brand (« calcul ajusté ») au lieu d'alerte
- [x] `npm run lint` (0 erreur)
- [x] `npm run typecheck` (OK)
- [x] `npm run test:run` (2270 passed / 4 skipped — +4 nouveaux tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)