### PR TITLE
fix(boot): auto-reload on stale chunk error after deploy

### DIFF
--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 import { Box, Button, Center, Heading, Text, VStack } from '@chakra-ui/react'
 import { logger } from '@/lib/logger'
+import { tryReloadOnChunkError } from '@/lib/chunkErrorHandler'
 
 interface Props {
   children: ReactNode
@@ -28,6 +29,8 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Si c'est un chunk obsolète post-deploy, reload silencieux
+    if (tryReloadOnChunkError(error)) return
     logger.error('ErrorBoundary a intercepté une erreur:', error)
     logger.error('Component stack:', errorInfo.componentStack)
   }

--- a/src/lib/chunkErrorHandler.test.ts
+++ b/src/lib/chunkErrorHandler.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  isChunkLoadError,
+  tryReloadOnChunkError,
+  clearChunkReloadFlag,
+} from './chunkErrorHandler'
+
+const RELOAD_FLAG_KEY = '__unilien_chunk_reload_attempted__'
+
+describe('chunkErrorHandler', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    reloadSpy = vi.fn()
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, reload: reloadSpy },
+    })
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  describe('isChunkLoadError', () => {
+    it('détecte "Failed to fetch dynamically imported module"', () => {
+      const err = new Error('Failed to fetch dynamically imported module: /assets/x.js')
+      expect(isChunkLoadError(err)).toBe(true)
+    })
+
+    it('détecte "error loading dynamically imported module"', () => {
+      const err = new Error('error loading dynamically imported module: https://app/x.js')
+      expect(isChunkLoadError(err)).toBe(true)
+    })
+
+    it('détecte "Importing a module script failed"', () => {
+      const err = new Error('Importing a module script failed.')
+      expect(isChunkLoadError(err)).toBe(true)
+    })
+
+    it('détecte "Unable to preload CSS"', () => {
+      const err = new Error('Unable to preload CSS for /assets/x.css')
+      expect(isChunkLoadError(err)).toBe(true)
+    })
+
+    it('ignore les erreurs non liées', () => {
+      expect(isChunkLoadError(new Error('TypeError: foo is undefined'))).toBe(false)
+      expect(isChunkLoadError(new Error('Network error'))).toBe(false)
+    })
+
+    it('gère null / undefined / strings', () => {
+      expect(isChunkLoadError(null)).toBe(false)
+      expect(isChunkLoadError(undefined)).toBe(false)
+      expect(isChunkLoadError('error loading dynamically imported module')).toBe(true)
+    })
+  })
+
+  describe('tryReloadOnChunkError', () => {
+    it('reload et set le flag pour une chunk error', () => {
+      const err = new Error('Failed to fetch dynamically imported module: /x.js')
+      const result = tryReloadOnChunkError(err)
+
+      expect(result).toBe(true)
+      expect(reloadSpy).toHaveBeenCalledOnce()
+      expect(sessionStorage.getItem(RELOAD_FLAG_KEY)).toBe('1')
+    })
+
+    it('ne reload pas si le flag est déjà présent (anti-boucle)', () => {
+      sessionStorage.setItem(RELOAD_FLAG_KEY, '1')
+      const err = new Error('Failed to fetch dynamically imported module: /x.js')
+      const result = tryReloadOnChunkError(err)
+
+      expect(result).toBe(false)
+      expect(reloadSpy).not.toHaveBeenCalled()
+    })
+
+    it('ne fait rien pour une erreur non chunk', () => {
+      const err = new Error('Some other error')
+      const result = tryReloadOnChunkError(err)
+
+      expect(result).toBe(false)
+      expect(reloadSpy).not.toHaveBeenCalled()
+      expect(sessionStorage.getItem(RELOAD_FLAG_KEY)).toBeNull()
+    })
+  })
+
+  describe('clearChunkReloadFlag', () => {
+    it('efface le flag', () => {
+      sessionStorage.setItem(RELOAD_FLAG_KEY, '1')
+      clearChunkReloadFlag()
+      expect(sessionStorage.getItem(RELOAD_FLAG_KEY)).toBeNull()
+    })
+  })
+})

