### PR TITLE
feat(courses): UI for multiple shopping list templates

### DIFF
--- a/src/components/planning/TaskSelector.tsx
+++ b/src/components/planning/TaskSelector.tsx
@@ -13,7 +13,8 @@ import {
   parseShoppingItemString,
 } from '@/lib/constants/taskDefaults'
 import type { ShoppingItem } from '@/lib/constants/taskDefaults'
-import { loadDefaultTasks, loadCustomTasks, loadShoppingList, useInterventionSettings } from '@/hooks/useInterventionSettings'
+import { loadDefaultTasks, loadCustomTasks, useInterventionSettings } from '@/hooks/useInterventionSettings'
+import { useShoppingListTemplates } from '@/hooks/useShoppingListTemplates'
 
 const MAX_CUSTOM_TASKS = 20
 
@@ -125,18 +126,28 @@ interface TaskSelectorProps {
 }
 
 export function TaskSelector({ value, onChange, prefillFromSettings = false }: TaskSelectorProps) {
-  const { articleSuggestions, searchArticles, trackArticle, shoppingList: savedShoppingList } = useInterventionSettings()
+  const { articleSuggestions, searchArticles, trackArticle } = useInterventionSettings()
+  const { templates, defaultTemplate } = useShoppingListTemplates()
 
-  // Prefill au mount
+  // Template sélectionné pour l'intervention en cours
+  // (par défaut = template "par défaut" de l'employeur, mais peut être changé via le dropdown)
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null)
+  const selectedTemplate = useMemo(
+    () => templates.find(t => t.id === selectedTemplateId) ?? defaultTemplate,
+    [templates, selectedTemplateId, defaultTemplate],
+  )
+  const savedShoppingList = useMemo(
+    () => selectedTemplate?.items ?? [],
+    [selectedTemplate],
+  )
+
+  // Prefill au mount (sans la liste de courses, qui est ajoutée plus tard quand
+  // les templates sont chargés)
   const initialValue = useMemo(() => {
     if (prefillFromSettings && value.length === 0) {
       const tasks = loadDefaultTasks()
       const custom = loadCustomTasks()
-      const hasCourses = tasks.includes('Courses')
-      const shopping = hasCourses
-        ? loadShoppingList().map(formatShoppingItem)
-        : []
-      return encodeTasksArray(tasks, shopping, custom)
+      return encodeTasksArray(tasks, [], custom)
     }
     return value
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -150,6 +161,23 @@ export function TaskSelector({ value, onChange, prefillFromSettings = false }: T
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Une fois que les templates sont chargés, si "Courses" est pré-sélectionnée
+  // et qu'aucun item n'a encore été ajouté, on pré-remplit avec les items du
+  // template par défaut.
+  const coursesPrefillDone = useRef(false)
+  useEffect(() => {
+    if (coursesPrefillDone.current) return
+    if (!prefillFromSettings) return
+    if (!defaultTemplate) return
+    const { selectedTasks: sel, shoppingItems: ship } = parseTasksArray(value)
+    if (sel.includes('Courses') && ship.length === 0 && defaultTemplate.items.length > 0) {
+      coursesPrefillDone.current = true
+      const items = defaultTemplate.items.map(formatShoppingItem)
+      onChange(encodeTasksArray(sel, items, parseTasksArray(value).customTasks))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultTemplate])
 
   const currentValue = value.length > 0 ? value : initialValue
 
@@ -421,10 +449,49 @@ export function TaskSelector({ value, onChange, prefillFromSettings = false }: T
                   borderRadius="0 8px 8px 0"
                   py={2}
                 >
+                  {/* Sélecteur de liste (visible uniquement si plusieurs templates) */}
+                  {templates.length > 1 && (
+                    <Flex justify="space-between" align="center" px={2} mb={2} gap={2}>
+                      <Text fontSize="xs" fontWeight="600" color="text.muted" whiteSpace="nowrap">
+                        Liste à utiliser
+                      </Text>
+                      <Box
+                        as="select"
+                        value={selectedTemplate?.id ?? ''}
+                        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                          const id = e.target.value
+                          setSelectedTemplateId(id)
+                          // Remplacer les items courants par ceux du nouveau template
+                          const tpl = templates.find(t => t.id === id)
+                          if (tpl) {
+                            emitChange({ shopping: tpl.items.map(formatShoppingItem) })
+                          }
+                        }}
+                        flex={1}
+                        px={2} py={1}
+                        borderRadius="8px"
+                        borderWidth="1.5px"
+                        borderColor="border.default"
+                        bg="bg.surface"
+                        fontSize="xs"
+                        fontWeight="500"
+                        cursor="pointer"
+                        _hover={{ borderColor: 'brand.solid' }}
+                        aria-label="Choisir la liste de courses"
+                      >
+                        {templates.map(t => (
+                          <option key={t.id} value={t.id}>
+                            {t.name}{t.isDefault ? ' (défaut)' : ''}
+                          </option>
+                        ))}
+                      </Box>
+                    </Flex>
+                  )}
+
                   {/* Header shopping avec toggle all */}
                   <Flex justify="space-between" align="center" px={2} mb={1}>
                     <Text fontSize="xs" fontWeight="600" color="text.muted">
-                      Liste de courses
+                      {templates.length > 1 ? selectedTemplate?.name ?? 'Liste de courses' : 'Liste de courses'}
                     </Text>
                     {allShoppingItems.length > 0 && (
                       <Box

--- a/src/components/profile/ShoppingListTemplatesSection.tsx
+++ b/src/components/profile/ShoppingListTemplatesSection.tsx
@@ -1,0 +1,401 @@
+/**
+ * Section "Mes listes de courses" dans la page Paramètres > Interventions.
+ *
+ * Permet à Marie de gérer jusqu'à 5 templates de listes de courses
+ * (ex: « Courses semaine », « Pharmacie », « Ménage »), de définir laquelle
+ * est utilisée par défaut, et d'éditer leurs items.
+ *
+ * Les modifications n'affectent pas les interventions passées (snapshot natif
+ * via `shifts.tasks`).
+ */
+
+import { useState } from 'react'
+import {
+  Box, Card, HStack, VStack, Text, Input, Badge, Spinner, Center,
+} from '@chakra-ui/react'
+import { GhostButton, PrimaryButton } from '@/components/ui'
+import { useShoppingListTemplates } from '@/hooks/useShoppingListTemplates'
+import { SHOPPING_LIST_TEMPLATES_LIMIT, type ShoppingListTemplate } from '@/services/shoppingListTemplateService'
+import type { ShoppingItem } from '@/lib/constants/taskDefaults'
+
+export function ShoppingListTemplatesSection() {
+  const {
+    templates, isLoading, isAtLimit, error,
+    createTemplate, updateTemplate, deleteTemplate, setDefault,
+  } = useShoppingListTemplates()
+
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  const handleCreate = async () => {
+    const name = newName.trim()
+    if (!name || isAtLimit) return
+    setCreating(true)
+    const created = await createTemplate({ name })
+    setCreating(false)
+    if (created) {
+      setNewName('')
+      setExpandedId(created.id)
+    }
+  }
+
+  if (isLoading && templates.length === 0) {
+    return (
+      <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm">
+        <Card.Body p={4}>
+          <Center py={6}><Spinner size="sm" /></Center>
+        </Card.Body>
+      </Card.Root>
+    )
+  }
+
+  return (
+    <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm">
+      <Card.Header px={4} py={3} borderBottomWidth="1px" borderColor="border.default">
+        <HStack justify="space-between" align="start">
+          <Box>
+            <Card.Title fontFamily="heading" fontSize="lg" fontWeight="700">
+              Mes listes de courses
+            </Card.Title>
+            <Text fontSize="sm" color="text.muted" mt={1}>
+              Créez jusqu&apos;à {SHOPPING_LIST_TEMPLATES_LIMIT} listes (ex&nbsp;: « Courses semaine », « Pharmacie »).
+              Vous choisirez laquelle utiliser à la création d&apos;une intervention.
+            </Text>
+          </Box>
+          <Badge variant="subtle" colorPalette="brand" fontSize="xs" whiteSpace="nowrap">
+            {templates.length} / {SHOPPING_LIST_TEMPLATES_LIMIT}
+          </Badge>
+        </HStack>
+      </Card.Header>
+      <Card.Body p={4}>
+        {error && (
+          <Box px={3} py={2} mb={3} borderRadius="md" bg="red.50" borderWidth="1px" borderColor="red.200">
+            <Text fontSize="sm" color="red.700">{error}</Text>
+          </Box>
+        )}
+
+        {templates.length === 0 ? (
+          <Box p={6} textAlign="center" borderWidth="1px" borderStyle="dashed" borderColor="border.default" borderRadius="md" mb={4}>
+            <Text fontSize="sm" color="text.muted">
+              Aucune liste pour l&apos;instant. Créez votre première liste ci-dessous.
+            </Text>
+          </Box>
+        ) : (
+          <VStack gap={2} align="stretch" mb={4}>
+            {templates.map(template => (
+              <TemplateRow
+                key={template.id}
+                template={template}
+                expanded={expandedId === template.id}
+                onToggleExpand={() => setExpandedId(expandedId === template.id ? null : template.id)}
+                onSetDefault={() => setDefault(template.id)}
+                onDelete={() => deleteTemplate(template.id)}
+                onUpdate={patch => updateTemplate(template.id, patch)}
+              />
+            ))}
+          </VStack>
+        )}
+
+        {/* Création d'une nouvelle liste */}
+        <Box pt={3} borderTopWidth="1px" borderColor="border.default">
+          <Text fontSize="sm" fontWeight="600" color="text.muted" mb={2}>
+            Créer une nouvelle liste
+          </Text>
+          <HStack gap={2}>
+            <Input
+              size="sm"
+              placeholder="Nom de la liste (ex : Pharmacie)"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter' && !isAtLimit) { e.preventDefault(); void handleCreate() } }}
+              borderRadius="md"
+              maxLength={60}
+              disabled={isAtLimit}
+              aria-label="Nom de la nouvelle liste"
+            />
+            <PrimaryButton
+              size="sm"
+              onClick={handleCreate}
+              disabled={isAtLimit || !newName.trim() || creating}
+            >
+              {creating ? '…' : '+ Créer'}
+            </PrimaryButton>
+          </HStack>
+          {isAtLimit && (
+            <Text fontSize="xs" color="text.muted" mt={2}>
+              Limite atteinte&nbsp;: {SHOPPING_LIST_TEMPLATES_LIMIT} listes maximum. Supprimez-en une pour en créer une nouvelle.
+            </Text>
+          )}
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  )
+}
+
+// ── Une ligne par template ──
+
+interface TemplateRowProps {
+  template: ShoppingListTemplate
+  expanded: boolean
+  onToggleExpand: () => void
+  onSetDefault: () => void
+  onDelete: () => void
+  onUpdate: (patch: { name?: string; items?: ShoppingItem[] }) => Promise<boolean>
+}
+
+function TemplateRow({
+  template, expanded, onToggleExpand,
+  onSetDefault, onDelete, onUpdate,
+}: TemplateRowProps) {
+  const [renaming, setRenaming] = useState(false)
+  const [name, setName] = useState(template.name)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const handleRename = async () => {
+    const trimmed = name.trim()
+    if (!trimmed || trimmed === template.name) {
+      setRenaming(false)
+      setName(template.name)
+      return
+    }
+    const ok = await onUpdate({ name: trimmed })
+    if (ok) setRenaming(false)
+  }
+
+  const handleDelete = async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true)
+      return
+    }
+    await onDelete()
+  }
+
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor={template.isDefault ? 'brand.300' : 'border.default'}
+      borderRadius="md"
+      bg={template.isDefault ? 'brand.subtle' : 'bg.surface'}
+      transition="all 0.15s"
+    >
+      {/* Header de la card */}
+      <HStack
+        gap={3}
+        px={3}
+        py={2}
+        cursor="pointer"
+        onClick={onToggleExpand}
+        _hover={{ bg: template.isDefault ? 'brand.subtle' : 'bg.muted' }}
+        borderRadius="md"
+      >
+        <Text fontSize="sm" color="text.muted" w="14px">
+          {expanded ? '▾' : '▸'}
+        </Text>
+
+        {renaming ? (
+          <Input
+            size="sm"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={e => {
+              e.stopPropagation()
+              if (e.key === 'Enter') { e.preventDefault(); void handleRename() }
+              if (e.key === 'Escape') { setRenaming(false); setName(template.name) }
+            }}
+            onClick={e => e.stopPropagation()}
+            onBlur={handleRename}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            maxLength={60}
+            flex={1}
+          />
+        ) : (
+          <Text
+            fontSize="sm"
+            fontWeight="600"
+            flex={1}
+            onDoubleClick={e => { e.stopPropagation(); setRenaming(true) }}
+          >
+            {template.name}
+          </Text>
+        )}
+
+        <Text fontSize="xs" color="text.muted">
+          {template.items.length} article{template.items.length > 1 ? 's' : ''}
+        </Text>
+
+        {template.isDefault && (
+          <Badge variant="subtle" colorPalette="brand" fontSize="xs">Par défaut</Badge>
+        )}
+      </HStack>
+
+      {/* Body expandable */}
+      {expanded && (
+        <Box px={3} pb={3} borderTopWidth="1px" borderColor="border.default" pt={2}>
+          {/* Items */}
+          <ItemsEditor
+            items={template.items}
+            onChange={items => onUpdate({ items })}
+          />
+
+          {/* Actions */}
+          <HStack gap={2} mt={3} pt={3} borderTopWidth="1px" borderColor="border.default" justify="flex-end" flexWrap="wrap">
+            {!renaming && (
+              <GhostButton size="sm" onClick={() => setRenaming(true)}>Renommer</GhostButton>
+            )}
+            {!template.isDefault && (
+              <GhostButton size="sm" onClick={onSetDefault}>Définir par défaut</GhostButton>
+            )}
+            {confirmDelete ? (
+              <>
+                <Text fontSize="xs" color="red.700" mr={2}>Confirmer ?</Text>
+                <GhostButton size="sm" onClick={() => setConfirmDelete(false)}>Annuler</GhostButton>
+                <PrimaryButton size="sm" colorPalette="red" onClick={handleDelete}>Supprimer</PrimaryButton>
+              </>
+            ) : (
+              <GhostButton size="sm" onClick={handleDelete}>Supprimer</GhostButton>
+            )}
+          </HStack>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+// ── Éditeur d'items pour un template ──
+
+interface ItemsEditorProps {
+  items: ShoppingItem[]
+  onChange: (items: ShoppingItem[]) => Promise<boolean>
+}
+
+function ItemsEditor({ items, onChange }: ItemsEditorProps) {
+  const [newName, setNewName] = useState('')
+  const [newBrand, setNewBrand] = useState('')
+  const [newNote, setNewNote] = useState('')
+
+  const addItem = () => {
+    const name = newName.trim()
+    if (!name) return
+    const next: ShoppingItem[] = [
+      ...items,
+      { name, brand: newBrand.trim(), quantity: 1, note: newNote.trim() },
+    ]
+    void onChange(next)
+    setNewName('')
+    setNewBrand('')
+    setNewNote('')
+  }
+
+  const removeItem = (index: number) => {
+    void onChange(items.filter((_, i) => i !== index))
+  }
+
+  const updateQuantity = (index: number, delta: number) => {
+    const next = items.map((item, i) =>
+      i === index
+        ? { ...item, quantity: Math.max(1, (item.quantity || 1) + delta) }
+        : item
+    )
+    void onChange(next)
+  }
+
+  return (
+    <VStack gap={2} align="stretch">
+      {items.length === 0 ? (
+        <Text fontSize="xs" color="text.muted" fontStyle="normal" textAlign="center" py={2}>
+          Aucun article. Ajoutez-en un ci-dessous.
+        </Text>
+      ) : (
+        <VStack gap={1} align="stretch">
+          {items.map((item, i) => (
+            <HStack
+              key={`${item.name}-${item.brand}-${i}`}
+              gap={2}
+              px={2} py={1.5}
+              bg="bg.surface"
+              borderWidth="1px"
+              borderColor="border.default"
+              borderRadius="md"
+              fontSize="sm"
+            >
+              <VStack gap={0} align="start" flex={1}>
+                <HStack gap={2}>
+                  <Text fontWeight="600" fontSize="sm">{item.name}</Text>
+                  {item.brand && (
+                    <Text fontSize="xs" color="text.muted">— {item.brand}</Text>
+                  )}
+                </HStack>
+                {item.note && (
+                  <Text fontSize="xs" color="text.muted">{item.note}</Text>
+                )}
+              </VStack>
+              <HStack gap={1}>
+                <Box
+                  as="button" type="button"
+                  w="20px" h="20px" borderRadius="full"
+                  bg="border.default" fontSize="xs" fontWeight="bold"
+                  display="flex" alignItems="center" justifyContent="center"
+                  _hover={{ bg: 'brand.subtle' }}
+                  onClick={() => updateQuantity(i, -1)}
+                  aria-label={`Diminuer ${item.name}`}
+                >−</Box>
+                <Text fontSize="xs" fontWeight="600" minW="22px" textAlign="center">
+                  x{item.quantity || 1}
+                </Text>
+                <Box
+                  as="button" type="button"
+                  w="20px" h="20px" borderRadius="full"
+                  bg="border.default" fontSize="xs" fontWeight="bold"
+                  display="flex" alignItems="center" justifyContent="center"
+                  _hover={{ bg: 'brand.subtle' }}
+                  onClick={() => updateQuantity(i, 1)}
+                  aria-label={`Augmenter ${item.name}`}
+                >+</Box>
+              </HStack>
+              <Box
+                as="button" type="button"
+                fontSize="xs" color="text.muted"
+                opacity={0.5} _hover={{ opacity: 1, color: 'red.500' }}
+                onClick={() => removeItem(i)}
+                aria-label={`Retirer ${item.name}`}
+              >&#10005;</Box>
+            </HStack>
+          ))}
+        </VStack>
+      )}
+
+      <HStack gap={2}>
+        <Input
+          size="sm"
+          placeholder="Article (ex : Lait)"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addItem() } }}
+          flex={2}
+          aria-label="Nom de l'article"
+        />
+        <Input
+          size="sm"
+          placeholder="Marque"
+          value={newBrand}
+          onChange={e => setNewBrand(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addItem() } }}
+          flex={1}
+          aria-label="Marque"
+        />
+        <Input
+          size="sm"
+          placeholder="Note"
+          value={newNote}
+          onChange={e => setNewNote(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addItem() } }}
+          flex={1}
+          aria-label="Note"
+        />
+        <GhostButton size="sm" onClick={addItem}>+</GhostButton>
+      </HStack>
+    </VStack>
+  )
+}

