### PR TITLE
feat(courses): backend for multiple shopping list templates (max 5)

### DIFF
--- a/src/services/shoppingListTemplateService.test.ts
+++ b/src/services/shoppingListTemplateService.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  listShoppingListTemplates,
+  createShoppingListTemplate,
+  updateShoppingListTemplate,
+  deleteShoppingListTemplate,
+  setDefaultShoppingListTemplate,
+  SHOPPING_LIST_TEMPLATES_LIMIT,
+} from './shoppingListTemplateService'
+
+// ─── Mocks ──────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn()
+
+vi.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/sanitize', () => ({
+  sanitizeText: vi.fn((text: string) => text.trim()),
+}))
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── list ────────────────────────────────────────────────────────────
+
+describe('listShoppingListTemplates', () => {
+  it('retourne la liste mappée', async () => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    chain.select = vi.fn().mockReturnValue(chain)
+    chain.eq = vi.fn().mockReturnValue(chain)
+    let orderCount = 0
+    chain.order = vi.fn().mockImplementation(() => {
+      orderCount++
+      if (orderCount >= 2) {
+        return Promise.resolve({
+          data: [
+            {
+              id: 't1',
+              employer_id: 'e1',
+              name: 'Liste par défaut',
+              is_default: true,
+              items: [{ name: 'Lait', brand: '', quantity: 1, note: '' }],
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z',
+            },
+          ],
+          error: null,
+        })
+      }
+      return chain
+    })
+    mockFrom.mockReturnValue(chain)
+
+    const result = await listShoppingListTemplates('e1')
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('t1')
+    expect(result[0].isDefault).toBe(true)
+    expect(result[0].items[0].name).toBe('Lait')
+  })
+
+  it('retourne tableau vide si erreur', async () => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    chain.select = vi.fn().mockReturnValue(chain)
+    chain.eq = vi.fn().mockReturnValue(chain)
+    let orderCount = 0
+    chain.order = vi.fn().mockImplementation(() => {
+      orderCount++
+      if (orderCount >= 2) {
+        return Promise.resolve({ data: null, error: { message: 'fail' } })
+      }
+      return chain
+    })
+    mockFrom.mockReturnValue(chain)
+
+    const result = await listShoppingListTemplates('e1')
+    expect(result).toEqual([])
+  })
+})
+
+// ── create ──────────────────────────────────────────────────────────
+
+describe('createShoppingListTemplate', () => {
+  it('refuse si la limite est atteinte', async () => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    chain.select = vi.fn().mockReturnValue(chain)
+    chain.eq = vi.fn().mockReturnValue(chain)
+    let orderCount = 0
+    chain.order = vi.fn().mockImplementation(() => {
+      orderCount++
+      if (orderCount >= 2) {
+        return Promise.resolve({
+          data: Array.from({ length: SHOPPING_LIST_TEMPLATES_LIMIT }, (_, i) => ({
+            id: `t${i}`,
+            employer_id: 'e1',
+            name: `Liste ${i}`,
+            is_default: i === 0,
+            items: [],
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          })),
+          error: null,
+        })
+      }
+      return chain
+    })
+    mockFrom.mockReturnValue(chain)
+
+    await expect(
+      createShoppingListTemplate('e1', { name: 'Sixième' }),
+    ).rejects.toThrow(/Limite atteinte/)
+  })
+
+  it('refuse un nom vide', async () => {
+    // listShoppingListTemplates retourne []
+    const listChain: Record<string, ReturnType<typeof vi.fn>> = {}
+    listChain.select = vi.fn().mockReturnValue(listChain)
+    listChain.eq = vi.fn().mockReturnValue(listChain)
+    let orderCount = 0
+    listChain.order = vi.fn().mockImplementation(() => {
+      orderCount++
+      if (orderCount >= 2) return Promise.resolve({ data: [], error: null })
+      return listChain
+    })
+    mockFrom.mockReturnValue(listChain)
+
+    await expect(
+      createShoppingListTemplate('e1', { name: '   ' }),
+    ).rejects.toThrow(/nom de la liste est obligatoire/)
+  })
+})
+
+// ── update ──────────────────────────────────────────────────────────
+
+describe('updateShoppingListTemplate', () => {
+  it('refuse un nom vide', async () => {
+    await expect(
+      updateShoppingListTemplate('t1', { name: '   ' }),
+    ).rejects.toThrow(/nom de la liste est obligatoire/)
+  })
+
+  it('met à jour avec succès', async () => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+    chain.update = vi.fn().mockReturnValue(chain)
+    chain.eq = vi.fn().mockResolvedValue({ data: null, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await expect(
+      updateShoppingListTemplate('t1', { name: 'Nouveau nom' }),
+    ).resolves.toBeUndefined()
+    expect(chain.update).toHaveBeenCalled()
+  })
+})
+
+// ── delete ──────────────────────────────────────────────────────────
+
+describe('deleteShoppingListTemplate', () => {
+  it('supprime sans promotion si pas le default', async () => {
+    const deleteChain: Record<string, ReturnType<typeof vi.fn>> = {}
+    deleteChain.delete = vi.fn().mockReturnValue(deleteChain)
+    deleteChain.eq = vi.fn().mockReturnValue(deleteChain)
+    deleteChain.select = vi.fn().mockReturnValue(deleteChain)
+    deleteChain.single = vi.fn().mockResolvedValue({
+      data: { id: 't1', employer_id: 'e1', is_default: false },
+      error: null,
+    })
+    mockFrom.mockReturnValue(deleteChain)
+
+    await deleteShoppingListTemplate('t1')
+    expect(deleteChain.delete).toHaveBeenCalled()
+  })
+})
+
+// ── setDefault ──────────────────────────────────────────────────────
+
+describe('setDefaultShoppingListTemplate', () => {
+  it('désactive l\'ancien default puis active le nouveau', async () => {
+    const calls: string[] = []
+    mockFrom.mockImplementation(() => {
+      const chain: Record<string, ReturnType<typeof vi.fn>> = {}
+      chain.update = vi.fn().mockImplementation((data) => {
+        calls.push(`update is_default=${(data as { is_default: boolean }).is_default}`)
+        return chain
+      })
+      // .eq() peut être chaîné plusieurs fois ; le dernier appel sert de terminal
+      // (le chain est thenable plus bas)
+      chain.eq = vi.fn().mockReturnValue(chain)
+      // thenable pour permettre `await chain.eq(...)` comme terminal
+      chain.then = vi.fn().mockImplementation((fn: (v: unknown) => unknown) => {
+        return Promise.resolve({ data: null, error: null }).then(fn)
+      })
+      return chain
+    })
+
+    await setDefaultShoppingListTemplate('t2', 'e1')
+    // 2 updates : 1 pour désactiver l'ancien, 1 pour activer le nouveau
+    expect(calls).toEqual([
+      'update is_default=false',
+      'update is_default=true',
+    ])
+  })
+})

--- a/src/services/shoppingListTemplateService.ts
+++ b/src/services/shoppingListTemplateService.ts
@@ -1,0 +1,220 @@
+/**
+ * Service CRUD pour les modèles de listes de courses.
+ * Table : shopping_list_templates (jusqu'à 5 par employeur).
+ *
+ * Le snapshot est natif : les items sont copiés dans `shifts.tasks` à la
+ * création d'une intervention, donc modifier un template ne modifie pas
+ * les interventions passées.
+ */
+
+import { supabase } from '@/lib/supabase/client'
+import { logger } from '@/lib/logger'
+import { sanitizeText } from '@/lib/sanitize'
+import type { ShoppingItem } from '@/lib/constants/taskDefaults'
+import type { ShoppingListTemplateDbRow } from '@/types/database'
+
+export const SHOPPING_LIST_TEMPLATES_LIMIT = 5
+export const SHOPPING_LIST_TEMPLATE_NAME_MAX = 60
+
+export interface ShoppingListTemplate {
+  id: string
+  employerId: string
+  name: string
+  isDefault: boolean
+  items: ShoppingItem[]
+  createdAt: Date
+  updatedAt: Date
+}
+
+function mapFromDb(row: ShoppingListTemplateDbRow): ShoppingListTemplate {
+  return {
+    id: row.id,
+    employerId: row.employer_id,
+    name: row.name,
+    isDefault: row.is_default,
+    items: (row.items ?? []).map(item => ({
+      name: item.name ?? '',
+      brand: item.brand ?? '',
+      quantity: item.quantity ?? 1,
+      note: item.note ?? '',
+    })),
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  }
+}
+
+function sanitizeItems(items: ShoppingItem[]): ShoppingItem[] {
+  return items.map(item => ({
+    name: sanitizeText(item.name),
+    brand: sanitizeText(item.brand),
+    quantity: item.quantity,
+    note: sanitizeText(item.note),
+  }))
+}
+
+/**
+ * Liste les templates d'un employeur, triés par défaut en tête puis par date.
+ */
+export async function listShoppingListTemplates(
+  employerId: string,
+): Promise<ShoppingListTemplate[]> {
+  const { data, error } = await supabase
+    .from('shopping_list_templates')
+    .select('*')
+    .eq('employer_id', employerId)
+    .order('is_default', { ascending: false })
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    logger.error('Erreur chargement shopping list templates:', error)
+    return []
+  }
+  return (data ?? []).map(row => mapFromDb(row as ShoppingListTemplateDbRow))
+}
+
+interface CreateInput {
+  name: string
+  items?: ShoppingItem[]
+  isDefault?: boolean
+}
+
+/**
+ * Crée un template. Refuse si l'employeur en a déjà 5.
+ * Si `isDefault` est passé à `true`, désactive le précédent default.
+ */
+export async function createShoppingListTemplate(
+  employerId: string,
+  input: CreateInput,
+): Promise<ShoppingListTemplate> {
+  const existing = await listShoppingListTemplates(employerId)
+  if (existing.length >= SHOPPING_LIST_TEMPLATES_LIMIT) {
+    throw new Error(
+      `Limite atteinte : ${SHOPPING_LIST_TEMPLATES_LIMIT} listes maximum par employeur.`,
+    )
+  }
+
+  const name = sanitizeText(input.name).slice(0, SHOPPING_LIST_TEMPLATE_NAME_MAX)
+  if (!name) throw new Error('Le nom de la liste est obligatoire.')
+
+  const wantsDefault = input.isDefault ?? existing.length === 0
+  if (wantsDefault) await unsetDefault(employerId)
+
+  const { data, error } = await supabase
+    .from('shopping_list_templates')
+    .insert({
+      employer_id: employerId,
+      name,
+      is_default: wantsDefault,
+      items: sanitizeItems(input.items ?? []),
+    })
+    .select()
+    .single()
+
+  if (error || !data) {
+    logger.error('Erreur création template liste de courses:', error)
+    throw error ?? new Error('Échec de création du template.')
+  }
+  return mapFromDb(data as ShoppingListTemplateDbRow)
+}
+
+interface UpdateInput {
+  name?: string
+  items?: ShoppingItem[]
+}
+
+/**
+ * Met à jour un template (nom et/ou items). Le statut `isDefault` se gère
+ * via `setDefaultShoppingListTemplate` pour préserver l'invariant.
+ */
+export async function updateShoppingListTemplate(
+  id: string,
+  patch: UpdateInput,
+): Promise<void> {
+  const update: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  }
+  if (patch.name !== undefined) {
+    const name = sanitizeText(patch.name).slice(0, SHOPPING_LIST_TEMPLATE_NAME_MAX)
+    if (!name) throw new Error('Le nom de la liste est obligatoire.')
+    update.name = name
+  }
+  if (patch.items !== undefined) {
+    update.items = sanitizeItems(patch.items)
+  }
+
+  const { error } = await supabase
+    .from('shopping_list_templates')
+    .update(update)
+    .eq('id', id)
+
+  if (error) {
+    logger.error('Erreur mise à jour template liste de courses:', error)
+    throw error
+  }
+}
+
+/**
+ * Supprime un template. Si c'était le default et qu'il reste d'autres listes,
+ * promeut la plus ancienne en nouveau default.
+ */
+export async function deleteShoppingListTemplate(id: string): Promise<void> {
+  const { data: deleted, error } = await supabase
+    .from('shopping_list_templates')
+    .delete()
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) {
+    logger.error('Erreur suppression template liste de courses:', error)
+    throw error
+  }
+
+  // Si on a supprimé le default, promouvoir le suivant comme nouveau default
+  const row = deleted as ShoppingListTemplateDbRow | null
+  if (row?.is_default) {
+    const { data: next } = await supabase
+      .from('shopping_list_templates')
+      .select('id')
+      .eq('employer_id', row.employer_id)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle()
+
+    if (next) {
+      await supabase
+        .from('shopping_list_templates')
+        .update({ is_default: true, updated_at: new Date().toISOString() })
+        .eq('id', (next as { id: string }).id)
+    }
+  }
+}
+
+async function unsetDefault(employerId: string): Promise<void> {
+  await supabase
+    .from('shopping_list_templates')
+    .update({ is_default: false, updated_at: new Date().toISOString() })
+    .eq('employer_id', employerId)
+    .eq('is_default', true)
+}
+
+/**
+ * Définit un template comme "par défaut". Désactive le précédent default
+ * de l'employeur (l'index unique partiel garantit l'unicité côté DB).
+ */
+export async function setDefaultShoppingListTemplate(
+  id: string,
+  employerId: string,
+): Promise<void> {
+  await unsetDefault(employerId)
+
+  const { error } = await supabase
+    .from('shopping_list_templates')
+    .update({ is_default: true, updated_at: new Date().toISOString() })
+    .eq('id', id)
+
+  if (error) {
+    logger.error('Erreur set default template liste de courses:', error)
+    throw error
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -419,6 +419,16 @@ export interface ShoppingArticleHistoryDbRow {
   last_used_at: string
 }
 
+export interface ShoppingListTemplateDbRow {
+  id: string
+  employer_id: string
+  name: string
+  is_default: boolean
+  items: ShoppingItemDb[]
+  created_at: string
+  updated_at: string
+}
+
 // ============================================================
 // CONVENTION SETTINGS
 // ============================================================


### PR DESCRIPTION
## Summary
Première brique pour permettre à Marie d'avoir plusieurs listes de courses (ex : « Courses semaine », « Pharmacie », « Ménage ») et de choisir laquelle utiliser à la création d'une intervention. Cette PR pose la fondation backend ; la PR suivante ajoutera l'UI (paramètres + dropdown au shift).

### Changements
- **Migration `056_shopping_list_templates.sql`** :
  - Nouvelle table `shopping_list_templates` (id, employer_id, name, is_default, items JSONB, timestamps)
  - **Index unique partiel** `WHERE is_default = true` pour garantir un seul template par défaut côté DB
  - RLS owner-only (`employer_id = auth.uid()`)
  - **Migration des listes existantes** : pour chaque utilisateur ayant une `intervention_settings.shopping_list` non vide, on crée automatiquement un template « Liste par défaut » → aucune perte de données
- **Service `shoppingListTemplateService.ts`** :
  - `listShoppingListTemplates`, `createShoppingListTemplate`, `updateShoppingListTemplate`, `deleteShoppingListTemplate`, `setDefaultShoppingListTemplate`
  - Limite à **5 templates par employeur** validée côté app (refus côté serveur via index unique pour `is_default`)
  - Sanitize via DOMPurify sur tous les champs texte (name, items.name/brand/note)
  - Promotion automatique du suivant en default si on supprime le default
- **Type DB** : nouveau `ShoppingListTemplateDbRow`
- **Tests** : 8 tests unitaires (list, create avec limite, validation nom, update, delete, setDefault avec ordonnancement)

### Conception
- **Snapshot natif** : les items sont copiés dans `shifts.tasks` (préfixés `[courses]`) à la création d'une intervention. Modifier un template **ne modifie pas** les interventions passées — pas de logique snapshot custom à ajouter.
- **Coexistence** : `intervention_settings.shopping_list` reste pour la rétrocompat read-only ; la migration y a fait pointer le contenu existant vers le nouveau modèle.

## Test plan
- [ ] Lancer la migration `056` sur l'env de test
- [ ] Vérifier que les utilisateurs avec une liste existante voient « Liste par défaut » créée automatiquement
- [ ] Tenter d'insérer 2 templates avec `is_default = true` pour le même employeur → la DB refuse (violation index unique)
- [ ] RLS : un utilisateur ne voit pas les templates des autres
- [x] `npm run lint` (0 erreur)
- [x] `npm run typecheck` (OK)
- [x] `npm run test:run` (2278 passed / 4 skipped — +8 nouveaux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)