### PR TITLE
feat(cesu): detailed monthly recap with breakdown and net estimate

### DIFF
--- a/src/lib/export/cesuGenerator.test.ts
+++ b/src/lib/export/cesuGenerator.test.ts
@@ -29,6 +29,9 @@ function makeEmployee(overrides: Partial<MonthlyDeclarationData['employees'][0]>
     hourlyRate: 12.5,
     totalHours: 80,
     normalHours: 72,
+    effectiveWorkHours: 80,
+    presenceDayHours: 0,
+    presenceNightHours: 0,
     sundayHours: 8,
     holidayHours: 0,
     nightHours: 4,
@@ -38,7 +41,11 @@ function makeEmployee(overrides: Partial<MonthlyDeclarationData['employees'][0]>
     holidayMajoration: 0,
     nightMajoration: 10,
     overtimeMajoration: 0,
+    presenceResponsiblePay: 0,
+    nightPresenceAllowance: 0,
     totalGrossPay: 940,
+    netPay: 740,
+    totalEmployeeDeductions: 200,
     shiftsCount: 1,
     shiftsDetails: [makeShiftDetail()],
     ...overrides,
@@ -49,6 +56,8 @@ const baseData: MonthlyDeclarationData = {
   year: 2026,
   month: 2,
   periodLabel: 'Février 2026',
+  periodStartDate: new Date('2026-02-01'),
+  periodEndDate: new Date('2026-02-28'),
   employerId: 'employer-1',
   employerFirstName: 'Marie',
   employerLastName: 'Dupont',
@@ -57,6 +66,7 @@ const baseData: MonthlyDeclarationData = {
   employees: [makeEmployee()],
   totalHours: 80,
   totalGrossPay: 940,
+  totalNetPay: 740,
   totalEmployees: 1,
   generatedAt: new Date('2026-02-20T10:00:00'),
 }
@@ -69,17 +79,19 @@ const dataNoCesu: MonthlyDeclarationData = {
 const dataMultiEmployees: MonthlyDeclarationData = {
   ...baseData,
   employees: [
-    makeEmployee({ employeeId: 'emp-1', firstName: 'Sophie', lastName: 'Martin', totalGrossPay: 940 }),
+    makeEmployee({ employeeId: 'emp-1', firstName: 'Sophie', lastName: 'Martin', totalGrossPay: 940, netPay: 740 }),
     makeEmployee({
       employeeId: 'emp-2',
       firstName: 'Luc',
       lastName: 'Bernard',
       totalGrossPay: 600,
+      netPay: 470,
       shiftsDetails: [makeShiftDetail({ date: new Date('2026-02-05'), isSunday: true })],
     }),
   ],
   totalHours: 160,
   totalGrossPay: 1540,
+  totalNetPay: 1210,
   totalEmployees: 2,
 }
 
@@ -277,14 +289,14 @@ describe('generateCesuSummary', () => {
       expect(content).not.toContain('Heures jours fériés')
     })
 
-    it('affiche le salaire de base', () => {
+    it('affiche le salaire effectif', () => {
       const { content } = generateCesuSummary(baseData)
-      expect(content).toContain('Salaire de base')
+      expect(content).toContain('Salaire effectif')
     })
 
     it('affiche les majorations dimanche', () => {
       const { content } = generateCesuSummary(baseData)
-      expect(content).toContain('Dimanche')
+      expect(content).toContain('Majoration dimanche')
     })
 
     it('affiche "TOTAL GÉNÉRAL"', () => {

--- a/src/lib/export/cesuGenerator.ts
+++ b/src/lib/export/cesuGenerator.ts
@@ -41,15 +41,22 @@ export function generateCesuCsv(data: MonthlyDeclarationData): ExportResult {
       'Nom',
       'Prénom',
       'Type contrat',
+      'Taux horaire',
       'Heures totales',
-      'Heures normales',
+      'Heures effectives',
+      'Heures présence jour',
+      'Heures présence nuit',
       'Heures dimanche',
       'Heures fériés',
       'Heures nuit',
-      'Taux horaire',
-      'Salaire brut',
+      'Heures sup',
+      'Salaire effectif',
+      'Présence jour (×2/3)',
+      'Présence nuit (×1/4 ou 100%)',
       'Majorations',
       'Total brut',
+      'Cotisations salariales',
+      'Net à verser',
     ].join(';'))
 
     // Données employés
@@ -61,15 +68,22 @@ export function generateCesuCsv(data: MonthlyDeclarationData): ExportResult {
         employee.lastName,
         employee.firstName,
         employee.contractType,
+        formatCurrency(employee.hourlyRate),
         formatNumber(employee.totalHours),
-        formatNumber(employee.normalHours),
+        formatNumber(employee.effectiveWorkHours),
+        formatNumber(employee.presenceDayHours),
+        formatNumber(employee.presenceNightHours),
         formatNumber(employee.sundayHours),
         formatNumber(employee.holidayHours),
         formatNumber(employee.nightHours),
-        formatCurrency(employee.hourlyRate),
+        formatNumber(employee.overtimeHours),
         formatCurrency(employee.basePay),
+        formatCurrency(employee.presenceResponsiblePay),
+        formatCurrency(employee.nightPresenceAllowance),
         formatCurrency(majorations),
         formatCurrency(employee.totalGrossPay),
+        formatCurrency(employee.totalEmployeeDeductions),
+        formatCurrency(employee.netPay),
       ].join(';'))
     }
 
@@ -80,6 +94,7 @@ export function generateCesuCsv(data: MonthlyDeclarationData): ExportResult {
     lines.push(`Nombre d'employés;${data.totalEmployees}`)
     lines.push(`Total heures;${formatNumber(data.totalHours)}`)
     lines.push(`Total brut;${formatCurrency(data.totalGrossPay)}`)
+    lines.push(`Total net à verser;${formatCurrency(data.totalNetPay)}`)
     lines.push('')
 
     // Détail par employé
@@ -166,46 +181,63 @@ export function generateCesuSummary(data: MonthlyDeclarationData): ExportResult 
 
       // Heures à déclarer
       lines.push('HEURES À DÉCLARER SUR CESU.URSSAF.FR:')
-      lines.push(`  • Nombre d'heures: ${formatNumber(employee.totalHours)} h`)
-      lines.push(`  • Salaire net à payer: ${formatCurrency(employee.totalGrossPay * 0.78)}`) // Estimation net
+      lines.push(`  • Nombre d'heures totales: ${formatNumber(employee.totalHours)} h`)
+      lines.push(`  • Net à verser:            ${formatCurrency(employee.netPay)}`)
+      lines.push(`  • (Brut correspondant:     ${formatCurrency(employee.totalGrossPay)})`)
       lines.push('')
 
       // Détail des heures
       lines.push('DÉTAIL DES HEURES:')
-      lines.push(`  • Heures normales:     ${formatNumber(employee.normalHours)} h`)
+      if (employee.effectiveWorkHours > 0) {
+        lines.push(`  • Travail effectif:        ${formatNumber(employee.effectiveWorkHours)} h`)
+      }
+      if (employee.presenceDayHours > 0) {
+        lines.push(`  • Présence resp. jour:     ${formatNumber(employee.presenceDayHours)} h (×2/3 Art. 137.1)`)
+      }
+      if (employee.presenceNightHours > 0) {
+        lines.push(`  • Présence resp. nuit:     ${formatNumber(employee.presenceNightHours)} h (forfait ×1/4 ou requalif. Art. 148)`)
+      }
       if (employee.sundayHours > 0) {
-        lines.push(`  • Heures dimanche:     ${formatNumber(employee.sundayHours)} h (+${MAJORATION_RATES.SUNDAY * 100}%)`)
+        lines.push(`  • Heures dimanche:         ${formatNumber(employee.sundayHours)} h (+${MAJORATION_RATES.SUNDAY * 100}%)`)
       }
       if (employee.holidayHours > 0) {
-        lines.push(`  • Heures jours fériés: ${formatNumber(employee.holidayHours)} h (+${MAJORATION_RATES.PUBLIC_HOLIDAY_WORKED * 100}%)`)
+        lines.push(`  • Heures jours fériés:     ${formatNumber(employee.holidayHours)} h (+${MAJORATION_RATES.PUBLIC_HOLIDAY_WORKED * 100}%)`)
       }
       if (employee.nightHours > 0) {
-        lines.push(`  • Heures de nuit:      ${formatNumber(employee.nightHours)} h (+${MAJORATION_RATES.NIGHT * 100}%)`)
+        lines.push(`  • Heures de nuit:          ${formatNumber(employee.nightHours)} h (+${MAJORATION_RATES.NIGHT * 100}%)`)
       }
       if (employee.overtimeHours > 0) {
-        lines.push(`  • Heures sup:          ${formatNumber(employee.overtimeHours)} h (+${MAJORATION_RATES.OVERTIME_FIRST_8H * 100}%/+${MAJORATION_RATES.OVERTIME_BEYOND_8H * 100}%)`)
+        lines.push(`  • Heures sup:              ${formatNumber(employee.overtimeHours)} h (+${MAJORATION_RATES.OVERTIME_FIRST_8H * 100}%/+${MAJORATION_RATES.OVERTIME_BEYOND_8H * 100}%)`)
       }
       lines.push('')
 
-      // Rémunération
-      lines.push('RÉMUNÉRATION:')
-      lines.push(`  • Salaire de base:     ${formatCurrency(employee.basePay)}`)
-      const totalMaj = employee.sundayMajoration + employee.holidayMajoration +
-                       employee.nightMajoration + employee.overtimeMajoration
-      if (totalMaj > 0) {
-        lines.push(`  • Majorations:         ${formatCurrency(totalMaj)}`)
-        if (employee.sundayMajoration > 0) {
-          lines.push(`      - Dimanche:        ${formatCurrency(employee.sundayMajoration)}`)
-        }
-        if (employee.holidayMajoration > 0) {
-          lines.push(`      - Jours fériés:    ${formatCurrency(employee.holidayMajoration)}`)
-        }
-        if (employee.nightMajoration > 0) {
-          lines.push(`      - Heures de nuit:  ${formatCurrency(employee.nightMajoration)}`)
-        }
+      // Rémunération (ligne par ligne, à reporter dans CESU compléments de salaire)
+      lines.push('RÉMUNÉRATION (à reporter ligne par ligne dans CESU):')
+      if (employee.basePay > 0) {
+        lines.push(`  • Salaire effectif:        ${formatCurrency(employee.basePay)}`)
+      }
+      if (employee.presenceResponsiblePay > 0) {
+        lines.push(`  • Présence resp. jour:     ${formatCurrency(employee.presenceResponsiblePay)}`)
+      }
+      if (employee.nightPresenceAllowance > 0) {
+        lines.push(`  • Présence resp. nuit:     ${formatCurrency(employee.nightPresenceAllowance)}`)
+      }
+      if (employee.sundayMajoration > 0) {
+        lines.push(`  • Majoration dimanche:     ${formatCurrency(employee.sundayMajoration)}`)
+      }
+      if (employee.holidayMajoration > 0) {
+        lines.push(`  • Majoration jour férié:   ${formatCurrency(employee.holidayMajoration)}`)
+      }
+      if (employee.nightMajoration > 0) {
+        lines.push(`  • Majoration nuit:         ${formatCurrency(employee.nightMajoration)}`)
+      }
+      if (employee.overtimeMajoration > 0) {
+        lines.push(`  • Heures sup:              ${formatCurrency(employee.overtimeMajoration)}`)
       }
       lines.push(`  ──────────────────────────`)
-      lines.push(`  • TOTAL BRUT:          ${formatCurrency(employee.totalGrossPay)}`)
+      lines.push(`  • TOTAL BRUT:              ${formatCurrency(employee.totalGrossPay)}`)
+      lines.push(`  • Cotisations salariales:  -${formatCurrency(employee.totalEmployeeDeductions)}`)
+      lines.push(`  • NET À VERSER:            ${formatCurrency(employee.netPay)}`)
       lines.push('')
 
       // Interventions
@@ -229,8 +261,11 @@ export function generateCesuSummary(data: MonthlyDeclarationData): ExportResult 
     lines.push('═══════════════════════════════════════════════════════')
     lines.push(`  Nombre d'employés:     ${data.totalEmployees}`)
     lines.push(`  Total heures:          ${formatNumber(data.totalHours)} h`)
-    lines.push(`  Total salaires bruts:  ${formatCurrency(data.totalGrossPay)}`)
+    lines.push(`  Total brut:            ${formatCurrency(data.totalGrossPay)}`)
+    lines.push(`  Total NET à verser:    ${formatCurrency(data.totalNetPay)}`)
     lines.push('═══════════════════════════════════════════════════════')
+    lines.push('')
+    lines.push('Date limite de déclaration : avant le 5 du mois suivant.')
 
     const content = lines.join('\n')
     const filename = `cesu_recap_${data.year}_${String(data.month).padStart(2, '0')}.txt`

--- a/src/lib/export/cesuPdfGenerator.tsx
+++ b/src/lib/export/cesuPdfGenerator.tsx
@@ -196,7 +196,6 @@ const s = StyleSheet.create({
     fontSize: 8.5,
     color: colors.textMuted,
     marginTop: 2,
-    fontStyle: 'italic',
   },
   // Grand total
   grandTotal: {

--- a/src/lib/export/cesuPdfGenerator.tsx
+++ b/src/lib/export/cesuPdfGenerator.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
 /**
  * Générateur PDF pour les déclarations CESU
- * Récapitulatif mensuel des heures et salaires.
+ * Récapitulatif mensuel détaillé : heures, décomposition de la rémunération
+ * (présence jour/nuit, majorations) et net estimé.
+ *
+ * Conçu pour que Marie puisse reporter directement chaque ligne dans CESU
+ * (rubrique « heures travaillées » + sous-rubrique « compléments de salaire »).
  *
  * Utilise @react-pdf/renderer pour un rendu vectoriel net.
  */
@@ -63,6 +67,11 @@ const s = StyleSheet.create({
     padding: '4px 10px',
     borderRadius: 4,
   },
+  periodLine: {
+    fontSize: 10,
+    color: colors.textMuted,
+    marginTop: 6,
+  },
   // Employee card
   employeeCard: {
     border: `1px solid ${colors.border}`,
@@ -74,7 +83,7 @@ const s = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 12,
+    marginBottom: 6,
   },
   empName: {
     fontSize: 14,
@@ -89,44 +98,105 @@ const s = StyleSheet.create({
     borderRadius: 4,
     textTransform: 'uppercase',
   },
-  cardGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+  cardSubline: {
+    fontSize: 9.5,
+    color: colors.textMuted,
     marginBottom: 12,
   },
-  cardMetric: {
-    width: '50%',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingRight: 12,
-    marginBottom: 4,
+  // Décomposition (table)
+  breakdown: {
+    marginBottom: 10,
   },
-  metricLabel: {
-    fontSize: 11,
-    color: colors.textMuted,
-  },
-  metricValue: {
-    fontSize: 12,
-    fontWeight: 600,
-  },
-  cardTotal: {
-    backgroundColor: colors.greenBg,
-    borderRadius: 6,
-    padding: '8px 12px',
+  breakdownRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    paddingVertical: 4,
+    borderBottom: `1px solid ${colors.border}`,
   },
-  cardTotalLabel: {
+  breakdownRowLast: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  breakdownLabelGroup: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+    flex: 1,
+  },
+  breakdownLabel: {
+    fontSize: 10.5,
+    color: colors.text,
+  },
+  breakdownDetail: {
+    fontSize: 9,
+    color: colors.textMuted,
+  },
+  breakdownAmount: {
+    fontSize: 10.5,
+    fontWeight: 600,
+  },
+  breakdownSubLabel: {
+    fontSize: 9.5,
+    color: colors.textMuted,
+    paddingLeft: 12,
+  },
+  breakdownSubAmount: {
+    fontSize: 9.5,
+    color: colors.textMuted,
+  },
+  // Totaux
+  totalBlock: {
+    marginTop: 8,
+  },
+  totalGrossRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: '#EDF1F5',
+    padding: '6px 10px',
+    borderRadius: 5,
+    marginBottom: 4,
+  },
+  totalGrossLabel: {
+    fontSize: 10.5,
+    fontWeight: 600,
+    color: colors.navy,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  totalGrossAmount: {
+    fontSize: 12,
+    fontWeight: 600,
+    color: colors.navy,
+  },
+  totalNetRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: colors.greenBg,
+    padding: '8px 12px',
+    borderRadius: 6,
+  },
+  totalNetLabel: {
     fontSize: 11,
     fontWeight: 600,
     color: colors.greenDark,
     textTransform: 'uppercase',
+    letterSpacing: 0.3,
   },
-  cardTotalAmount: {
-    fontSize: 15,
+  totalNetAmount: {
+    fontSize: 14,
     fontWeight: 600,
     color: colors.greenDark,
+  },
+  totalNetSub: {
+    fontSize: 8.5,
+    color: colors.textMuted,
+    marginTop: 2,
+    fontStyle: 'italic',
   },
   // Grand total
   grandTotal: {
@@ -138,6 +208,9 @@ const s = StyleSheet.create({
     alignItems: 'center',
     marginTop: 20,
   },
+  grandTotalLeft: {
+    flex: 1,
+  },
   grandTotalTitle: {
     fontSize: 13,
     fontWeight: 600,
@@ -146,17 +219,33 @@ const s = StyleSheet.create({
     letterSpacing: 0.3,
   },
   grandTotalSub: {
-    fontSize: 11,
+    fontSize: 10,
     color: 'white',
     opacity: 0.75,
     marginTop: 2,
   },
-  grandTotalAmount: {
-    fontSize: 24,
+  grandTotalAmounts: {
+    alignItems: 'flex-end',
+  },
+  grandTotalNet: {
+    fontSize: 20,
     fontWeight: 600,
     color: 'white',
   },
-  // How-to (exact proto sizes)
+  grandTotalNetLabel: {
+    fontSize: 9,
+    color: 'white',
+    opacity: 0.75,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  grandTotalGross: {
+    fontSize: 11,
+    color: 'white',
+    opacity: 0.85,
+    marginTop: 2,
+  },
+  // How-to
   howto: {
     backgroundColor: '#EDF1F5',
     border: `1px solid ${colors.borderDark}`,
@@ -245,6 +334,10 @@ export async function generateCesuPdf(data: MonthlyDeclarationData): Promise<Exp
   }
 }
 
+function formatShortDate(date: Date): string {
+  return date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+}
+
 function CesuDocument({ data }: { data: MonthlyDeclarationData }) {
   return (
     <Document>
@@ -268,6 +361,9 @@ function CesuDocument({ data }: { data: MonthlyDeclarationData }) {
                 <Text style={s.cesuNumber}>N° CESU : {data.cesuNumber}</Text>
               )}
             </View>
+            <Text style={s.periodLine}>
+              Période d{'’'}emploi : du {formatShortDate(data.periodStartDate)} au {formatShortDate(data.periodEndDate)}
+            </Text>
           </View>
 
           <SectionTitle>Employés ({data.totalEmployees})</SectionTitle>
@@ -278,11 +374,15 @@ function CesuDocument({ data }: { data: MonthlyDeclarationData }) {
 
           {/* Grand total */}
           <View style={s.grandTotal} wrap={false}>
-            <View>
+            <View style={s.grandTotalLeft}>
               <Text style={s.grandTotalTitle}>Total général</Text>
-              <Text style={s.grandTotalSub}>{hrs(data.totalHours)} travaillées</Text>
+              <Text style={s.grandTotalSub}>{hrs(data.totalHours)} travaillées sur la période</Text>
             </View>
-            <Text style={s.grandTotalAmount}>{euro(data.totalGrossPay)}</Text>
+            <View style={s.grandTotalAmounts}>
+              <Text style={s.grandTotalNetLabel}>Net à verser</Text>
+              <Text style={s.grandTotalNet}>{euro(data.totalNetPay)}</Text>
+              <Text style={s.grandTotalGross}>Brut : {euro(data.totalGrossPay)}</Text>
+            </View>
           </View>
 
           {/* How-to */}
@@ -298,12 +398,82 @@ function CesuDocument({ data }: { data: MonthlyDeclarationData }) {
   )
 }
 
+interface BreakdownLine {
+  label: string
+  detail?: string
+  amount: number
+}
+
+function buildBreakdown(emp: EmployeeDeclarationData): BreakdownLine[] {
+  const lines: BreakdownLine[] = []
+
+  if (emp.basePay > 0) {
+    lines.push({
+      label: 'Travail effectif',
+      detail: `${hrs(emp.effectiveWorkHours)} × ${euro(emp.hourlyRate)}/h`,
+      amount: emp.basePay,
+    })
+  }
+  if (emp.presenceResponsiblePay > 0) {
+    lines.push({
+      label: 'Présence responsable jour',
+      detail: `${hrs(emp.presenceDayHours)} × 2/3 (Art. 137.1)`,
+      amount: emp.presenceResponsiblePay,
+    })
+  }
+  if (emp.nightPresenceAllowance > 0) {
+    lines.push({
+      label: 'Présence responsable nuit',
+      detail: `${hrs(emp.presenceNightHours)} (forfait ×1/4 ou requalif. Art. 148)`,
+      amount: emp.nightPresenceAllowance,
+    })
+  }
+  if (emp.sundayMajoration > 0) {
+    lines.push({
+      label: 'Majoration dimanche (+30%)',
+      detail: `${hrs(emp.sundayHours)} le dimanche`,
+      amount: emp.sundayMajoration,
+    })
+  }
+  if (emp.holidayMajoration > 0) {
+    lines.push({
+      label: 'Majoration jour férié',
+      detail: `${hrs(emp.holidayHours)} sur jour férié`,
+      amount: emp.holidayMajoration,
+    })
+  }
+  if (emp.nightMajoration > 0) {
+    lines.push({
+      label: 'Majoration heures de nuit (+20%)',
+      detail: `${hrs(emp.nightHours)} entre 21h et 6h`,
+      amount: emp.nightMajoration,
+    })
+  }
+  if (emp.overtimeMajoration > 0) {
+    lines.push({
+      label: 'Heures supplémentaires (+25% / +50%)',
+      detail: `${hrs(emp.overtimeHours)} au-delà de l{'’'}horaire contractuel`,
+      amount: emp.overtimeMajoration,
+    })
+  }
+  return lines
+}
+
 function EmployeeCard({ emp }: { emp: EmployeeDeclarationData }) {
-  const totalMajorations =
-    emp.sundayMajoration +
-    emp.holidayMajoration +
-    emp.nightMajoration +
-    emp.overtimeMajoration
+  const lines = buildBreakdown(emp)
+  const contractLine = (() => {
+    const parts: string[] = [`${euro(emp.hourlyRate)}/h`]
+    if (emp.contractStartDate) {
+      const start = formatShortDate(emp.contractStartDate)
+      if (emp.contractEndDate) {
+        parts.push(`du ${start} au ${formatShortDate(emp.contractEndDate)}`)
+      } else {
+        parts.push(`depuis le ${start}`)
+      }
+    }
+    parts.push(`${emp.shiftsCount} intervention${emp.shiftsCount > 1 ? 's' : ''}`)
+    return parts.join(' · ')
+  })()
 
   return (
     <View style={s.employeeCard} wrap={false}>
@@ -311,27 +481,39 @@ function EmployeeCard({ emp }: { emp: EmployeeDeclarationData }) {
         <Text style={s.empName}>{emp.firstName} {emp.lastName}</Text>
         <Text style={s.contractBadge}>{emp.contractType}</Text>
       </View>
-      <View style={s.cardGrid}>
-        <View style={s.cardMetric}>
-          <Text style={s.metricLabel}>Heures totales</Text>
-          <Text style={s.metricValue}>{hrs(emp.totalHours)}</Text>
-        </View>
-        <View style={s.cardMetric}>
-          <Text style={s.metricLabel}>Interventions</Text>
-          <Text style={s.metricValue}>{emp.shiftsCount}</Text>
-        </View>
-        <View style={s.cardMetric}>
-          <Text style={s.metricLabel}>Salaire de base</Text>
-          <Text style={s.metricValue}>{euro(emp.basePay)}</Text>
-        </View>
-        <View style={s.cardMetric}>
-          <Text style={s.metricLabel}>Majorations</Text>
-          <Text style={s.metricValue}>{euro(totalMajorations)}</Text>
-        </View>
+      <Text style={s.cardSubline}>{contractLine}</Text>
+
+      {/* Décomposition de la rémunération */}
+      <View style={s.breakdown}>
+        {lines.map((line, i) => {
+          const isLast = i === lines.length - 1
+          return (
+            <View key={i} style={isLast ? s.breakdownRowLast : s.breakdownRow}>
+              <View style={s.breakdownLabelGroup}>
+                <Text style={s.breakdownLabel}>{line.label}</Text>
+                {line.detail && <Text style={s.breakdownDetail}>{line.detail}</Text>}
+              </View>
+              <Text style={s.breakdownAmount}>{euro(line.amount)}</Text>
+            </View>
+          )
+        })}
       </View>
-      <View style={s.cardTotal}>
-        <Text style={s.cardTotalLabel}>Total brut</Text>
-        <Text style={s.cardTotalAmount}>{euro(emp.totalGrossPay)}</Text>
+
+      {/* Totaux brut + net */}
+      <View style={s.totalBlock}>
+        <View style={s.totalGrossRow}>
+          <Text style={s.totalGrossLabel}>Total brut</Text>
+          <Text style={s.totalGrossAmount}>{euro(emp.totalGrossPay)}</Text>
+        </View>
+        <View style={s.totalNetRow}>
+          <View>
+            <Text style={s.totalNetLabel}>Net à verser</Text>
+            <Text style={s.totalNetSub}>
+              Cotisations salariales déduites ({euro(emp.totalEmployeeDeductions)})
+            </Text>
+          </View>
+          <Text style={s.totalNetAmount}>{euro(emp.netPay)}</Text>
+        </View>
       </View>
     </View>
   )
@@ -347,8 +529,8 @@ const HOWTO_STEPS = [
     desc: null, // filled dynamically
   },
   {
-    title: 'Reportez les heures et le salaire net de ce récapitulatif',
-    desc: 'Pour chaque employé, renseignez le nombre d\u2019heures totales et le salaire net versé (hors congés payés si inclus).',
+    title: 'Reportez les heures totales et le salaire net à verser',
+    desc: 'Saisissez le nombre d’heures et le total NET à verser. Pour les compléments (présence responsable, heures de nuit), utilisez la rubrique « compléments de salaire ».',
   },
   {
     title: 'Validez la déclaration',
@@ -389,9 +571,11 @@ function HowToSection({ periodLabel }: { periodLabel: string }) {
       </Link>
 
       <Text style={s.howtoNote}>
-        Date limite de déclaration : avant le 15 du mois suivant la période d{'\u2019'}emploi.
-        En cas de retard, des pénalités peuvent s{'\u2019'}appliquer.
+        Date limite de déclaration : avant le 5 du mois suivant la période d{'’'}emploi.
+        En cas de retard, des pénalités peuvent s{'’'}appliquer.
         Les cotisations sont prélevées automatiquement sur votre compte bancaire environ 2 jours ouvrés après la déclaration.
+        {'\n'}
+        Le net affiché est une estimation IDCC 3239 (taux 2025) ; le montant exact figure sur le bulletin officiel CESU.
       </Text>
     </View>
   )

--- a/src/lib/export/declarationService.ts
+++ b/src/lib/export/declarationService.ts
@@ -7,8 +7,9 @@ import { supabase } from '@/lib/supabase/client'
 import { format, startOfMonth, endOfMonth } from 'date-fns'
 import { calculateShiftDuration, calculateNightHours } from '@/lib/compliance/utils'
 import { isPublicHoliday, isSunday } from '@/lib/compliance/types'
-import { MAJORATION_RATES, calculateOvertimeHours } from '@/lib/compliance/calculatePay'
-import type { ShiftForValidation } from '@/lib/compliance/types'
+import { calculateShiftPay, calculateOvertimeHours, MAJORATION_RATES } from '@/lib/compliance/calculatePay'
+import type { ShiftForValidation, ContractForCalculation, GuardSegment } from '@/lib/compliance/types'
+import { calculateCotisations } from './cotisationsCalculator'
 import type {
   MonthlyDeclarationData,
   EmployeeDeclarationData,
@@ -35,8 +36,11 @@ interface ContractForDeclarationDb {
   id: string
   employee_id: string
   contract_type: 'CDI' | 'CDD'
+  start_date: string
+  end_date: string | null
   hourly_rate: number
   weekly_hours: number
+  pas_rate?: number
   employee_profile?: {
     profile?: {
       id?: string
@@ -87,11 +91,14 @@ export async function getMonthlyDeclarationData(
   // Calculer les totaux
   const totalHours = employees.reduce((sum, e) => sum + e.totalHours, 0)
   const totalGrossPay = employees.reduce((sum, e) => sum + e.totalGrossPay, 0)
+  const totalNetPay = employees.reduce((sum, e) => sum + e.netPay, 0)
 
   return {
     year,
     month,
     periodLabel: getMonthLabel(year, month),
+    periodStartDate: startDate,
+    periodEndDate: endDate,
     employerId,
     employerFirstName: employerData.firstName,
     employerLastName: employerData.lastName,
@@ -100,6 +107,7 @@ export async function getMonthlyDeclarationData(
     employees,
     totalHours: Math.round(totalHours * 100) / 100,
     totalGrossPay: Math.round(totalGrossPay * 100) / 100,
+    totalNetPay: Math.round(totalNetPay * 100) / 100,
     totalEmployees: employees.length,
     generatedAt: new Date(),
   }
@@ -152,8 +160,11 @@ async function getActiveContracts(
       id,
       employee_id,
       contract_type,
+      start_date,
+      end_date,
       hourly_rate,
       weekly_hours,
+      pas_rate,
       employee_profile:employees!employee_id(
         profile:profiles!profile_id(
           id,
@@ -205,9 +216,9 @@ async function getShiftsForPeriod(
 }
 
 /**
- * Convertit un ShiftDbRow en ShiftForValidation pour les fonctions de calcul centralisées
+ * Convertit un ShiftDbRow en ShiftForValidation enrichi pour calculateShiftPay.
  */
-function toShiftForValidation(shift: ShiftDbRow, employeeId: string, contractId: string): ShiftForValidation {
+function toShiftForCalc(shift: ShiftDbRow, employeeId: string, contractId: string): ShiftForValidation {
   return {
     id: shift.id,
     contractId,
@@ -216,13 +227,21 @@ function toShiftForValidation(shift: ShiftDbRow, employeeId: string, contractId:
     startTime: shift.start_time,
     endTime: shift.end_time,
     breakDuration: shift.break_duration || 0,
+    shiftType: shift.shift_type ?? 'effective',
+    hasNightAction: shift.has_night_action !== false,
+    nightInterventionsCount: shift.night_interventions_count ?? 0,
+    guardSegments: (shift.guard_segments as GuardSegment[] | null) ?? undefined,
   }
 }
 
 /**
- * Calcule les données de déclaration pour un employé
- * Utilise les taux de MAJORATION_RATES (Convention Collective IDCC 3239)
- * et le calcul réel des heures supplémentaires via calculateOvertimeHours
+ * Calcule les données de déclaration pour un employé.
+ *
+ * Utilise `calculateShiftPay` pour chaque shift (source unique de vérité du calcul de paie
+ * IDCC 3239 — y compris le split jour/nuit pour les présences mixtes), puis agrège
+ * les composants pour obtenir les totaux mensuels.
+ *
+ * Le NET estimé est calculé via `calculateCotisations` à partir du brut total.
  */
 function calculateEmployeeDeclaration(
   contract: ContractForDeclarationDb,
@@ -230,10 +249,17 @@ function calculateEmployeeDeclaration(
 ): EmployeeDeclarationData {
   const hourlyRate = contract.hourly_rate
   const contractualWeeklyHours = contract.weekly_hours || 35
+  const contractForCalc: ContractForCalculation = {
+    id: contract.id,
+    weeklyHours: contractualWeeklyHours,
+    hourlyRate,
+  }
   const shiftsDetails: ShiftDeclarationDetail[] = []
 
   let totalHours = 0
-  let normalHours = 0
+  let effectiveWorkHours = 0
+  let presenceDayHours = 0
+  let presenceNightHours = 0
   let sundayHours = 0
   let holidayHours = 0
   let nightHours = 0
@@ -247,138 +273,96 @@ function calculateEmployeeDeclaration(
   let presenceResponsiblePay = 0
   let nightPresenceAllowance = 0
 
-  // Préparer tous les shifts au format ShiftForValidation pour le calcul des heures sup
-  const allShiftsForValidation = shifts.map((s) =>
-    toShiftForValidation(s, contract.employee_id, contract.id)
+  // Tous les shifts au format calcul (utile pour les heures sup contextualisées)
+  const allShiftsForCalc = shifts.map((s) =>
+    toShiftForCalc(s, contract.employee_id, contract.id)
   )
 
   for (let i = 0; i < shifts.length; i++) {
     const shift = shifts[i]
     const shiftDate = new Date(shift.date)
     const shiftType = shift.shift_type || 'effective'
-    const fullDurationMinutes = calculateShiftDuration(shift.start_time, shift.end_time, shift.break_duration || 0)
-    const fullDurationHours = fullDurationMinutes / 60
-    const effectiveMinutes = (shiftType === 'guard_24h' && shift.effective_hours != null)
-      ? shift.effective_hours * 60
-      : fullDurationMinutes
-    const effectiveHours = effectiveMinutes / 60
+    const fullDurationHours =
+      calculateShiftDuration(shift.start_time, shift.end_time, shift.break_duration || 0) / 60
     const shiftNightHours = calculateNightHours(shiftDate, shift.start_time, shift.end_time)
     const isSundayShift = isSunday(shiftDate)
     const isHolidayShift = isPublicHoliday(shiftDate)
 
-    let shiftBasePay = 0
-    let shiftPresenceResponsible = 0
-    let shiftNightPresence = 0
-    let shiftTotal = 0
-    let shiftSundayMaj = 0
-    let shiftHolidayMaj = 0
-    let shiftNightMaj = 0
-    let shiftOvertimeMaj = 0
+    // Calcul de paie centralisé (split jour/nuit, requalification, garde 24h, majorations).
+    // Hypothèse : travail habituel sur jours fériés → +60% (comportement historique du récap CESU).
+    const shiftForCalc = allShiftsForCalc[i]
+    const previousShifts = allShiftsForCalc.slice(0, i)
+    const pay = calculateShiftPay(shiftForCalc, contractForCalc, previousShifts, true)
 
+    // Agrégation des composants de paie (overtime recalculé en cumulatif plus bas)
+    basePay += pay.basePay
+    sundayMajoration += pay.sundayMajoration
+    holidayMajoration += pay.holidayMajoration
+    nightMajoration += pay.nightMajoration
+    presenceResponsiblePay += pay.presenceResponsiblePay
+    nightPresenceAllowance += pay.nightPresenceAllowance
+
+    // Compteurs d'heures (par catégorie pour le récap)
     if (shiftType === 'presence_day') {
-      // Art. 137.1 IDCC 3239 — présence responsable de jour : 1h = 2/3h de travail effectif
-      // effective_hours en DB = déjà réduit à 2/3 si renseigné, sinon on calcule
-      const presenceHours = shift.effective_hours ?? fullDurationHours * (2 / 3)
-      shiftPresenceResponsible = presenceHours * hourlyRate
-      if (isSundayShift) {
-        shiftSundayMaj = shiftPresenceResponsible * MAJORATION_RATES.SUNDAY
-        sundayHours += presenceHours
-      }
-      if (isHolidayShift) {
-        shiftHolidayMaj = shiftPresenceResponsible * MAJORATION_RATES.PUBLIC_HOLIDAY_WORKED
-        holidayHours += presenceHours
-      }
-      shiftTotal = shiftPresenceResponsible + shiftSundayMaj + shiftHolidayMaj
-      totalHours += presenceHours
-      presenceResponsiblePay += shiftPresenceResponsible
-
+      presenceDayHours += fullDurationHours
     } else if (shiftType === 'presence_night') {
-      // Art. 148 IDCC 3239 — présence de nuit : forfait >= 1/4 du taux horaire, ou 100% si requalifié
-      shiftNightPresence = shift.is_requalified
-        ? fullDurationHours * hourlyRate
-        : fullDurationHours * hourlyRate * 0.25
-      shiftTotal = shiftNightPresence
-      totalHours += fullDurationHours
-      nightPresenceAllowance += shiftNightPresence
-
+      presenceNightHours += fullDurationHours
+    } else if (shiftType === 'guard_24h') {
+      effectiveWorkHours += shift.effective_hours ?? 0
     } else {
-      // effective + guard_24h
-      shiftBasePay = effectiveHours * hourlyRate
-      shiftTotal = shiftBasePay
+      effectiveWorkHours += fullDurationHours
+    }
+    totalHours += fullDurationHours
 
-      if (isSundayShift) {
-        shiftSundayMaj = shiftBasePay * MAJORATION_RATES.SUNDAY
-        shiftTotal += shiftSundayMaj
-        sundayHours += effectiveHours
-      }
-
-      if (isHolidayShift) {
-        shiftHolidayMaj = shiftBasePay * MAJORATION_RATES.PUBLIC_HOLIDAY_WORKED
-        shiftTotal += shiftHolidayMaj
-        holidayHours += effectiveHours
-      }
-
-      // Majoration nuit : uniquement si un acte est effectué (has_night_action)
-      // Pour les anciens shifts sans le champ (null), on applique la majoration par rétrocompatibilité
-      const shiftHasNightAction = shift.has_night_action !== false
-      if (shiftNightHours > 0 && shiftHasNightAction) {
-        shiftNightMaj = shiftNightHours * hourlyRate * MAJORATION_RATES.NIGHT
-        shiftTotal += shiftNightMaj
-        nightHours += shiftNightHours
-      }
-
-      // Calcul réel des heures supplémentaires pour cette intervention
-      const shiftForValidation = allShiftsForValidation[i]
-      const previousShifts = allShiftsForValidation.slice(0, i)
-      const shiftOvertime = calculateOvertimeHours(
-        shiftForValidation,
-        previousShifts,
-        contractualWeeklyHours
-      )
-
-      if (shiftOvertime > 0) {
-        const cumulativeOvertimeBefore = overtimeHours
-        const cumulativeOvertimeAfter = overtimeHours + shiftOvertime
-        const first8hBefore = Math.min(8, cumulativeOvertimeBefore)
-        const first8hAfter = Math.min(8, cumulativeOvertimeAfter)
-        const beyond8hBefore = Math.max(0, cumulativeOvertimeBefore - 8)
-        const beyond8hAfter = Math.max(0, cumulativeOvertimeAfter - 8)
-        shiftOvertimeMaj =
-          (first8hAfter - first8hBefore) * hourlyRate * MAJORATION_RATES.OVERTIME_FIRST_8H +
-          (beyond8hAfter - beyond8hBefore) * hourlyRate * MAJORATION_RATES.OVERTIME_BEYOND_8H
-        shiftTotal += shiftOvertimeMaj
-        overtimeHours += shiftOvertime
-        overtimeMajoration += shiftOvertimeMaj
-      }
-
-      totalHours += effectiveHours
-      basePay += shiftBasePay
+    if (isSundayShift) sundayHours += fullDurationHours
+    if (isHolidayShift) holidayHours += fullDurationHours
+    // nightHours = heures de nuit majorées (uniquement si action de nuit)
+    const shiftHasNightAction = shift.has_night_action !== false
+    if (shiftNightHours > 0 && shiftHasNightAction && shiftType !== 'presence_day' && shiftType !== 'presence_night') {
+      nightHours += shiftNightHours
     }
 
-    sundayMajoration += shiftSundayMaj
-    holidayMajoration += shiftHolidayMaj
-    nightMajoration += shiftNightMaj
+    // Heures sup : calcul cumulatif sur la semaine pour répartir +25% / +50%
+    const shiftOvertime = calculateOvertimeHours(shiftForCalc, previousShifts, contractualWeeklyHours)
+    if (shiftOvertime > 0) {
+      const before = overtimeHours
+      const after = overtimeHours + shiftOvertime
+      const first8hAdded = Math.min(8, after) - Math.min(8, before)
+      const beyond8hAdded = Math.max(0, after - 8) - Math.max(0, before - 8)
+      overtimeMajoration += first8hAdded * hourlyRate * MAJORATION_RATES.OVERTIME_FIRST_8H
+      overtimeMajoration += beyond8hAdded * hourlyRate * MAJORATION_RATES.OVERTIME_BEYOND_8H
+      overtimeHours += shiftOvertime
+    }
 
-    // Ajouter le détail
     shiftsDetails.push({
       date: shiftDate,
       startTime: shift.start_time,
       endTime: shift.end_time,
       breakDuration: shift.break_duration || 0,
-      effectiveHours: shiftType === 'presence_day'
-        ? (shift.effective_hours ?? fullDurationHours * (2 / 3))
-        : effectiveHours,
+      effectiveHours:
+        shiftType === 'presence_day'
+          ? (shift.effective_hours ?? fullDurationHours * (2 / 3))
+          : shiftType === 'guard_24h'
+            ? (shift.effective_hours ?? 0)
+            : fullDurationHours,
       isSunday: isSundayShift,
       isHoliday: isHolidayShift,
       nightHours: shiftNightHours,
-      pay: Math.round(shiftTotal * 100) / 100,
+      pay: pay.totalPay,
     })
   }
 
-  // Heures normales = total - spéciales - supplémentaires (éviter double comptage)
-  normalHours = totalHours - sundayHours - holidayHours - overtimeHours
+  // Heures normales = total - spéciales - supplémentaires (sans double comptage)
+  const normalHours = Math.max(0, totalHours - sundayHours - holidayHours - overtimeHours)
 
-  const totalGrossPay = basePay + sundayMajoration + holidayMajoration + nightMajoration + overtimeMajoration + presenceResponsiblePay + nightPresenceAllowance
+  const totalGrossPay =
+    basePay + sundayMajoration + holidayMajoration + nightMajoration +
+    overtimeMajoration + presenceResponsiblePay + nightPresenceAllowance
+
+  // Net estimé via le calculateur de cotisations IDCC 3239
+  const cotisations = calculateCotisations(totalGrossPay, {
+    pasRate: contract.pas_rate ?? 0,
+  })
 
   return {
     employeeId: contract.employee_id,
@@ -386,9 +370,14 @@ function calculateEmployeeDeclaration(
     lastName: contract.employee_profile?.profile?.last_name || '',
     contractId: contract.id,
     contractType: contract.contract_type,
+    contractStartDate: contract.start_date ? new Date(contract.start_date) : undefined,
+    contractEndDate: contract.end_date ? new Date(contract.end_date) : undefined,
     hourlyRate,
     totalHours: Math.round(totalHours * 100) / 100,
     normalHours: Math.round(normalHours * 100) / 100,
+    effectiveWorkHours: Math.round(effectiveWorkHours * 100) / 100,
+    presenceDayHours: Math.round(presenceDayHours * 100) / 100,
+    presenceNightHours: Math.round(presenceNightHours * 100) / 100,
     sundayHours: Math.round(sundayHours * 100) / 100,
     holidayHours: Math.round(holidayHours * 100) / 100,
     nightHours: Math.round(nightHours * 100) / 100,
@@ -401,6 +390,8 @@ function calculateEmployeeDeclaration(
     presenceResponsiblePay: Math.round(presenceResponsiblePay * 100) / 100,
     nightPresenceAllowance: Math.round(nightPresenceAllowance * 100) / 100,
     totalGrossPay: Math.round(totalGrossPay * 100) / 100,
+    netPay: cotisations.netAPayer,
+    totalEmployeeDeductions: cotisations.totalEmployeeDeductions,
     shiftsCount: shifts.length,
     shiftsDetails,
   }

--- a/src/lib/export/types.ts
+++ b/src/lib/export/types.ts
@@ -12,15 +12,20 @@ export interface EmployeeDeclarationData {
   lastName: string
   contractId: string
   contractType: 'CDI' | 'CDD'
+  contractStartDate?: Date
+  contractEndDate?: Date
   hourlyRate: number
-  // Heures du mois
+  // Heures du mois (décomposition pour le récap CESU)
   totalHours: number
   normalHours: number
+  effectiveWorkHours: number   // Heures de travail effectif (shifts type "effective" + part effective garde 24h)
+  presenceDayHours: number     // Heures brutes de présence responsable de jour
+  presenceNightHours: number   // Heures brutes de présence responsable de nuit
   sundayHours: number
   holidayHours: number
   nightHours: number
   overtimeHours: number
-  // Rémunération
+  // Rémunération brute
   basePay: number
   sundayMajoration: number
   holidayMajoration: number
@@ -29,6 +34,9 @@ export interface EmployeeDeclarationData {
   presenceResponsiblePay: number  // Art. 137.1 — présence de jour (1h = 2/3h)
   nightPresenceAllowance: number  // Art. 148 — présence de nuit (forfait >= 1/4)
   totalGrossPay: number
+  // Net estimé (montant à reporter sur CESU)
+  netPay: number
+  totalEmployeeDeductions: number
   // Détails des interventions
   shiftsCount: number
   shiftsDetails: ShiftDeclarationDetail[]
@@ -53,6 +61,8 @@ export interface MonthlyDeclarationData {
   year: number
   month: number // 1-12
   periodLabel: string // "Janvier 2024"
+  periodStartDate: Date  // 1er du mois
+  periodEndDate: Date    // dernier du mois
   // Employeur
   employerId: string
   employerFirstName: string
@@ -64,6 +74,7 @@ export interface MonthlyDeclarationData {
   // Totaux
   totalHours: number
   totalGrossPay: number
+  totalNetPay: number
   totalEmployees: number
   // Métadonnées
   generatedAt: Date

--- a/src/services/cesuDeclarationService.ts
+++ b/src/services/cesuDeclarationService.ts
@@ -25,18 +25,22 @@ const SIGNED_URL_TTL_SECONDS = 3600
  * Convertit les objets Date en strings ISO.
  */
 function serializeDeclarationData(data: MonthlyDeclarationData): Record<string, unknown> {
+  const dateToIso = (d: Date | string | undefined): string | undefined => {
+    if (!d) return undefined
+    return d instanceof Date ? d.toISOString() : d
+  }
   return {
     ...data,
-    generatedAt: data.generatedAt instanceof Date
-      ? data.generatedAt.toISOString()
-      : data.generatedAt,
+    generatedAt: dateToIso(data.generatedAt as Date),
+    periodStartDate: dateToIso(data.periodStartDate as Date),
+    periodEndDate: dateToIso(data.periodEndDate as Date),
     employees: data.employees.map((emp) => ({
       ...emp,
+      contractStartDate: dateToIso(emp.contractStartDate),
+      contractEndDate: dateToIso(emp.contractEndDate),
       shiftsDetails: emp.shiftsDetails.map((shift) => ({
         ...shift,
-        date: shift.date instanceof Date
-          ? shift.date.toISOString()
-          : shift.date,
+        date: dateToIso(shift.date as Date),
       })),
     })),
   }
@@ -48,11 +52,17 @@ function serializeDeclarationData(data: MonthlyDeclarationData): Record<string, 
  */
 function deserializeDeclarationData(raw: Record<string, unknown>): MonthlyDeclarationData {
   const data = raw as unknown as MonthlyDeclarationData
+  const isoToDate = (v: string | Date | undefined): Date | undefined =>
+    v ? (v instanceof Date ? v : new Date(v)) : undefined
   return {
     ...data,
     generatedAt: new Date(data.generatedAt as unknown as string),
+    periodStartDate: isoToDate(data.periodStartDate as unknown as string)!,
+    periodEndDate: isoToDate(data.periodEndDate as unknown as string)!,
     employees: (data.employees || []).map((emp) => ({
       ...emp,
+      contractStartDate: isoToDate(emp.contractStartDate as unknown as string),
+      contractEndDate: isoToDate(emp.contractEndDate as unknown as string),
       shiftsDetails: (emp.shiftsDetails || []).map((shift) => ({
         ...shift,
         date: new Date(shift.date as unknown as string),


### PR DESCRIPTION
## Summary
Refonte du récap mensuel CESU pour donner à Marie tout ce dont elle a besoin pour reporter sa déclaration ligne par ligne. Avant, le PDF affichait `Salaire de base + Majorations = TOTAL BRUT` mais omettait `presenceResponsiblePay` et `nightPresenceAllowance` — du coup le total ne matchait pas la somme des composants. Et il n'y avait pas de net estimé, alors que c'est ce que CESU demande.

### Changements UI (PDF)
- **Période d'emploi explicite** sous l'employeur : `du 01/03/2026 au 31/03/2026`
- **Card employé enrichie** : taux horaire, dates de contrat (CDD/CDI), nombre d'interventions
- **Décomposition détaillée de la rémunération** (1 ligne par composant > 0) :
  - Travail effectif (heures × taux)
  - Présence responsable jour (×2/3, Art. 137.1)
  - Présence responsable nuit (forfait ×1/4 ou requalif. Art. 148)
  - Majoration dimanche (+30%)
  - Majoration jour férié
  - Majoration heures de nuit (+20%)
  - Heures supplémentaires (+25% / +50%)
- **Total brut** clairement labellisé
- **Net à verser** (avec déduction des cotisations salariales affichée)
- **Total général** : net + brut
- **Date limite corrigée** : avant le 5 du mois suivant (au lieu de 15)
- **Note** sur l'estimation IDCC 3239 (taux 2025)

### Changements backend
- **`declarationService.ts`** : refactor utilisant `calculateShiftPay` (source unique de vérité pour le calcul de paie, incluant le fix mixte jour/nuit de la PR #324). La logique cumulative des heures sup +25% / +50% est conservée (calculateShiftPay calcule shift par shift sans cumul). Net estimé via `calculateCotisations` (cotisations IDCC 3239 2025).
- **`types.ts`** : `EmployeeDeclarationData` étendu avec `effectiveWorkHours`, `presenceDayHours`, `presenceNightHours`, `contractStartDate/EndDate`, `netPay`, `totalEmployeeDeductions`. `MonthlyDeclarationData` étendu avec `periodStartDate/EndDate`, `totalNetPay`.
- **`cesuGenerator.ts`** (CSV + summary texte) : alignés avec les nouveaux champs (5 colonnes ajoutées au CSV, décomposition détaillée dans le summary).
- **`cesuDeclarationService.ts`** : serializer/deserializer adaptés pour les nouvelles dates (contractStartDate, contractEndDate, periodStartDate, periodEndDate).

### Erreurs corrigées par cette PR
1. **Total brut incohérent** : `basePay + majorations` n'incluait pas `presenceResponsiblePay` ni `nightPresenceAllowance` dans l'affichage → écart silencieux entre les composants visibles et le total
2. **Date limite incorrecte** : 15 → **5** (cf. cesu.urssaf.fr — 15 c'est Pajemploi)
3. **Pas de net estimé** : Marie devait calculer mentalement les cotisations
4. **Pas de période d'emploi** : champ obligatoire CESU absent
5. **Calcul interne désynchronisé** : `declarationService` recalculait la paie sans le split mixte de la PR #324

## Test plan
- [x] Générer un récap CESU pour un mois avec plusieurs types de shifts (effective + présence jour + présence nuit + garde 24h)
- [x] Vérifier que chaque composant > 0 est listé ligne par ligne dans la card employé
- [x] Vérifier que `Total brut = somme des lignes` (plus d'écart fantôme)
- [x] Vérifier que `Net à verser = Total brut - Cotisations salariales`
- [x] Tester un shift mixte 18h-23h en présence_day → ligne `Présence jour` au montant juste (3h × 2/3 × taux), ligne `Présence nuit` (2h × 0.25 × taux)
- [x] Tester avec un employé en CDD → dates de contrat affichées
- [x] Date limite affichée : "avant le 5 du mois suivant"
- [x] Période d'emploi : `du 01/MM au dernier jour du mois`
- [x] `npm run lint` (0 erreur)
- [x] `npm run typecheck` (OK)
- [x] `npm run test:run` (2270 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)