### PR TITLE
refactor(absence): harmonize labels and deduplicate

### DIFF
--- a/src/components/planning/AbsenceDetailModal.test.tsx
+++ b/src/components/planning/AbsenceDetailModal.test.tsx
@@ -73,15 +73,15 @@ describe('AbsenceDetailModal', () => {
   })
 
   describe('Affichage des données', () => {
-    it('affiche le type d\'absence "Congé payé" pour vacation', async () => {
+    it('affiche le type d\'absence "Congés payés" pour vacation', async () => {
       renderWithProviders(<AbsenceDetailModal {...defaultProps} />)
 
       await waitFor(() => {
-        expect(screen.getByText('Congé payé')).toBeInTheDocument()
+        expect(screen.getByText('Congés payés')).toBeInTheDocument()
       })
     })
 
-    it('affiche le type d\'absence "Maladie" pour sick', async () => {
+    it('affiche le type d\'absence "Arrêt maladie" pour sick', async () => {
       renderWithProviders(
         <AbsenceDetailModal
           {...defaultProps}
@@ -90,7 +90,7 @@ describe('AbsenceDetailModal', () => {
       )
 
       await waitFor(() => {
-        expect(screen.getByText('Maladie')).toBeInTheDocument()
+        expect(screen.getByText('Arrêt maladie')).toBeInTheDocument()
       })
     })
 

--- a/src/components/planning/AbsenceRequestModal.test.tsx
+++ b/src/components/planning/AbsenceRequestModal.test.tsx
@@ -111,7 +111,7 @@ describe('AbsenceRequestModal', () => {
       renderWithProviders(<AbsenceRequestModal {...defaultProps} />)
 
       await waitFor(() => {
-        expect(screen.getByText('Congé payé (CP)')).toBeInTheDocument()
+        expect(screen.getByText('Congés payés (CP)')).toBeInTheDocument()
         expect(screen.getByText('Congé sans solde')).toBeInTheDocument()
         expect(screen.getByText('Congé formation (CPF)')).toBeInTheDocument()
       })
@@ -173,7 +173,7 @@ describe('AbsenceRequestModal', () => {
       renderWithProviders(<AbsenceRequestModal {...defaultProps} />)
 
       await waitFor(() => {
-        expect(screen.getByText(/Congé payé · Rémunéré/i)).toBeInTheDocument()
+        expect(screen.getByText(/Congés payés · Rémunéré/i)).toBeInTheDocument()
       })
     })
   })
@@ -223,7 +223,7 @@ describe('AbsenceRequestModal', () => {
     it('n\'affiche pas la section d\'upload pour un type congé', async () => {
       renderWithProviders(<AbsenceRequestModal {...defaultProps} />)
 
-      // Par défaut, onglet "Congés" avec "Congé payé" sélectionné
+      // Par défaut, onglet "Congés" avec "Congés payés" sélectionné
       expect(screen.queryByLabelText(/Sélectionner un arrêt de travail/i)).not.toBeInTheDocument()
     })
   })
@@ -238,7 +238,7 @@ describe('AbsenceRequestModal', () => {
       )
 
       await waitFor(() => {
-        expect(screen.getByText('Congé payé (CP)')).toBeInTheDocument()
+        expect(screen.getByText('Congés payés (CP)')).toBeInTheDocument()
       })
 
       await user.click(screen.getByRole('button', { name: /Envoyer la demande/i }))

--- a/src/components/planning/AbsenceRequestModal.tsx
+++ b/src/components/planning/AbsenceRequestModal.tsx
@@ -69,7 +69,7 @@ const CATEGORIES: { key: AbsenceCategory; label: string }[] = [
 
 const ABSENCE_OPTIONS: Record<AbsenceCategory, AbsenceTypeOption[]> = {
   conges: [
-    { value: 'conge_paye', backendType: 'vacation', label: 'Congé payé (CP)', sub: '{days} dispo · Rémunéré · Art. L3141-1', dot: 'brand.500' },
+    { value: 'conge_paye', backendType: 'vacation', label: 'Congés payés (CP)', sub: '{days} dispo · Rémunéré · Art. L3141-1', dot: 'brand.500' },
     { value: 'sans_solde', backendType: 'vacation', label: 'Congé sans solde', sub: 'Durée libre · Accord employeur · Non rémunéré', dot: 'brand.500' },
     { value: 'formation', backendType: 'training', label: 'Congé formation (CPF)', sub: 'Variable · Financement CPF · Art. L6323-1', dot: 'brand.500' },
   ],
@@ -103,10 +103,10 @@ function getInfoText(
 ) {
   if (!selected) return null
   if (selected.value === 'conge_paye') {
-    if (!leaveBalance) return 'Congé payé · Rémunéré · Chargement du solde…'
+    if (!leaveBalance) return 'Congés payés · Rémunéré · Chargement du solde…'
     const days = leaveBalance.remainingDays
-    if (days <= 0) return 'Congé payé · Rémunéré · Aucun jour de CP disponible. Votre solde sera recalculé selon votre ancienneté.'
-    return `Congé payé · Rémunéré · Il vous reste ${days.toFixed(0)} jour${days >= 2 ? 's' : ''} de CP disponibles.`
+    if (days <= 0) return 'Congés payés · Rémunéré · Aucun jour de CP disponible. Votre solde sera recalculé selon votre ancienneté.'
+    return `Congés payés · Rémunéré · Il vous reste ${days.toFixed(0)} jour${days >= 2 ? 's' : ''} de CP disponibles.`
   }
   if (selected.value === 'sans_solde') return 'Congé sans solde · Non rémunéré · Nécessite l\'accord de votre employeur.'
   if (selected.value === 'formation') return 'Congé formation · CPF · Financé via votre Compte Personnel de Formation.'

--- a/src/components/planning/MonthView.test.tsx
+++ b/src/components/planning/MonthView.test.tsx
@@ -131,7 +131,7 @@ describe('MonthView', () => {
       const date = new Date('2026-02-12T12:00:00')
       const absence = makeAbsence(date, date, { absenceType: 'vacation' })
       renderWithProviders(<MonthView {...defaultProps} absences={[absence]} />)
-      expect(screen.getByText('Congé payé')).toBeInTheDocument()
+      expect(screen.getByText('Congés payés')).toBeInTheDocument()
     })
 
     it('affiche une absence multi-jours sur chaque jour concerné', () => {
@@ -139,15 +139,15 @@ describe('MonthView', () => {
       const end = new Date('2026-02-11T12:00:00')
       const absence = makeAbsence(start, end, { absenceType: 'training' })
       renderWithProviders(<MonthView {...defaultProps} absences={[absence]} />)
-      const labels = screen.getAllByText('Formation')
+      const labels = screen.getAllByText('Congé formation')
       expect(labels).toHaveLength(3) // 9, 10, 11 fév
     })
 
-    it('affiche les types : Maladie, Formation, Indispo., Urgence', () => {
+    it('affiche les types : Arrêt maladie, Congé formation, Indispo., Urgence', () => {
       const date = new Date('2026-02-20T12:00:00')
       for (const [type, label] of [
-        ['sick', 'Maladie'],
-        ['training', 'Formation'],
+        ['sick', 'Arrêt maladie'],
+        ['training', 'Congé formation'],
         ['unavailable', 'Indisponibilité'],
         ['emergency', 'Urgence personnelle'],
       ] as const) {
@@ -216,7 +216,7 @@ describe('MonthView', () => {
       renderWithProviders(
         <MonthView {...defaultProps} absences={[absence]} onAbsenceClick={onAbsenceClick} />
       )
-      const card = screen.getByText('Maladie').closest('[role="button"]')!
+      const card = screen.getByText('Arrêt maladie').closest('[role="button"]')!
       fireEvent.click(card)
       expect(onAbsenceClick).toHaveBeenCalledWith(absence)
     })
@@ -228,7 +228,7 @@ describe('MonthView', () => {
       renderWithProviders(
         <MonthView {...defaultProps} absences={[absence]} onAbsenceClick={onAbsenceClick} />
       )
-      const card = screen.getByText('Maladie').closest('[role="button"]')!
+      const card = screen.getByText('Arrêt maladie').closest('[role="button"]')!
       fireEvent.keyDown(card, { key: 'Enter' })
       expect(onAbsenceClick).toHaveBeenCalledWith(absence)
     })
@@ -240,7 +240,7 @@ describe('MonthView', () => {
       renderWithProviders(
         <MonthView {...defaultProps} absences={[absence]} onAbsenceClick={onAbsenceClick} />
       )
-      const card = screen.getByText('Maladie').closest('[role="button"]')!
+      const card = screen.getByText('Arrêt maladie').closest('[role="button"]')!
       fireEvent.keyDown(card, { key: ' ' })
       expect(onAbsenceClick).toHaveBeenCalledWith(absence)
     })

--- a/src/components/planning/WeekView.test.tsx
+++ b/src/components/planning/WeekView.test.tsx
@@ -127,8 +127,8 @@ describe('WeekView', () => {
     it('affiche le type d\'absence suivi de "Congé"', () => {
       const absence = makeAbsence(1, { absenceType: 'sick' })
       renderWithProviders(<WeekView {...defaultProps} absences={[absence]} />)
-      // Le composant affiche "Maladie — Congé"
-      expect(screen.getByText(/Maladie/)).toBeInTheDocument()
+      // Le composant affiche "Arrêt maladie — Congé"
+      expect(screen.getByText(/Arrêt maladie/)).toBeInTheDocument()
     })
 
     it('affiche la raison si présente', () => {
@@ -143,8 +143,8 @@ describe('WeekView', () => {
         endDate: addDays(weekStart(), 3),   // Jeudi
       })
       renderWithProviders(<WeekView {...defaultProps} absences={[absence]} />)
-      // "Maladie" apparaît 3 fois (mardi, mercredi, jeudi)
-      const labels = screen.getAllByText(/Maladie/)
+      // "Arrêt maladie" apparaît 3 fois (mardi, mercredi, jeudi)
+      const labels = screen.getAllByText(/Arrêt maladie/)
       expect(labels).toHaveLength(3)
     })
   })
@@ -200,7 +200,7 @@ describe('WeekView', () => {
       renderWithProviders(
         <WeekView {...defaultProps} absences={[absence]} onAbsenceClick={onAbsenceClick} />
       )
-      const card = screen.getByText(/Maladie/).closest('[role="button"]')!
+      const card = screen.getByText(/Arrêt maladie/).closest('[role="button"]')!
       fireEvent.click(card)
       expect(onAbsenceClick).toHaveBeenCalledWith(absence)
     })
@@ -211,7 +211,7 @@ describe('WeekView', () => {
       renderWithProviders(
         <WeekView {...defaultProps} absences={[absence]} onAbsenceClick={onAbsenceClick} />
       )
-      const card = screen.getByText(/Maladie/).closest('[role="button"]')!
+      const card = screen.getByText(/Arrêt maladie/).closest('[role="button"]')!
       fireEvent.keyDown(card, { key: 'Enter' })
       expect(onAbsenceClick).toHaveBeenCalledWith(absence)
     })
@@ -222,7 +222,7 @@ describe('WeekView', () => {
       renderWithProviders(
         <WeekView {...defaultProps} absences={[absence]} onAbsenceClick={onAbsenceClick} />
       )
-      const card = screen.getByText(/Maladie/).closest('[role="button"]')!
+      const card = screen.getByText(/Arrêt maladie/).closest('[role="button"]')!
       fireEvent.keyDown(card, { key: ' ' })
       expect(onAbsenceClick).toHaveBeenCalledWith(absence)
     })

--- a/src/lib/constants/statusMaps.ts
+++ b/src/lib/constants/statusMaps.ts
@@ -51,10 +51,10 @@ export const ABSENCE_STATUS_LABELS: Record<Absence['status'], string> = {
 }
 
 export const ABSENCE_TYPE_LABELS: Record<Absence['absenceType'], string> = {
-  sick: 'Maladie',
-  vacation: 'Congé payé',
+  sick: 'Arrêt maladie',
+  vacation: 'Congés payés',
   family_event: 'Événement familial',
-  training: 'Formation',
+  training: 'Congé formation',
   unavailable: 'Indisponibilité',
   emergency: 'Urgence personnelle',
 }

--- a/src/lib/export/planningExcelGenerator.ts
+++ b/src/lib/export/planningExcelGenerator.ts
@@ -8,6 +8,7 @@ import { fr } from 'date-fns/locale'
 import type { PlanningExportData, EmployeePlanningData } from './types'
 import type { ExportResult } from './types'
 import type * as XLSXType from 'xlsx'
+import { ABSENCE_TYPE_LABELS } from '@/lib/constants/statusMaps'
 
 const DAYS_FR = ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
 
@@ -16,15 +17,6 @@ const SHIFT_TYPE_LABELS: Record<string, string> = {
   presence_day: 'Présence jour',
   presence_night: 'Présence nuit',
   guard_24h: 'Garde 24h',
-}
-
-const ABSENCE_TYPE_LABELS: Record<string, string> = {
-  sick: 'Arrêt maladie',
-  vacation: 'Congé payé',
-  family_event: 'Événement familial',
-  training: 'Formation',
-  unavailable: 'Indisponibilité',
-  emergency: 'Urgence personnelle',
 }
 
 const STATUS_LABELS: Record<string, string> = {

--- a/src/lib/export/planningIcalGenerator.ts
+++ b/src/lib/export/planningIcalGenerator.ts
@@ -6,21 +6,13 @@
 import { format, addDays } from 'date-fns'
 import type { PlanningExportData, PlanningShiftEntry, PlanningAbsenceEntry } from './types'
 import type { ExportResult } from './types'
+import { ABSENCE_TYPE_LABELS } from '@/lib/constants/statusMaps'
 
 const SHIFT_TYPE_LABELS: Record<string, string> = {
   effective: 'Intervention',
   presence_day: 'Présence jour',
   presence_night: 'Présence nuit',
   guard_24h: 'Garde 24h',
-}
-
-const ABSENCE_TYPE_LABELS: Record<string, string> = {
-  sick: 'Arrêt maladie',
-  vacation: 'Congé payé',
-  family_event: 'Événement familial',
-  training: 'Formation',
-  unavailable: 'Indisponibilité',
-  emergency: 'Urgence personnelle',
 }
 
 /** Repli à 74 caractères selon RFC 5545 §3.1 */

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -8,6 +8,7 @@ import type { AuxiliarySummary } from '@/services/auxiliaryService'
 import type { LogEntryWithAuthor } from '@/services/logbookService'
 import type { DocumentWithEmployee } from '@/services/documentService'
 import { FEATURES } from '@/lib/featureFlags'
+import { ABSENCE_TYPE_LABELS } from '@/lib/constants/statusMaps'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -243,15 +244,6 @@ export function searchMessages(
 }
 
 // ── Documents (absences) ─────────────────────────────────────────────────────
-
-const ABSENCE_TYPE_LABELS: Record<string, string> = {
-  sick: 'Maladie',
-  vacation: 'Congé',
-  family_event: 'Événement familial',
-  training: 'Formation',
-  unavailable: 'Indisponibilité',
-  emergency: 'Urgence',
-}
 
 export function searchDocuments(
   query: string,


### PR DESCRIPTION
## Summary
Harmonisation des libellés de motifs d'absence sur tout le projet + déduplication de 3 copies divergentes.

### Libellés mis à jour (`statusMaps.ts`)
- \`Maladie\` → **\`Arrêt maladie\`** (cohérence avec le wording du modal)
- \`Congé payé\` → **\`Congés payés\`** (forme admise au pluriel)
- \`Formation\` → **\`Congé formation\`**
- Inchangés : \`Événement familial\`, \`Indisponibilité\`, \`Urgence personnelle\`

### Modal demande d'absence
- Option par défaut : \`Congé payé (CP)\` → \`Congés payés (CP)\`
- 3 textes contextuels alignés : \`Congés payés · Rémunéré · ...\`

### Déduplication
\`planningExcelGenerator.ts\`, \`planningIcalGenerator.ts\` et \`searchService.ts\` importent maintenant \`ABSENCE_TYPE_LABELS\` depuis \`@/lib/constants/statusMaps\`. 3 dictionnaires locaux divergeants supprimés (notamment \`searchService\` qui avait \`Maladie\`/\`Congé\`/\`Urgence\` tronqués).

### Tests adaptés
- \`MonthView.test.tsx\`, \`WeekView.test.tsx\`, \`AbsenceDetailModal.test.tsx\`, \`AbsenceRequestModal.test.tsx\`

## Test plan
- [x] \`npm run lint\` (0 errors)
- [x] \`npm run test:run\` — **2286 passed | 4 skipped**
- [x] Vérif manuelle planning : badge absence affiche le bon label en \`MonthView\`/\`WeekView\`
- [x] Vérif manuelle modal demande d'absence : option \`Congés payés (CP)\` + textes contextuels OK
- [x] Export Excel + iCal : libellés harmonisés