### PR TITLE
feat(contact): subject optgroups, file attachment and dashboard integration

### DIFF
--- a/docs/PROTOTYPE_GAP_CHECKLIST.md
+++ b/docs/PROTOTYPE_GAP_CHECKLIST.md
@@ -142,8 +142,8 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 
 ## 10. Contact — Elements manquants
 
-- [ ] **Subject optgroups** — categoriser les sujets (Utilisation / Compte / Autre)
-- [ ] **Piece jointe** — input file (PDF, PNG, JPG, max 5 Mo)
+- [x] **Subject optgroups** — categoriser les sujets (Utilisation / Compte / Autre) ✅ _(ContactPage.tsx — `subjectGroups` + `AccessibleSelect groups` prop)_
+- [x] **Piece jointe** — input file (PDF, PNG, JPG, max 5 Mo) ✅ _(ContactPage.tsx — validation type/taille + UI avec retrait)_
 - [x] **Etat succes** — animation checkmark + message de confirmation + bouton "Envoyer un autre" ✅ _(ContactPage.tsx l.155-167)_
 - [x] **FAQ integree** — questions en bas de page ✅ _(ContactPage.tsx l.262-281, affichage statique)_
 
@@ -187,9 +187,9 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 | Logbook | 8 | 8 | ✅ Termine |
 | Team | 7 | 7 | ✅ Termine |
 | Clock-in | 6 | 6 | ✅ Termine |
-| Contact | 4 | 2 | Basse |
+| Contact | 4 | 4 | ✅ Termine |
 | Messaging | 4 | 4 | ✅ Termine |
 | Planning | 4 | 4 | ✅ Termine |
 | Documents | 3 | 3 | ✅ Termine |
 | Patterns UI | 4 | 3 | Basse |
-| **Total** | **102** | **97** | — |
+| **Total** | **102** | **99** | — |

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -67,6 +67,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: 'Mon profil', href: '/profil', icon: 'user', ariaLabel: 'Voir mon profil' },
       { label: 'Paramètres', href: '/parametres', icon: 'settings', ariaLabel: 'Accéder aux paramètres' },
       { label: 'Aide', href: '/aide', icon: 'help', ariaLabel: 'Consulter le guide d\'utilisation' },
+      { label: 'Contact', href: '/contact', icon: 'message', ariaLabel: 'Contacter l\'équipe Unilien' },
     ],
   },
 ]

--- a/src/components/ui/AccessibleSelect.tsx
+++ b/src/components/ui/AccessibleSelect.tsx
@@ -10,11 +10,18 @@ export interface SelectOption {
   disabled?: boolean
 }
 
+export interface SelectOptionGroup {
+  label: string
+  options: SelectOption[]
+}
+
 export interface AccessibleSelectProps {
   /** Label du champ (obligatoire pour accessibilité) */
   label: string
-  /** Options du select */
-  options: SelectOption[]
+  /** Options à plat (ignoré si `groups` est fourni) */
+  options?: SelectOption[]
+  /** Options groupées (rendues en `<optgroup>`) */
+  groups?: SelectOptionGroup[]
   /** Masquer le label visuellement */
   hideLabel?: boolean
   /** Message d'erreur */
@@ -46,6 +53,7 @@ export const AccessibleSelect = forwardRef<HTMLSelectElement, AccessibleSelectPr
     {
       label,
       options,
+      groups,
       hideLabel = false,
       error,
       helperText,
@@ -111,15 +119,29 @@ export const AccessibleSelect = forwardRef<HTMLSelectElement, AccessibleSelectPr
                 {placeholder}
               </option>
             )}
