### PR TITLE
feat(documents): add dedicated search field on documents page

### DIFF
--- a/docs/DEVELOPMENT_ROADMAP.md
+++ b/docs/DEVELOPMENT_ROADMAP.md
@@ -2311,8 +2311,8 @@ La cible < 200 KB n'est pas atteignable avec React 19 + Chakra UI v3 + Supabase.
    - ❌ Bandeau "Mode démo" dismissible (localStorage)
    - ✅ Variante dashboard quand aucun employé (icône + CTA "Ajouter un auxiliaire")
 
-3. **Document search + table unifiée** — recherche déjà couverte côté global via `SpotlightSearch` (Ctrl+K, `searchDocuments` dans `searchService.ts`).
-   - 🔧 Champ recherche dédié sur la page Documents (nom, type, période) — manquant dans la page elle-même, l'utilisateur passe par Ctrl+K
+3. **Document search + table unifiée**
+   - ✅ Champ recherche dédié sur la page Documents — `<Input>` au-dessus des Tabs avec placeholder dynamique. Filtre côté client sur 4 onglets : Bulletins (employé + période), Contrats (employé + type), Absences (employé + motif + libellé type), Déclarations CESU (période). Reset auto au changement de tab. Export planning = formulaire d'export, pas de liste donc pas de recherche.
    - 🔧 Optionnel : table `documents` centralisée avec `category` + métadonnées — structure actuelle = tables séparées par type (`payslips`, `cesu_declarations`, `absences`), refonte non bloquante
 
 4. **Analytics exports**