--- a/src/lib/chunkErrorHandler.ts
+++ b/src/lib/chunkErrorHandler.ts
@@ -1,0 +1,66 @@
+import { logger } from '@/lib/logger'
+
+const RELOAD_FLAG_KEY = '__unilien_chunk_reload_attempted__'
+
+const CHUNK_ERROR_PATTERNS = [
+  /failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /importing a module script failed/i,
+  /unable to preload css/i,
+]
+
+export function isChunkLoadError(err: unknown): boolean {
+  if (!err) return false
+  const msg = err instanceof Error ? err.message : String(err)
+  return CHUNK_ERROR_PATTERNS.some((re) => re.test(msg))
+}
+
+/**
+ * Reload la page si l'erreur ressemble à un chunk obsolète post-deploy.
+ * Utilise sessionStorage pour éviter une boucle de reload infinie si
+ * l'erreur persiste (ex: vraie panne, pas un simple deploy).
+ *
+ * Retourne true si un reload a été déclenché, false sinon.
+ */
+export function tryReloadOnChunkError(err: unknown): boolean {
+  if (!isChunkLoadError(err)) return false
+
+  if (sessionStorage.getItem(RELOAD_FLAG_KEY)) {
+    logger.warn('[chunkErrorHandler] Erreur de chunk persistante après reload — abandon')
+    return false
+  }
+
+  sessionStorage.setItem(RELOAD_FLAG_KEY, '1')
+  logger.info('[chunkErrorHandler] Chunk obsolète détecté — reload')
+  window.location.reload()
+  return true
+}
+
+/**
+ * À appeler une fois au boot de l'app, après un rendu réussi
+ * (pour effacer le flag si tout va bien).
+ */
+export function clearChunkReloadFlag(): void {
+  sessionStorage.removeItem(RELOAD_FLAG_KEY)
+}
+
+interface VitePreloadErrorEvent extends Event {
+  payload?: unknown
+}
+
+export function registerChunkErrorHandlers(): void {
+  // Vite émet cet event quand un import() dynamique échoue
+  window.addEventListener('vite:preloadError', (event: Event) => {
+    const e = event as VitePreloadErrorEvent
+    if (tryReloadOnChunkError(e.payload)) {
+      event.preventDefault()
+    }
+  })
+
+  // Filet de sécurité : promesses rejetées non traitées
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    if (tryReloadOnChunkError(event.reason)) {
+      event.preventDefault()
+    }
+  })
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,17 @@ import ReactDOM, { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { Provider } from '@/components/ui/provider'
 import { ErrorBoundary } from '@/components/ui'
+import { registerChunkErrorHandlers, clearChunkReloadFlag } from '@/lib/chunkErrorHandler'
 import App from './App'
 import './index.css'
+
+registerChunkErrorHandlers()
+// Si le rendu démarre sans erreur, on peut effacer le flag de reload
+if (typeof window.requestIdleCallback === 'function') {
+  window.requestIdleCallback(clearChunkReloadFlag)
+} else {
+  setTimeout(clearChunkReloadFlag, 2000)
+}
 
 if (import.meta.env.DEV) {
   import('@axe-core/react').then((axe) => {


### PR DESCRIPTION
## Summary
Fix l'écran d'erreur "Une erreur est survenue" qui apparaissait parfois post-déploiement quand un onglet ouvert depuis longtemps tentait de naviguer vers une page lazy-loaded dont le chunk avait changé de hash.

### Contexte
Erreur observée en prod :
```
TypeError: error loading dynamically imported module: https://unilien.app/assets/Dashboard-D1aXmBmj.js
```
Causée par un `index.html` en cache pointant vers un asset (chunk) qui n'existe plus côté serveur après un deploy.

### Changements
- Nouveau `src/lib/chunkErrorHandler.ts` :
  - `isChunkLoadError()` matche 4 patterns Vite (`Failed to fetch dynamically imported module`, `error loading dynamically imported module`, `Importing a module script failed`, `Unable to preload CSS`)
  - `tryReloadOnChunkError()` : reload une seule fois (anti-boucle via `sessionStorage`)
  - `registerChunkErrorHandlers()` : listeners sur `vite:preloadError` + `unhandledrejection`
- `main.tsx` : enregistre les handlers au boot + efface le flag au prochain idle / 2s
- `ErrorBoundary.componentDidCatch` : tente d'abord le reload silencieux avant d'afficher le fallback UI
- 10 tests unitaires (`chunkErrorHandler.test.ts`)

### Note auth
L'erreur `AuthApiError: Invalid Refresh Token` qui apparaissait dans le même log est bénigne — Supabase v2 émet automatiquement `SIGNED_OUT` qui est déjà géré dans `useAuth.ts`. Pas de fix nécessaire de ce côté.

## Test plan
- [x] `npm run lint` (0 erreur)
- [x] `npm run typecheck`
- [x] `npm run test:run` — 2286 passed / 4 skipped (133 fichiers)
- [ ] Vérif manuelle prod : déployer, ouvrir un onglet, redéployer, naviguer dans l'onglet → reload silencieux au lieu d'écran d'erreur
- [ ] Vérif anti-boucle : si le reload échoue 2x de suite (vraie panne), l'écran d'erreur s'affiche bien

🤖 Generated with [Claude Code](https://claude.com/claude-code)