### PR TITLE
fix(migration): restore content of 056_shopping_list_templates

### DIFF
--- a/supabase/migrations/056_shopping_list_templates.sql
+++ b/supabase/migrations/056_shopping_list_templates.sql
@@ -1,0 +1,48 @@
+-- Modèles de listes de courses (jusqu'à 5 par employeur)
+-- Permet à Marie de gérer plusieurs listes (ex: "Courses semaine", "Pharmacie",
+-- "Ménage") et de choisir laquelle utiliser à la création d'une intervention.
+--
+-- Le snapshot est natif : les items sélectionnés sont copiés dans `shifts.tasks`
+-- (préfixés `[courses]`), donc modifier un template n'affecte pas les
+-- interventions passées.
+
+CREATE TABLE shopping_list_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  employer_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  name TEXT NOT NULL CHECK (length(name) BETWEEN 1 AND 60),
+  is_default BOOLEAN NOT NULL DEFAULT false,
+  items JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- items format: [{ "name": "Lait", "brand": "Lactel", "quantity": 1, "note": "" }]
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Un seul template "par défaut" par employeur (index partiel filtré)
+CREATE UNIQUE INDEX shopping_list_templates_one_default_per_employer
+  ON shopping_list_templates (employer_id)
+  WHERE is_default = true;
+
+CREATE INDEX shopping_list_templates_employer_idx
+  ON shopping_list_templates (employer_id);
+
+ALTER TABLE shopping_list_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own shopping list templates"
+  ON shopping_list_templates FOR ALL
+  USING (employer_id = auth.uid())
+  WITH CHECK (employer_id = auth.uid());
+
+-- Migration des listes existantes : pour chaque utilisateur ayant une
+-- `intervention_settings.shopping_list` non vide, on crée un template
+-- "Liste par défaut" par défaut.
+INSERT INTO shopping_list_templates (employer_id, name, is_default, items)
+SELECT
+  profile_id,
+  'Liste par défaut',
+  true,
+  shopping_list
+FROM intervention_settings
+WHERE shopping_list IS NOT NULL
+  AND jsonb_typeof(shopping_list) = 'array'
+  AND jsonb_array_length(shopping_list) > 0
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
La migration `056_shopping_list_templates.sql` mergée dans la PR #326 a été commitée **vide** (0 lignes) côté `main`, alors que le contenu original (48 lignes) avait été écrit lors de l'édition. Cette PR restaure le contenu exact.

### Conséquence si non corrigée
La migration ne fait rien lors du déploiement → la table `shopping_list_templates` n'est jamais créée → le service de la PR #326 plantera à la première utilisation, et la PR 2 (UI) sera bloquée.

### Contenu restauré
- Table `shopping_list_templates` (id, employer_id, name, is_default, items JSONB, timestamps) avec contrainte sur la longueur du nom (1-60 caractères)
- Index unique partiel `WHERE is_default = true` → garantit un seul template par défaut par employeur
- Index général sur `employer_id`
- RLS owner-only (`employer_id = auth.uid()`)
- Migration des `intervention_settings.shopping_list` existantes vers une template « Liste par défaut » par employeur

## Test plan
- [ ] Lancer la migration `056` sur l'env de test (cette fois elle créera bien la table)
- [ ] Vérifier que la table `shopping_list_templates` existe + RLS active + index présents
- [ ] Vérifier que les utilisateurs ayant une liste existante voient « Liste par défaut » créée

🤖 Generated with [Claude Code](https://claude.com/claude-code)