--- a/src/components/documents/CesuDeclarationSection.tsx
+++ b/src/components/documents/CesuDeclarationSection.tsx
@@ -4,7 +4,7 @@
  * Les declarations sont persistees en base (table cesu_declarations).
  */
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useMemo } from 'react'
 import {
   Box,
   VStack,
@@ -42,9 +42,10 @@ import { formatHoursCompact } from '@/lib/formatHours'
 
 interface Props {
   employerId: string
+  searchTerm?: string
 }
 
-export function CesuDeclarationSection({ employerId }: Props) {
+export function CesuDeclarationSection({ employerId, searchTerm = '' }: Props) {
   const now = new Date()
   const currentYear = now.getFullYear()
   const currentMonth = now.getMonth() + 1
@@ -70,6 +71,12 @@ export function CesuDeclarationSection({ employerId }: Props) {
   // ── Historique des declarations (persistees en base)
   const [declarations, setDeclarations] = useState<CesuDeclarationRecord[]>([])
   const [isLoading, setIsLoading] = useState(true)
+
+  const filteredDeclarations = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase()
+    if (!q) return declarations
+    return declarations.filter((r) => r.periodLabel.toLowerCase().includes(q))
+  }, [declarations, searchTerm])
 
   // ── Chargement initial depuis la base
   useEffect(() => {
@@ -254,6 +261,15 @@ export function CesuDeclarationSection({ employerId }: Props) {
             </EmptyState.Description>
           </EmptyState.Content>
         </EmptyState.Root>
+      ) : filteredDeclarations.length === 0 ? (
+        <EmptyState.Root>
+          <EmptyState.Content>
+            <EmptyState.Title>Aucun résultat</EmptyState.Title>
+            <EmptyState.Description>
+              Aucune déclaration ne correspond à « {searchTerm} ».
+            </EmptyState.Description>
+          </EmptyState.Content>
+        </EmptyState.Root>
       ) : (
         <Box overflowX="auto">
           <Table.Root size="sm">
@@ -267,7 +283,7 @@ export function CesuDeclarationSection({ employerId }: Props) {
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {declarations.map((r) => (
+              {filteredDeclarations.map((r) => (
                 <Table.Row key={r.id}>
                   <Table.Cell>
                     <Text fontWeight="medium" fontSize="sm">{r.periodLabel}</Text>

--- a/src/components/documents/ContractsSection.tsx
+++ b/src/components/documents/ContractsSection.tsx
@@ -3,7 +3,7 @@
  * Pattern doc-list : icône SVG + doc-info (nom + meta) + actions (télécharger + statut pill).
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import {
   VStack,
   HStack,
@@ -24,6 +24,7 @@ import { logger } from '@/lib/logger'
 
 interface Props {
   employerId: string
+  searchTerm?: string
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -61,10 +62,21 @@ function DownloadIcon() {
   )
 }
 
-export function ContractsSection({ employerId }: Props) {
+export function ContractsSection({ employerId, searchTerm = '' }: Props) {
   const [contracts, setContracts] = useState<ContractWithEmployee[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  const filteredContracts = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase()
+    if (!q) return contracts
+    return contracts.filter((c) => {
+      const name = c.employee
+        ? `${c.employee.firstName} ${c.employee.lastName}`.toLowerCase()
+        : ''
+      return name.includes(q) || c.contractType.toLowerCase().includes(q)
+    })
+  }, [contracts, searchTerm])
 
   const loadContracts = useCallback(async () => {
     try {
@@ -112,9 +124,22 @@ export function ContractsSection({ employerId }: Props) {
     )
   }
 
+  if (filteredContracts.length === 0) {
+    return (
+      <EmptyState.Root>
+        <EmptyState.Content>
+          <EmptyState.Title>Aucun résultat</EmptyState.Title>
+          <EmptyState.Description>
+            Aucun contrat ne correspond à « {searchTerm} ».
+          </EmptyState.Description>
+        </EmptyState.Content>
+      </EmptyState.Root>
+    )
+  }
+
   return (
     <VStack gap={0} align="stretch">
-      {contracts.map((contract) => (
+      {filteredContracts.map((contract) => (
         <Box
           key={contract.id}
           py={4}

--- a/src/components/documents/DocumentManagementSection.tsx
+++ b/src/components/documents/DocumentManagementSection.tsx
@@ -42,9 +42,10 @@ const MONTHS_FR = [
 
 interface DocumentManagementSectionProps {
   employerId: string
+  searchTerm?: string
 }
 
-export function DocumentManagementSection({ employerId }: DocumentManagementSectionProps) {
+export function DocumentManagementSection({ employerId, searchTerm = '' }: DocumentManagementSectionProps) {
   const [documents, setDocuments] = useState<DocumentWithEmployee[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -104,6 +105,7 @@ export function DocumentManagementSection({ employerId }: DocumentManagementSect
 
   // Filtrage combiné
   const filteredDocuments = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase()
     return documents.filter((doc) => {
       if (filterEmployeeId && doc.employee.id !== filterEmployeeId) return false
 
@@ -119,9 +121,16 @@ export function DocumentManagementSection({ employerId }: DocumentManagementSect
       if (filterJustification === 'with' && !doc.absence.justificationUrl) return false
       if (filterJustification === 'without' && doc.absence.justificationUrl) return false
 
+      if (q) {
+        const name = `${doc.employee.firstName} ${doc.employee.lastName}`.toLowerCase()
+        const reason = (doc.absence.reason ?? '').toLowerCase()
+        const typeLabel = (ABSENCE_TYPE_LABELS[doc.absence.absenceType] ?? '').toLowerCase()
+        if (!name.includes(q) && !reason.includes(q) && !typeLabel.includes(q)) return false
+      }
+
       return true
     })
-  }, [documents, filterEmployeeId, filterMonth, filterType, filterStatus, filterJustification])
+  }, [documents, filterEmployeeId, filterMonth, filterType, filterStatus, filterJustification, searchTerm])
 
   const activeFilterCount = [filterEmployeeId, filterMonth, filterType, filterStatus, filterJustification]
     .filter(Boolean).length

--- a/src/components/documents/EmployeePayslipSection.tsx
+++ b/src/components/documents/EmployeePayslipSection.tsx
@@ -25,6 +25,7 @@ import type { Payslip } from '@/types'
 
 interface Props {
   employeeId: string
+  searchTerm?: string
 }
 
 function formatUploadDate(date: Date): string {
@@ -35,7 +36,7 @@ function periodLabelFor(year: number, month: number): string {
   return `${MONTHS_FR[month - 1]} ${year}`
 }
 
-export function EmployeePayslipSection({ employeeId }: Props) {
+export function EmployeePayslipSection({ employeeId, searchTerm = '' }: Props) {
   const [payslips, setPayslips] = useState<Payslip[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [filterYear, setFilterYear] = useState<string>('')
@@ -61,10 +62,17 @@ export function EmployeePayslipSection({ employeeId }: Props) {
   }, [payslips])
 
   const filteredPayslips = useMemo(() => {
-    if (!filterYear) return payslips
-    const y = Number(filterYear)
-    return payslips.filter((p) => p.year === y)
-  }, [payslips, filterYear])
+    let result = payslips
+    if (filterYear) {
+      const y = Number(filterYear)
+      result = result.filter((p) => p.year === y)
+    }
+    const q = searchTerm.trim().toLowerCase()
+    if (q) {
+      result = result.filter((p) => periodLabelFor(p.year, p.month).toLowerCase().includes(q))
+    }
+    return result
+  }, [payslips, filterYear, searchTerm])
 
   const handleDownload = async (payslip: Payslip) => {
     if (!payslip.storagePath) return

--- a/src/components/documents/PayslipSection.tsx
+++ b/src/components/documents/PayslipSection.tsx
@@ -44,6 +44,7 @@ import type { Payslip } from '@/types'
 
 interface Props {
   employerId: string
+  searchTerm?: string
 }
 
 function formatUploadDate(date: Date): string {
@@ -54,7 +55,7 @@ function periodLabelFor(year: number, month: number): string {
   return `${MONTHS_FR[month - 1]} ${year}`
 }
 
-export function PayslipSection({ employerId }: Props) {
+export function PayslipSection({ employerId, searchTerm = '' }: Props) {
   const now = new Date()
   const currentYear = now.getFullYear()
   const currentMonth = now.getMonth() + 1
@@ -145,8 +146,17 @@ export function PayslipSection({ employerId }: Props) {
     if (filterPeriod) {
       result = result.filter((p) => periodLabelFor(p.year, p.month) === filterPeriod)
     }
+    const q = searchTerm.trim().toLowerCase()
+    if (q) {
+      result = result.filter((p) => {
+        const name = getEmployeeName(p.employeeId).toLowerCase()
+        const period = periodLabelFor(p.year, p.month).toLowerCase()
+        return name.includes(q) || period.includes(q)
+      })
+    }
     return result
-  }, [allPayslips, filterEmployeeId, filterPeriod])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allPayslips, filterEmployeeId, filterPeriod, searchTerm, contracts])
 
   const selectedContract = contracts.find((c) => c.id === selectedContractId)
 

--- a/src/pages/DocumentsPage.tsx
+++ b/src/pages/DocumentsPage.tsx
@@ -5,12 +5,15 @@
 import { useState, useEffect } from 'react'
 import { Navigate } from 'react-router-dom'
 import {
+  Box,
   Container,
   VStack,
   Spinner,
   Center,
   Alert,
   Tabs,
+  Input,
+  InputGroup,
 } from '@chakra-ui/react'
 import { DashboardLayout } from '@/components/dashboard'
 import { useAuth } from '@/hooks/useAuth'
@@ -25,12 +28,36 @@ import {
 } from '@/components/documents'
 import type { Caregiver } from '@/types'
 
+const SEARCH_PLACEHOLDERS: Record<string, string> = {
+  payslips: 'Rechercher un bulletin (employé, période)…',
+  contracts: 'Rechercher un contrat (employé)…',
+  absences: 'Rechercher une absence (employé, motif)…',
+  declarations: 'Rechercher une déclaration (période)…',
+}
+
+const SearchIcon = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+)
+
 export function DocumentsPage() {
   const { profile } = useAuth()
   const [caregiver, setCaregiver] = useState<Caregiver | null>(null)
   const [isLoadingCaregiver, setIsLoadingCaregiver] = useState(
     () => profile?.role === 'caregiver'
   )
+  const [activeTab, setActiveTab] = useState('payslips')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const handleTabChange = (details: { value: string }) => {
+    setActiveTab(details.value)
+    setSearchTerm('')
+  }
+
+  const searchPlaceholder = SEARCH_PLACEHOLDERS[activeTab]
+  const isSearchable = !!searchPlaceholder
 
   useEffect(() => {
     if (profile?.role !== 'caregiver') return
@@ -68,7 +95,21 @@ export function DocumentsPage() {
     <DashboardLayout title="Documents">
       <Container maxW="container.xl" py={6}>
         <VStack gap={6} align="stretch">
-          <Tabs.Root defaultValue="payslips" variant="enclosed">
+          <Tabs.Root value={activeTab} onValueChange={handleTabChange} variant="enclosed">
+            {isSearchable && (
+              <Box mb={4}>
+                <InputGroup startElement={SearchIcon}>
+                  <Input
+                    type="search"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    placeholder={searchPlaceholder}
+                    aria-label={searchPlaceholder}
+                    size="md"
+                  />
+                </InputGroup>
+              </Box>
+            )}
             <Tabs.List>
               <Tabs.Trigger value="payslips">
                 Bulletins de paie
@@ -95,9 +136,9 @@ export function DocumentsPage() {
 
             <Tabs.Content value="payslips" pt={6}>
               {isEmployee ? (
-                <EmployeePayslipSection employeeId={profile.id} />
+                <EmployeePayslipSection employeeId={profile.id} searchTerm={searchTerm} />
               ) : effectiveEmployerId ? (
-                <PayslipSection employerId={effectiveEmployerId} />
+                <PayslipSection employerId={effectiveEmployerId} searchTerm={searchTerm} />
               ) : (
                 <Alert.Root status="warning">
                   <Alert.Indicator />
@@ -109,7 +150,7 @@ export function DocumentsPage() {
             {!isEmployee && (
               <Tabs.Content value="contracts" pt={6}>
                 {effectiveEmployerId ? (
-                  <ContractsSection employerId={effectiveEmployerId} />
+                  <ContractsSection employerId={effectiveEmployerId} searchTerm={searchTerm} />
                 ) : (
                   <Alert.Root status="warning">
                     <Alert.Indicator />
@@ -122,7 +163,7 @@ export function DocumentsPage() {
             {!isEmployee && (
               <Tabs.Content value="absences" pt={6}>
                 {effectiveEmployerId ? (
-                  <DocumentManagementSection employerId={effectiveEmployerId} />
+                  <DocumentManagementSection employerId={effectiveEmployerId} searchTerm={searchTerm} />
                 ) : (
                   <Alert.Root status="warning">
                     <Alert.Indicator />
@@ -143,7 +184,7 @@ export function DocumentsPage() {
             {!isEmployee && (
               <Tabs.Content value="declarations" pt={6}>
                 {effectiveEmployerId ? (
-                  <CesuDeclarationSection employerId={effectiveEmployerId} />
+                  <CesuDeclarationSection employerId={effectiveEmployerId} searchTerm={searchTerm} />
                 ) : (
                   <Alert.Root status="warning">
                     <Alert.Indicator />


### PR DESCRIPTION
## Summary
P1.3 — Champ recherche dédié sur la page Documents (au-dessus des onglets), filtrage côté client par section.

### UI
- \`<Input>\` avec icône loupe au-dessus de \`Tabs.List\`
- Placeholder **dynamique** selon l'onglet actif :
  - Bulletins : \`Rechercher un bulletin (employé, période)…\`
  - Contrats : \`Rechercher un contrat (employé)…\`
  - Absences : \`Rechercher une absence (employé, motif)…\`
  - Déclarations CESU : \`Rechercher une déclaration (période)…\`
- Champ caché sur \`Export planning\` (formulaire d'export pur, pas de liste)
- \`Tabs.Root\` passé en controlled (\`value\` / \`onValueChange\`), reset \`searchTerm\` au changement de tab

### Filtrage côté client
- **PayslipSection** (employeur) : nom employé + libellé période
- **EmployeePayslipSection** (employé) : libellé période
- **ContractsSection** : nom employé + type contrat — empty state dédié \"Aucun résultat pour « x »\"
- **DocumentManagementSection** : nom + motif + libellé type d'absence (cumulé avec filtres existants)
- **CesuDeclarationSection** : \`periodLabel\` — empty state dédié

## Test plan
- [x] \`npm run lint\` (0 errors)
- [x] \`npm run typecheck\` OK
- [x] \`npm run test:run\` — **2286 passed | 4 skipped**
- [x] Vérif manuelle en compte employer : taper dans le champ filtre les bulletins/contrats/absences/CESU
- [x] Vérif manuelle en compte employee : 2 onglets visibles, recherche présente sur Bulletins
- [x] Reset au changement d'onglet