-            {options.map((option) => (
-              <option
-                key={option.value}
-                value={option.value}
-                disabled={option.disabled}
-              >
-                {option.label}
-              </option>
-            ))}
+            {groups
+              ? groups.map((group) => (
+                  <optgroup key={group.label} label={group.label}>
+                    {group.options.map((option) => (
+                      <option
+                        key={option.value}
+                        value={option.value}
+                        disabled={option.disabled}
+                      >
+                        {option.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))
+              : options?.map((option) => (
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    disabled={option.disabled}
+                  >
+                    {option.label}
+                  </option>
+                ))}
           </NativeSelect.Field>
           <NativeSelect.Indicator />
         </NativeSelect.Root>

--- a/src/components/ui/NavIcon.tsx
+++ b/src/components/ui/NavIcon.tsx
@@ -26,6 +26,8 @@ const PATHS: Record<string, string> = {
   monitor: '<rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>',
   'user-plus': '<path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/>',
   help: '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/>',
+  paperclip: '<path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/>',
+  close: '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>',
 }
 
 export function NavIcon({ name, size = 18 }: NavIconProps) {

--- a/src/pages/ContactPage.test.tsx
+++ b/src/pages/ContactPage.test.tsx
@@ -63,6 +63,13 @@ describe('ContactPage', () => {
       expect(sujetSelect).toContainHTML('Partenariat')
     })
 
+    it('regroupe les sujets par catégorie (Utilisation / Compte / Autre)', () => {
+      const { container } = renderWithProviders(<ContactPage />)
+      const optgroups = container.querySelectorAll('optgroup')
+      const labels = Array.from(optgroups).map((g) => g.getAttribute('label'))
+      expect(labels).toEqual(['Utilisation', 'Compte', 'Autre'])
+    })
+
     it('les champs de saisie acceptent du texte', async () => {
       const user = userEvent.setup()
       renderWithProviders(<ContactPage />)
@@ -79,6 +86,70 @@ describe('ContactPage', () => {
       const emailInput = screen.getByLabelText(/votre email/i)
       await user.type(emailInput, 'jean@example.com')
       expect(emailInput).toHaveValue('jean@example.com')
+    })
+  })
+
+  describe('Pièce jointe', () => {
+    it('affiche le bouton "Ajouter un fichier" et la contrainte de format', () => {
+      renderWithProviders(<ContactPage />)
+      expect(screen.getByRole('button', { name: /ajouter un fichier/i })).toBeInTheDocument()
+      expect(screen.getByText(/PDF, PNG ou JPG · 5 Mo max/i)).toBeInTheDocument()
+    })
+
+    it('accepte un PDF valide et affiche son nom', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ContactPage />)
+
+      const fileInput = screen.getByLabelText(/pièce jointe/i) as HTMLInputElement
+      const validFile = new File(['hello'], 'document.pdf', { type: 'application/pdf' })
+      await user.upload(fileInput, validFile)
+
+      expect(screen.getByText('document.pdf')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /retirer la pièce jointe/i })
+      ).toBeInTheDocument()
+    })
+
+    it('rejette un format non supporté', async () => {
+      const user = userEvent.setup({ applyAccept: false })
+      renderWithProviders(<ContactPage />)
+
+      const fileInput = screen.getByLabelText(/pièce jointe/i) as HTMLInputElement
+      const invalidFile = new File(['data'], 'archive.zip', { type: 'application/zip' })
+      await user.upload(fileInput, invalidFile)
+
+      expect(screen.getByText(/format non supporté/i)).toBeInTheDocument()
+      expect(screen.queryByText('archive.zip')).not.toBeInTheDocument()
+    })
+
+    it('rejette un fichier trop volumineux (> 5 Mo)', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ContactPage />)
+
+      const fileInput = screen.getByLabelText(/pièce jointe/i) as HTMLInputElement
+      // 6 Mo de données pour dépasser la limite
+      const bigFile = new File([new Uint8Array(6 * 1024 * 1024)], 'gros.pdf', {
+        type: 'application/pdf',
+      })
+      await user.upload(fileInput, bigFile)
+
+      expect(screen.getByText(/dépasse 5 Mo/i)).toBeInTheDocument()
+      expect(screen.queryByText('gros.pdf')).not.toBeInTheDocument()
+    })
+
+    it('permet de retirer la pièce jointe ajoutée', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<ContactPage />)
+
+      const fileInput = screen.getByLabelText(/pièce jointe/i) as HTMLInputElement
+      const validFile = new File(['hello'], 'photo.png', { type: 'image/png' })
+      await user.upload(fileInput, validFile)
+
+      expect(screen.getByText('photo.png')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: /retirer la pièce jointe/i }))
+      expect(screen.queryByText('photo.png')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /ajouter un fichier/i })).toBeInTheDocument()
     })
   })
 

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import {
   Box,
@@ -10,30 +10,76 @@ import {
   GridItem,
   Link,
   Textarea,
+  IconButton,
 } from '@chakra-ui/react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { AccessibleButton, AccessibleInput, AccessibleSelect } from '@/components/ui'
+import type { SelectOptionGroup } from '@/components/ui/AccessibleSelect'
+import { NavIcon } from '@/components/ui/NavIcon'
+import { DashboardLayout } from '@/components/dashboard/DashboardLayout'
+import { useAuth } from '@/hooks/useAuth'
 import { logger } from '@/lib/logger'
+
+const MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024 // 5 Mo
+const ALLOWED_ATTACHMENT_TYPES = ['application/pdf', 'image/png', 'image/jpeg']
+const ALLOWED_ATTACHMENT_LABEL = 'PDF, PNG ou JPG · 5 Mo max'
 
 const contactSchema = z.object({
   name: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
   email: z.string().email('Adresse email invalide'),
-  subject: z.enum(['general', 'support', 'partnership', 'press'], {
-    required_error: 'Veuillez sélectionner un sujet',
-  }),
+  subject: z.enum(
+    [
+      'general',
+      'support',
+      'onboarding',
+      'login',
+      'billing',
+      'account_deletion',
+      'partnership',
+      'press',
+      'other',
+    ],
+    { required_error: 'Veuillez sélectionner un sujet' }
+  ),
   message: z.string().min(10, 'Le message doit contenir au moins 10 caractères'),
 })
 
 type ContactFormData = z.infer<typeof contactSchema>
 
-const subjectOptions = [
-  { value: 'general', label: 'Question générale' },
-  { value: 'support', label: 'Support technique' },
-  { value: 'partnership', label: 'Partenariat' },
-  { value: 'press', label: 'Presse' },
+const subjectGroups: SelectOptionGroup[] = [
+  {
+    label: 'Utilisation',
+    options: [
+      { value: 'general', label: 'Question générale' },
+      { value: 'support', label: 'Support technique' },
+      { value: 'onboarding', label: 'Aide à la prise en main' },
+    ],
+  },
+  {
+    label: 'Compte',
+    options: [
+      { value: 'login', label: 'Problème de connexion' },
+      { value: 'billing', label: 'Facturation / Abonnement' },
+      { value: 'account_deletion', label: 'Suppression de compte' },
+    ],
+  },
+  {
+    label: 'Autre',
+    options: [
+      { value: 'partnership', label: 'Partenariat' },
+      { value: 'press', label: 'Presse' },
+      { value: 'other', label: 'Autre' },
+    ],
+  },
 ]
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} o`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} Ko`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} Mo`
+}
 
 function ContactInfo({
   icon,
@@ -71,6 +117,9 @@ function ContactInfo({
 export function ContactPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
+  const [attachment, setAttachment] = useState<File | null>(null)
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const {
     register,
@@ -81,16 +130,282 @@ export function ContactPage() {
     resolver: zodResolver(contactSchema),
   })
 
+  const validateAttachment = (file: File): string | null => {
+    if (!ALLOWED_ATTACHMENT_TYPES.includes(file.type)) {
+      return `Format non supporté (${ALLOWED_ATTACHMENT_LABEL})`
+    }
+    if (file.size > MAX_ATTACHMENT_SIZE) {
+      return `Le fichier dépasse 5 Mo (${formatFileSize(file.size)})`
+    }
+    return null
+  }
+
+  const handleAttachmentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null
+    if (!file) {
+      setAttachment(null)
+      setAttachmentError(null)
+      return
+    }
+
+    const error = validateAttachment(file)
+    if (error) {
+      setAttachment(null)
+      setAttachmentError(error)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      return
+    }
+
+    setAttachment(file)
+    setAttachmentError(null)
+  }
+
+  const handleRemoveAttachment = () => {
+    setAttachment(null)
+    setAttachmentError(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
   const onSubmit = async (data: ContactFormData) => {
     setIsSubmitting(true)
 
     // Simulate API call
     await new Promise((resolve) => setTimeout(resolve, 1500))
 
-    logger.debug('Contact form submitted:', data)
+    logger.debug('Contact form submitted:', {
+      ...data,
+      attachment: attachment
+        ? { name: attachment.name, size: attachment.size, type: attachment.type }
+        : null,
+    })
     setIsSubmitting(false)
     setIsSubmitted(true)
     reset()
+    setAttachment(null)
+    setAttachmentError(null)
+  }
+
+  const { user } = useAuth()
+  const isAuthenticated = !!user
+
+  const formAndInfoContent = (
+    <Grid templateColumns={{ base: '1fr', lg: '1fr 1fr' }} gap={12}>
+      {/* Form */}
+      <GridItem>
+        <Box bg="bg.surface" p={8} borderRadius="xl" boxShadow="0 4px 16px rgba(78,100,120,.12)">
+          {isSubmitted ? (
+            <Stack gap={6} textAlign="center" py={8}>
+              <Text fontSize="4xl">✅</Text>
+              <Text fontSize="xl" fontWeight="bold" color="text.default">
+                Message envoyé !
+              </Text>
+              <Text color="text.muted">
+                Merci pour votre message. Notre équipe vous répondra dans les plus brefs délais.
+              </Text>
+              <AccessibleButton onClick={() => setIsSubmitted(false)}>
+                Envoyer un autre message
+              </AccessibleButton>
+            </Stack>
+          ) : (
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <Stack gap={5}>
+                <Text fontSize="xl" fontWeight="bold" color="text.default">
+                  Envoyez-nous un message
+                </Text>
+
+                <AccessibleInput
+                  label="Votre nom"
+                  placeholder="Jean Dupont"
+                  error={errors.name?.message}
+                  required
+                  {...register('name')}
+                />
+
+                <AccessibleInput
+                  label="Votre email"
+                  type="email"
+                  placeholder="jean.dupont@email.com"
+                  error={errors.email?.message}
+                  required
+                  {...register('email')}
+                />
+
+                <AccessibleSelect
+                  label="Sujet"
+                  groups={subjectGroups}
+                  placeholder="Sélectionnez un sujet"
+                  error={errors.subject?.message}
+                  required
+                  {...register('subject')}
+                />
+
+                <Box>
+                  <Text fontWeight="medium" fontSize="md" mb={2}>
+                    Votre message <Text as="span" color="red.500">*</Text>
+                  </Text>
+                  <Textarea
+                    placeholder="Décrivez votre demande..."
+                    rows={5}
+                    borderWidth="2px"
+                    borderColor={errors.message ? 'red.500' : 'gray.200'}
+                    _hover={{ borderColor: errors.message ? 'red.500' : 'gray.300' }}
+                    _focus={{ borderColor: 'brand.500', boxShadow: '0 0 0 1px var(--chakra-colors-brand-500)' }}
+                    {...register('message')}
+                  />
+                  {errors.message && (
+                    <Text color="red.500" fontSize="sm" mt={1}>
+                      {errors.message.message}
+                    </Text>
+                  )}
+                </Box>
+
+                <Box>
+                  <Text fontWeight="medium" fontSize="md" mb={2}>
+                    Pièce jointe{' '}
+                    <Text as="span" color="text.muted" fontWeight="normal" fontSize="sm">
+                      (facultatif)
+                    </Text>
+                  </Text>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".pdf,.png,.jpg,.jpeg,application/pdf,image/png,image/jpeg"
+                    onChange={handleAttachmentChange}
+                    style={{ display: 'none' }}
+                    aria-label="Pièce jointe"
+                  />
+                  {attachment ? (
+                    <Flex
+                      align="center"
+                      gap={3}
+                      p={3}
+                      borderWidth="1.5px"
+                      borderColor="border.default"
+                      borderRadius="10px"
+                      bg="bg.page"
+                    >
+                      <Box color="brand.500">
+                        <NavIcon name="paperclip" size={18} />
+                      </Box>
+                      <Box flex={1} minW={0}>
+                        <Text fontSize="sm" fontWeight="medium" truncate>
+                          {attachment.name}
+                        </Text>
+                        <Text fontSize="xs" color="text.muted">
+                          {formatFileSize(attachment.size)}
+                        </Text>
+                      </Box>
+                      <IconButton
+                        aria-label="Retirer la pièce jointe"
+                        size="sm"
+                        variant="ghost"
+                        onClick={handleRemoveAttachment}
+                      >
+                        <NavIcon name="close" size={16} />
+                      </IconButton>
+                    </Flex>
+                  ) : (
+                    <AccessibleButton
+                      type="button"
+                      variant="outline"
+                      size="md"
+                      onClick={() => fileInputRef.current?.click()}
+                      width="full"
+                    >
+                      <Box as="span" display="inline-flex" mr={2}>
+                        <NavIcon name="paperclip" size={16} />
+                      </Box>
+                      Ajouter un fichier
+                    </AccessibleButton>
+                  )}
+                  <Text fontSize="xs" color="text.muted" mt={2}>
+                    {ALLOWED_ATTACHMENT_LABEL}
+                  </Text>
+                  {attachmentError && (
+                    <Text color="red.500" fontSize="sm" mt={1}>
+                      {attachmentError}
+                    </Text>
+                  )}
+                </Box>
+
+                <AccessibleButton
+                  type="submit"
+                  colorPalette="brand"
+                  size="lg"
+                  loading={isSubmitting}
+                  loadingText="Envoi en cours..."
+                >
+                  Envoyer le message
+                </AccessibleButton>
+              </Stack>
+            </form>
+          )}
+        </Box>
+      </GridItem>
+
+      {/* Contact Info */}
+      <GridItem>
+        <Stack gap={8}>
+          <Box>
+            <Text fontSize="xl" fontWeight="bold" color="text.default" mb={6}>
+              Autres moyens de nous contacter
+            </Text>
+            <Stack gap={6}>
+              <ContactInfo
+                icon="📧"
+                title="Email"
+                content="contact@unilien.app"
+              />
+            </Stack>
+          </Box>
+
+          {/* FAQ Shortcut */}
+          <Box bg="brand.subtle" p={6} borderRadius="xl">
+            <Text fontWeight="bold" color="brand.700" mb={2}>
+              Questions fréquentes
+            </Text>
+            <Text color="brand.700" fontSize="sm" mb={4}>
+              Consultez notre FAQ pour trouver rapidement des réponses à vos questions.
+            </Text>
+            <Stack gap={2}>
+              <Text color="brand.600" fontSize="sm">
+                • Comment créer un compte ?
+              </Text>
+              <Text color="brand.600" fontSize="sm">
+                • Comment ajouter un auxiliaire ?
+              </Text>
+              <Text color="brand.600" fontSize="sm">
+                • Comment générer une déclaration CESU ?
+              </Text>
+            </Stack>
+          </Box>
+
+          {/* Response Time */}
+          <Box bg="accent.subtle" p={6} borderRadius="xl">
+            <Flex gap={3} align="center" mb={2}>
+              <Text fontSize="xl">⚡</Text>
+              <Text fontWeight="bold" color="green.800">
+                Réponse rapide
+              </Text>
+            </Flex>
+            <Text color="green.700" fontSize="sm">
+              Notre équipe s'engage à répondre à toutes les demandes sous 24 heures ouvrées.
+            </Text>
+          </Box>
+        </Stack>
+      </GridItem>
+    </Grid>
+  )
+
+  // Mode authentifié : intégré dans DashboardLayout
+  if (isAuthenticated) {
+    return (
+      <DashboardLayout title="Contact">
+        <Box maxW="container.xl" mx="auto" px={{ base: 4, md: 6 }} py={8}>
+          {formAndInfoContent}
+        </Box>
+      </DashboardLayout>
+    )
   }
 
   return (
@@ -147,155 +462,7 @@ export function ContactPage() {
 
       {/* Contact Form & Info */}
       <Box py="60px">
-        <Container maxW="container.xl">
-          <Grid templateColumns={{ base: '1fr', lg: '1fr 1fr' }} gap={12}>
-            {/* Form */}
-            <GridItem>
-              <Box bg="bg.surface" p={8} borderRadius="xl" boxShadow="0 4px 16px rgba(78,100,120,.12)">
-                {isSubmitted ? (
-                  <Stack gap={6} textAlign="center" py={8}>
-                    <Text fontSize="4xl">✅</Text>
-                    <Text fontSize="xl" fontWeight="bold" color="text.default">
-                      Message envoyé !
-                    </Text>
-                    <Text color="text.muted">
-                      Merci pour votre message. Notre équipe vous répondra dans les plus brefs délais.
-                    </Text>
-                    <AccessibleButton onClick={() => setIsSubmitted(false)}>
-                      Envoyer un autre message
-                    </AccessibleButton>
-                  </Stack>
-                ) : (
-                  <form onSubmit={handleSubmit(onSubmit)}>
-                    <Stack gap={5}>
-                      <Text fontSize="xl" fontWeight="bold" color="text.default">
-                        Envoyez-nous un message
-                      </Text>
-
-                      <AccessibleInput
-                        label="Votre nom"
-                        placeholder="Jean Dupont"
-                        error={errors.name?.message}
-                        required
-                        {...register('name')}
-                      />
-
-                      <AccessibleInput
-                        label="Votre email"
-                        type="email"
-                        placeholder="jean.dupont@email.com"
-                        error={errors.email?.message}
-                        required
-                        {...register('email')}
-                      />
-
-                      <AccessibleSelect
-                        label="Sujet"
-                        options={subjectOptions}
-                        placeholder="Sélectionnez un sujet"
-                        error={errors.subject?.message}
-                        required
-                        {...register('subject')}
-                      />
-
-                      <Box>
-                        <Text fontWeight="medium" fontSize="md" mb={2}>
-                          Votre message <Text as="span" color="red.500">*</Text>
-                        </Text>
-                        <Textarea
-                          placeholder="Décrivez votre demande..."
-                          rows={5}
-                          borderWidth="2px"
-                          borderColor={errors.message ? 'red.500' : 'gray.200'}
-                          _hover={{ borderColor: errors.message ? 'red.500' : 'gray.300' }}
-                          _focus={{ borderColor: 'brand.500', boxShadow: '0 0 0 1px var(--chakra-colors-brand-500)' }}
-                          {...register('message')}
-                        />
-                        {errors.message && (
-                          <Text color="red.500" fontSize="sm" mt={1}>
-                            {errors.message.message}
-                          </Text>
-                        )}
-                      </Box>
-
-                      <AccessibleButton
-                        type="submit"
-                        colorPalette="brand"
-                        size="lg"
-                        loading={isSubmitting}
-                        loadingText="Envoi en cours..."
-                      >
-                        Envoyer le message
-                      </AccessibleButton>
-                    </Stack>
-                  </form>
-                )}
-              </Box>
-            </GridItem>
-
-            {/* Contact Info */}
-            <GridItem>
-              <Stack gap={8}>
-                <Box>
-                  <Text fontSize="xl" fontWeight="bold" color="text.default" mb={6}>
-                    Autres moyens de nous contacter
-                  </Text>
-                  <Stack gap={6}>
-                    <ContactInfo
-                      icon="📧"
-                      title="Email"
-                      content="contact@unilien.app"
-                    />
-                    <ContactInfo
-                      icon="📞"
-                      title="Téléphone"
-                      content="01 23 45 67 89 (Lun-Ven, 9h-18h)"
-                    />
-                    <ContactInfo
-                      icon="📍"
-                      title="Adresse"
-                      content="123 Rue de l'Innovation, 75001 Paris"
-                    />
-                  </Stack>
-                </Box>
-
-                {/* FAQ Shortcut */}
-                <Box bg="brand.subtle" p={6} borderRadius="xl">
-                  <Text fontWeight="bold" color="brand.700" mb={2}>
-                    Questions fréquentes
-                  </Text>
-                  <Text color="brand.700" fontSize="sm" mb={4}>
-                    Consultez notre FAQ pour trouver rapidement des réponses à vos questions.
-                  </Text>
-                  <Stack gap={2}>
-                    <Text color="brand.600" fontSize="sm">
-                      • Comment créer un compte ?
-                    </Text>
-                    <Text color="brand.600" fontSize="sm">
-                      • Comment ajouter un auxiliaire ?
-                    </Text>
-                    <Text color="brand.600" fontSize="sm">
-                      • Comment générer une déclaration CESU ?
-                    </Text>
-                  </Stack>
-                </Box>
-
-                {/* Response Time */}
-                <Box bg="accent.subtle" p={6} borderRadius="xl">
-                  <Flex gap={3} align="center" mb={2}>
-                    <Text fontSize="xl">⚡</Text>
-                    <Text fontWeight="bold" color="green.800">
-                      Réponse rapide
-                    </Text>
-                  </Flex>
-                  <Text color="green.700" fontSize="sm">
-                    Notre équipe s'engage à répondre à toutes les demandes sous 24 heures ouvrées.
-                  </Text>
-                </Box>
-              </Stack>
-            </GridItem>
-          </Grid>
-        </Container>
+        <Container maxW="container.xl">{formAndInfoContent}</Container>
       </Box>
 
       {/* Footer */}


### PR DESCRIPTION
## Summary
Refonte de la page Contact pour cocher les 2 derniers items du Prototype Gap Checklist, intégration dans l'interface authentifiée et nettoyage des infos de contact non disponibles.

### Changements

**Sujets — optgroups**
- Nouveau prop `groups?: SelectOptionGroup[]` sur `AccessibleSelect` (rendu `<optgroup>`), backward compatible avec `options`
- Sujets ContactPage regroupés en 3 catégories :
  - **Utilisation** : Question générale · Support technique · Aide à la prise en main
  - **Compte** : Problème de connexion · Facturation / Abonnement · Suppression de compte
  - **Autre** : Partenariat · Presse · Autre

**Pièce jointe**
- Input file caché + bouton "Ajouter un fichier" pleine largeur (icône trombone)
- Validation type (`PDF`, `PNG`, `JPG`) + taille (5 Mo max)
- UI fichier sélectionné : icône + nom (truncate) + taille formatée + bouton retrait
- Reset auto au submit

**Intégration interface**
- Item **Contact** ajouté à la sidebar (section *Compte*, juste après *Aide*)
- `ContactPage` détecte `useAuth()` et adapte son layout : `DashboardLayout` si authentifié, header/footer marketing sinon
- Form + colonne info extraits en `formAndInfoContent` (anti-duplication)

**Divers**
- `NavIcon` : nouvelles icônes `paperclip` + `close`
- Téléphone et adresse masqués temporairement (en attendant les vraies infos), seul `contact@unilien.app` reste affiché
- Checklist `PROTOTYPE_GAP_CHECKLIST.md` mise à jour : section Contact 4/4 ✅, total 99/102

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (2 warnings préexistants hors PR)
- [x] `npm run test:run` : **2292 passed / 4 skipped** (133 fichiers, +6 vs main)
- [x] Test manuel public : `/contact` non connecté → header marketing OK, optgroups visibles, upload PDF OK, upload .zip rejeté, upload > 5 Mo rejeté
- [x] Test manuel authentifié : sidebar > Compte > Contact → ouvre dans `DashboardLayout`, form fonctionnel
- [x] Vérifier que la colonne droite n'affiche que l'email

🤖 Generated with [Claude Code](https://claude.com/claude-code)