--- a/src/hooks/useShoppingListTemplates.ts
+++ b/src/hooks/useShoppingListTemplates.ts
@@ -1,0 +1,143 @@
+/**
+ * Hook React pour la gestion des modèles de listes de courses.
+ *
+ * Charge les templates de l'employeur connecté au mount, expose des mutations
+ * (create / update / delete / setDefault) qui re-fetchent automatiquement.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { useAuthStore } from '@/stores/authStore'
+import {
+  listShoppingListTemplates,
+  createShoppingListTemplate,
+  updateShoppingListTemplate,
+  deleteShoppingListTemplate,
+  setDefaultShoppingListTemplate,
+  SHOPPING_LIST_TEMPLATES_LIMIT,
+  type ShoppingListTemplate,
+} from '@/services/shoppingListTemplateService'
+import type { ShoppingItem } from '@/lib/constants/taskDefaults'
+import { logger } from '@/lib/logger'
+
+interface UseShoppingListTemplatesResult {
+  templates: ShoppingListTemplate[]
+  defaultTemplate: ShoppingListTemplate | null
+  isLoading: boolean
+  error: string | null
+  /** True si l'employeur a déjà atteint la limite de 5 templates */
+  isAtLimit: boolean
+  /** Crée un template (refus si limite atteinte) */
+  createTemplate: (input: { name: string; items?: ShoppingItem[]; isDefault?: boolean }) => Promise<ShoppingListTemplate | null>
+  /** Met à jour le nom et/ou les items d'un template */
+  updateTemplate: (id: string, patch: { name?: string; items?: ShoppingItem[] }) => Promise<boolean>
+  /** Supprime un template (promotion auto du suivant si c'était le default) */
+  deleteTemplate: (id: string) => Promise<boolean>
+  /** Définit un template comme "par défaut" */
+  setDefault: (id: string) => Promise<boolean>
+  /** Force un re-fetch */
+  refresh: () => Promise<void>
+}
+
+export function useShoppingListTemplates(): UseShoppingListTemplatesResult {
+  const profileId = useAuthStore(s => s.profile?.id)
+  const [templates, setTemplates] = useState<ShoppingListTemplate[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchTemplates = useCallback(async () => {
+    if (!profileId) {
+      setTemplates([])
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    try {
+      const data = await listShoppingListTemplates(profileId)
+      setTemplates(data)
+    } catch (e) {
+      logger.error('Erreur chargement templates listes de courses:', e)
+      setError(e instanceof Error ? e.message : 'Erreur de chargement')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [profileId])
+
+  useEffect(() => {
+    void fetchTemplates()
+  }, [fetchTemplates])
+
+  const createTemplate = useCallback(
+    async (input: { name: string; items?: ShoppingItem[]; isDefault?: boolean }) => {
+      if (!profileId) return null
+      try {
+        const created = await createShoppingListTemplate(profileId, input)
+        await fetchTemplates()
+        return created
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Erreur lors de la création'
+        setError(msg)
+        return null
+      }
+    },
+    [profileId, fetchTemplates],
+  )
+
+  const updateTemplate = useCallback(
+    async (id: string, patch: { name?: string; items?: ShoppingItem[] }) => {
+      try {
+        await updateShoppingListTemplate(id, patch)
+        await fetchTemplates()
+        return true
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Erreur lors de la mise à jour')
+        return false
+      }
+    },
+    [fetchTemplates],
+  )
+
+  const deleteTemplate = useCallback(
+    async (id: string) => {
+      try {
+        await deleteShoppingListTemplate(id)
+        await fetchTemplates()
+        return true
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Erreur lors de la suppression')
+        return false
+      }
+    },
+    [fetchTemplates],
+  )
+
+  const setDefault = useCallback(
+    async (id: string) => {
+      if (!profileId) return false
+      try {
+        await setDefaultShoppingListTemplate(id, profileId)
+        await fetchTemplates()
+        return true
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Erreur lors du changement de défaut')
+        return false
+      }
+    },
+    [profileId, fetchTemplates],
+  )
+
+  const defaultTemplate = templates.find(t => t.isDefault) ?? null
+  const isAtLimit = templates.length >= SHOPPING_LIST_TEMPLATES_LIMIT
+
+  return {
+    templates,
+    defaultTemplate,
+    isLoading,
+    error,
+    isAtLimit,
+    createTemplate,
+    updateTemplate,
+    deleteTemplate,
+    setDefault,
+    refresh: fetchTemplates,
+  }
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -39,6 +39,7 @@ import { logger } from '@/lib/logger'
 import { useHealthConsent } from '@/hooks/useHealthConsent'
 import { GhostButton, PrimaryButton } from '@/components/ui'
 import { useInterventionSettings } from '@/hooks/useInterventionSettings'
+import { ShoppingListTemplatesSection } from '@/components/profile/ShoppingListTemplatesSection'
 import { useConventionSettings } from '@/hooks/useConventionSettings'
 import { useMfa } from '@/hooks/useMfa'
 import { MfaEnrollment } from '@/components/auth/MfaEnrollment'
@@ -1333,15 +1334,11 @@ function NotificationsPanel({ userId }: { userId: string }) {
 
 function InterventionsPanel() {
   const {
-    defaultTasks, customTasks, shoppingList,
+    defaultTasks, customTasks,
     saveDefaultTasks, addCustomTask, removeCustomTask,
-    addShoppingItem, removeShoppingItem, updateShoppingItem,
   } = useInterventionSettings()
 
   const [newTask, setNewTask] = useState('')
-  const [newItemName, setNewItemName] = useState('')
-  const [newItemBrand, setNewItemBrand] = useState('')
-  const [newItemNote, setNewItemNote] = useState('')
   const [feedback, setFeedback] = useState<string | null>(null)
 
   const showFeedback = (msg: string) => {
@@ -1362,17 +1359,6 @@ function InterventionsPanel() {
     addCustomTask(trimmed)
     setNewTask('')
     showFeedback(`"${trimmed}" ajoutée`)
-  }
-
-  const handleAddShoppingItem = () => {
-    const name = newItemName.trim()
-    if (!name) return
-    const brand = newItemBrand.trim()
-    const note = newItemNote.trim()
-    addShoppingItem({ name, brand, quantity: 1, note })
-    setNewItemName('')
-    setNewItemBrand('')
-    setNewItemNote('')
   }
 
   return (
@@ -1477,104 +1463,8 @@ function InterventionsPanel() {
         </Card.Body>
       </Card.Root>
 
-      {/* Liste de courses */}
-      <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm">
-        <Card.Header px={4} py={3} borderBottomWidth="1px" borderColor="border.default">
-          <Card.Title fontFamily="heading" fontSize="lg" fontWeight="700">Liste de courses type</Card.Title>
-          <Text fontSize="sm" color="text.muted" mt={1}>
-            Créez votre liste d'articles habituels. Elle sera pré-remplie quand "Courses" est sélectionné dans une intervention.
-          </Text>
-        </Card.Header>
-        <Card.Body p={4}>
-          {shoppingList.length > 0 && (
-            <VStack gap={2} align="stretch" mb={4}>
-              {shoppingList.map(item => (
-                <HStack
-                  key={`${item.name}-${item.brand}`}
-                  gap={3}
-                  px={3} py={2}
-                  bg="bg.muted"
-                  borderWidth="1px"
-                  borderColor="border.default"
-                  borderRadius="md"
-                  fontSize="sm"
-                  _hover={{ borderColor: 'brand.300', bg: 'brand.subtle' }}
-                  transition="all 0.12s"
-                >
-                  <VStack gap={0} align="start" flex={1}>
-                    <HStack gap={2}>
-                      <Text fontWeight="600">{item.name}</Text>
-                      {item.brand && (
-                        <Text fontSize="xs" color="text.muted" fontStyle="italic">{item.brand}</Text>
-                      )}
-                    </HStack>
-                    {item.note && (
-                      <Text fontSize="xs" color="text.muted">{item.note}</Text>
-                    )}
-                  </VStack>
-                  <HStack gap={1}>
-                    <Box
-                      as="button" type="button"
-                      w="22px" h="22px" borderRadius="full"
-                      bg="border.default" color="text.default" fontSize="xs" fontWeight="bold"
-                      display="flex" alignItems="center" justifyContent="center"
-                      _hover={{ bg: 'brand.subtle', borderColor: 'brand.solid' }}
-                      onClick={() => updateShoppingItem(item.name, item.brand, { quantity: Math.max(1, (item.quantity || 1) - 1) })}
-                      aria-label={`Diminuer la quantité de ${item.name}`}
-                    >-</Box>
-                    <Text fontSize="xs" fontWeight="600" minW="22px" textAlign="center">
-                      x{item.quantity || 1}
-                    </Text>
-                    <Box
-                      as="button" type="button"
-                      w="22px" h="22px" borderRadius="full"
-                      bg="border.default" color="text.default" fontSize="xs" fontWeight="bold"
-                      display="flex" alignItems="center" justifyContent="center"
-                      _hover={{ bg: 'brand.subtle', borderColor: 'brand.solid' }}
-                      onClick={() => updateShoppingItem(item.name, item.brand, { quantity: (item.quantity || 1) + 1 })}
-                      aria-label={`Augmenter la quantité de ${item.name}`}
-                    >+</Box>
-                  </HStack>
-                  <Box
-                    as="button" type="button"
-                    fontSize="xs" color="text.muted"
-                    opacity={0.5} _hover={{ opacity: 1, color: 'red.500' }}
-                    onClick={() => removeShoppingItem(item)}
-                    aria-label={`Retirer l'article ${item.name}`}
-                  >&#10005;</Box>
-                </HStack>
-              ))}
-            </VStack>
-          )}
-          <HStack gap={2}>
-            <Input
-              size="sm"
-              placeholder="Article (ex : Lait, Bananes…)"
-              value={newItemName}
-              onChange={e => setNewItemName(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); document.getElementById('settings-brand-input')?.focus() } }}
-              borderRadius="md"
-              flex={2}
-              aria-label="Nom de l'article"
-            />
-            <Input
-              id="settings-brand-input"
-              size="sm"
-              placeholder="Marque (optionnel)"
-              value={newItemBrand}
-              onChange={e => setNewItemBrand(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddShoppingItem() } }}
-              borderRadius="md"
-              flex={1}
-              aria-label="Marque de l'article"
-            />
-            <PrimaryButton size="sm" onClick={handleAddShoppingItem}>+ Ajouter</PrimaryButton>
-          </HStack>
-          <Text fontSize="xs" color="text.muted" mt={2}>
-            Les articles ajoutés dans le formulaire d'intervention seront aussi mémorisés ici.
-          </Text>
-        </Card.Body>
-      </Card.Root>
+      {/* Listes de courses (templates multiples) */}
+      <ShoppingListTemplatesSection />
     </VStack>
   )
 }


### PR DESCRIPTION
## Summary
Deuxième brique du chantier « plusieurs listes de courses ». Marie peut désormais gérer jusqu'à 5 listes nommées (ex : « Courses semaine », « Pharmacie », « Ménage ») depuis les paramètres, et choisir laquelle utiliser à la création d'une intervention. Le snapshot est natif (cf. PR #326), donc modifier une liste n'affecte pas les interventions passées.

### Changements
- **`useShoppingListTemplates`** (nouveau hook) : load au mount + mutations (create / update / delete / setDefault) avec re-fetch automatique. Expose `templates`, `defaultTemplate`, `isAtLimit`, etc.
- **`ShoppingListTemplatesSection`** (nouveau composant) : section accordéon dans Paramètres > Interventions
  - Liste des templates avec badge « Par défaut » sur celui actif
  - Compteur `X / 5` en header
  - Pour chaque template : éditeur d'items inline (ajouter / supprimer / quantité), boutons Renommer / Définir par défaut / Supprimer (avec confirmation)
  - Bouton « + Créer » désactivé si limite atteinte avec message explicatif
- **`TaskSelector`** : intégration des templates
  - Si plusieurs templates : dropdown « Liste à utiliser » au-dessus de la zone Courses → switcher de template remplace les items
  - Prefill async via useEffect : quand `defaultTemplate` est chargé, pré-remplit la liste si « Courses » est cochée
  - Header de la liste affiche désormais le nom du template choisi
- **`SettingsPage`** : remplace le bloc unique « Liste de courses type » par `<ShoppingListTemplatesSection />`. Le panneau Interventions garde la gestion des tâches habituelles + tâches personnalisées (intactes).

### Détails UX
- **Créer** : nom + Entrée → liste créée et automatiquement déployée pour ajouter des items
- **Renommer** : double-clic sur le nom OU bouton « Renommer »
- **Premier template d'un employeur** : auto-promu en `is_default = true`
- **Suppression du default** : promotion automatique du suivant en default (logique service de la PR #326)
- **Pas de migration côté client** : les anciens utilisateurs ont déjà leur « Liste par défaut » créée par la migration SQL #056

## Test plan
- [ ] Aller dans Paramètres > Interventions → voir la section « Mes listes de courses »
- [ ] Créer 2 listes (« Courses semaine », « Pharmacie ») → la première devient le default automatiquement
- [ ] Définir « Pharmacie » comme défaut → badge se déplace
- [ ] Ajouter 3 items dans « Courses semaine », 2 dans « Pharmacie »
- [ ] Créer une nouvelle intervention, cocher « Courses » → liste « Pharmacie » pré-remplie
- [ ] Switcher vers « Courses semaine » via le dropdown → items remplacés
- [ ] Sauvegarder l'intervention, modifier la liste « Pharmacie » dans les paramètres → l'intervention sauvegardée garde l'ancien snapshot
- [ ] Tenter de créer une 6ème liste → bouton désactivé + message « Limite atteinte »
- [ ] Supprimer la liste par défaut → la suivante est promue
- [x] `npm run lint` (0 erreur)
- [x] `npm run typecheck` (OK)
- [x] `npm run test:run` (2278 passed / 4 skipped — pas de régression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)