### PR TITLE
feat(privacy): analytics opt-in toggle and Plausible conditional loader

### DIFF
--- a/docs/ANALYTICS_IMPLEMENTATION.md
+++ b/docs/ANALYTICS_IMPLEMENTATION.md
@@ -1,6 +1,6 @@
 # Analytics & Cookies de performance — Plan d'implémentation
 
-> Statut : **En attente** — les toggles sont présents dans Paramètres > Données (badge "Bientôt")
+> Statut : **Code app prêt** ✅ — il reste uniquement à déployer Plausible et configurer les env vars (cf. section *Activation prod* en bas).
 
 ---
 
@@ -123,13 +123,13 @@ Le toggle "Cookies de performance" n'a de sens que si un outil futur en pose (ex
 
 ## Estimation
 
-| Tâche | Effort |
-|-------|--------|
-| Setup Plausible self-hosted (Docker) | ~1h |
-| Composant `<Analytics />` + hook | ~30min |
-| Migration DB + service + store | ~30min (code déjà préparé) |
-| Activation toggles Settings | ~15min |
-| **Total** | **~2h** |
+| Tâche | Effort | Statut |
+|-------|--------|--------|
+| Setup Plausible self-hosted (Docker) | ~1h | À faire (infra) |
+| Composant `<Analytics />` + hook | ~30min | ✅ |
+| Migration DB + service + store | ~30min | ✅ |
+| Activation toggles Settings | ~15min | ✅ |
+| **Total** | **~2h** | **~1h restant (infra)** |
 
 ---
 
@@ -137,3 +137,20 @@ Le toggle "Cookies de performance" n'a de sens que si un outil futur en pose (ex
 
 - Un serveur/VPS pour héberger Plausible (ou utiliser le cloud à 9€/mois)
 - Un domaine/sous-domaine pour le dashboard (ex: `plausible.unilien.app`)
+
+---
+
+## Activation prod
+
+Une fois Plausible déployé :
+
+1. Configurer 2 variables d'environnement Vite (env de build) :
+   ```
+   VITE_PLAUSIBLE_DOMAIN=unilien.app
+   VITE_PLAUSIBLE_SRC=https://plausible.unilien.app/js/script.js
+   ```
+2. Rebuild + redeploy le front
+3. Appliquer la migration `057_privacy_settings.sql` côté Supabase prod
+4. C'est tout : le composant `<Analytics />` lit les env vars + la préférence user et injecte/retire le script automatiquement
+
+> Si les env vars sont absentes, `<Analytics />` est silencieux (no-op) — pas de risque en dev/staging.

--- a/docs/PROTOTYPE_GAP_CHECKLIST.md
+++ b/docs/PROTOTYPE_GAP_CHECKLIST.md
@@ -31,7 +31,7 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 - [x] **Panneau Accessibilite** — toggle optimisation lecteur ecran ✅
 - [x] **Panneau Accessibilite** — toggle police dyslexie ✅
 - [x] **Panneau Donnees** — export JSON (7 tables) + CSV (planning) ✅
-- [ ] **Panneau Donnees** — toggles confidentialite (analytics, cookies) _(badge "Bientot", disabled)_
+- [x] **Panneau Donnees** — toggle confidentialite analytics fonctionnel ✅ _(SettingsPage.tsx — `PrivacySettingsCard`, persistance Zustand + Supabase, hook `usePrivacySettings`, toggle cookies retire car Plausible cookieless)_
 
 ---
 
@@ -179,7 +179,7 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 
 | Bloc | Items | Done | Priorite |
 |------|-------|------|----------|
-| Settings | 22 | 22 | ✅ Termine (confidentialite : badge "Bientot" intentionnel) |
+| Settings | 22 | 22 | ✅ Termine |
 | Dashboard | 11 | 9 | Basse (demo banner, empty state) |
 | Landing | 11 | 11 | ✅ Termine |
 | Compliance | 9 | 9 | ✅ Termine |

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -24,6 +24,10 @@ vi.mock('@/stores/authStore', () => ({
   }),
 }))
 
+vi.mock('@/components/Analytics', () => ({
+  Analytics: () => null,
+}))
+
 // Formulaires auth (imports statiques)
 vi.mock('@/components/auth', () => ({
   LoginForm: () => <div data-testid="login-form">Login</div>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginForm, SignupForm, ForgotPasswordForm, ResetPasswordForm } from '@/
 import { ErrorBoundary } from '@/components/ui'
 import { CookieConsentBanner } from '@/components/ui/CookieConsentBanner'
 import { RouteAnnouncer } from '@/components/accessibility/RouteAnnouncer'
+import { Analytics } from '@/components/Analytics'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccessibilityStore } from '@/stores/authStore'
 import { supabase } from '@/lib/supabase/client'
@@ -124,6 +125,7 @@ function App() {
     <>
       <AccessibilityApplier />
       <RouteAnnouncer />
+      <Analytics />
       <Suspense fallback={<LoadingPage />}>
         <Routes>
           {/* Page d'accueil publique */}

--- a/src/components/Analytics.test.tsx
+++ b/src/components/Analytics.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+const mockUsePrivacySettings = vi.fn()
+
+vi.mock('@/hooks/usePrivacySettings', () => ({
+  usePrivacySettings: () => mockUsePrivacySettings(),
+}))
+
+const SCRIPT_ID = 'plausible-analytics'
+
+async function loadAnalytics() {
+  vi.resetModules()
+  const mod = await import('./Analytics')
+  return mod.Analytics
+}
+
+beforeEach(() => {
+  document.head.querySelectorAll(`#${SCRIPT_ID}`).forEach((el) => el.remove())
+  mockUsePrivacySettings.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  cleanup()
+  document.head.querySelectorAll(`#${SCRIPT_ID}`).forEach((el) => el.remove())
+})
+
+describe('Analytics', () => {
+  it("n'injecte rien si analytics activé mais env vars absentes", async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', '')
+    vi.stubEnv('VITE_PLAUSIBLE_SRC', '')
+    mockUsePrivacySettings.mockReturnValue({ analyticsEnabled: true })
+
+    const Analytics = await loadAnalytics()
+    render(<Analytics />)
+
+    expect(document.getElementById(SCRIPT_ID)).toBeNull()
+  })
+
+  it("n'injecte rien si analytics désactivé", async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'unilien.app')
+    vi.stubEnv('VITE_PLAUSIBLE_SRC', 'https://plausible.unilien.app/js/script.js')
+    mockUsePrivacySettings.mockReturnValue({ analyticsEnabled: false })
+
+    const Analytics = await loadAnalytics()
+    render(<Analytics />)
+
+    expect(document.getElementById(SCRIPT_ID)).toBeNull()
+  })
+
+  it('injecte le script si activé + env configurées', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'unilien.app')
+    vi.stubEnv('VITE_PLAUSIBLE_SRC', 'https://plausible.unilien.app/js/script.js')
+    mockUsePrivacySettings.mockReturnValue({ analyticsEnabled: true })
+
+    const Analytics = await loadAnalytics()
+    render(<Analytics />)
+
+    const script = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null
+    expect(script).not.toBeNull()
+    expect(script?.dataset.domain).toBe('unilien.app')
+    expect(script?.src).toBe('https://plausible.unilien.app/js/script.js')
+    expect(script?.defer).toBe(true)
+  })
+
+  it('retire le script quand analytics passe à false', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'unilien.app')
+    vi.stubEnv('VITE_PLAUSIBLE_SRC', 'https://plausible.unilien.app/js/script.js')
+    mockUsePrivacySettings.mockReturnValue({ analyticsEnabled: true })
+
+    const Analytics = await loadAnalytics()
+    const { rerender } = render(<Analytics />)
+    expect(document.getElementById(SCRIPT_ID)).not.toBeNull()
+
+    mockUsePrivacySettings.mockReturnValue({ analyticsEnabled: false })
+    rerender(<Analytics />)
+
+    expect(document.getElementById(SCRIPT_ID)).toBeNull()
+  })
+
+  it('ne duplique pas le script sur re-render', async () => {
+    vi.stubEnv('VITE_PLAUSIBLE_DOMAIN', 'unilien.app')
+    vi.stubEnv('VITE_PLAUSIBLE_SRC', 'https://plausible.unilien.app/js/script.js')
+    mockUsePrivacySettings.mockReturnValue({ analyticsEnabled: true })
+
+    const Analytics = await loadAnalytics()
+    const { rerender } = render(<Analytics />)
+    rerender(<Analytics />)
+    rerender(<Analytics />)
+
+    expect(document.querySelectorAll(`#${SCRIPT_ID}`).length).toBe(1)
+  })
+})

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,42 @@
+/**
+ * Charge conditionnellement le script Plausible (cookieless analytics).
+ *
+ * Conditions d'activation :
+ * - `VITE_PLAUSIBLE_DOMAIN` et `VITE_PLAUSIBLE_SRC` configurés (sinon no-op)
+ * - L'utilisateur n'a pas désactivé les analytics dans Paramètres > Confidentialité
+ *
+ * Le script est injecté/retiré dynamiquement quand la préférence change.
+ */
+
+import { useEffect } from 'react'
+import { usePrivacySettings } from '@/hooks/usePrivacySettings'
+
+const SCRIPT_ID = 'plausible-analytics'
+
+const PLAUSIBLE_DOMAIN = import.meta.env.VITE_PLAUSIBLE_DOMAIN as string | undefined
+const PLAUSIBLE_SRC = import.meta.env.VITE_PLAUSIBLE_SRC as string | undefined
+
+export function Analytics() {
+  const { analyticsEnabled } = usePrivacySettings()
+
+  useEffect(() => {
+    // Pas configuré → ne rien faire
+    if (!PLAUSIBLE_DOMAIN || !PLAUSIBLE_SRC) return
+
+    const existing = document.getElementById(SCRIPT_ID)
+
+    if (analyticsEnabled) {
+      if (existing) return
+      const script = document.createElement('script')
+      script.id = SCRIPT_ID
+      script.defer = true
+      script.dataset.domain = PLAUSIBLE_DOMAIN
+      script.src = PLAUSIBLE_SRC
+      document.head.appendChild(script)
+    } else if (existing) {
+      existing.remove()
+    }
+  }, [analyticsEnabled])
+
+  return null
+}

--- a/src/hooks/usePrivacySettings.ts
+++ b/src/hooks/usePrivacySettings.ts
@@ -1,0 +1,41 @@
+/**
+ * Hook pour les préférences de confidentialité (analytics).
+ * Wrapper autour du store Zustand (persistance localStorage + Supabase).
+ */
+
+import { useEffect } from 'react'
+import { usePrivacySettingsStore, subscribeSyncToDb } from '@/stores/privacySettingsStore'
+import { useAuthStore } from '@/stores/authStore'
+import type { PrivacySettings } from '@/services/privacySettingsService'
+
+export function usePrivacySettings() {
+  const profile = useAuthStore((s) => s.profile)
+  const profileId = profile?.id
+
+  const store = usePrivacySettingsStore()
+
+  // Charger depuis la DB au premier mount si connecté
+  useEffect(() => {
+    if (profileId && !store.isSynced && !store.isLoading) {
+      store.loadFromDb(profileId)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [profileId])
+
+  // Auto-save debounced vers la DB
+  useEffect(() => {
+    if (!profileId) return
+    const unsub = subscribeSyncToDb(profileId)
+    return () => {
+      unsub?.()
+    }
+  }, [profileId])
+
+  return {
+    analyticsEnabled: store.analyticsEnabled,
+    isLoading: store.isLoading,
+
+    updateSettings: (patch: Partial<PrivacySettings>) => store.updateSettings(patch),
+    resetToDefaults: store.resetToDefaults,
+  }
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -41,6 +41,7 @@ import { GhostButton, PrimaryButton } from '@/components/ui'
 import { useInterventionSettings } from '@/hooks/useInterventionSettings'
 import { ShoppingListTemplatesSection } from '@/components/profile/ShoppingListTemplatesSection'
 import { useConventionSettings } from '@/hooks/useConventionSettings'
+import { usePrivacySettings } from '@/hooks/usePrivacySettings'
 import { useMfa } from '@/hooks/useMfa'
 import { MfaEnrollment } from '@/components/auth/MfaEnrollment'
 import { DEFAULT_TASKS } from '@/lib/constants/taskDefaults'
@@ -2153,33 +2154,32 @@ function DonneesPanel({ userId }: { userId: string }) {
 
       <HealthConsentCard />
 
-      <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm" opacity={0.6}>
-        <Card.Header px={4} py={3} borderBottomWidth="1px" borderColor="border.default">
-          <HStack gap={2}>
-            <Card.Title fontFamily="heading" fontSize="lg" fontWeight="700">Confidentialité</Card.Title>
-            <Badge size="sm" colorPalette="gray">Bientôt</Badge>
-          </HStack>
-        </Card.Header>
-        <Card.Body p={4}>
-          <VStack gap={0} align="stretch">
-            <ToggleRow
-              label="Analyses anonymisées"
-              description="Contribuez à améliorer Unilien en partageant des données d'usage anonymisées."
-              checked={true}
-              onChange={() => {}}
-              disabled
-            />
-            <ToggleRow
-              label="Cookies de performance"
-              description="Cookies pour optimiser les temps de chargement."
-              checked={true}
-              onChange={() => {}}
-              disabled
-            />
-          </VStack>
-        </Card.Body>
-      </Card.Root>
+      <PrivacySettingsCard />
     </VStack>
+  )
+}
+
+function PrivacySettingsCard() {
+  const { analyticsEnabled, updateSettings } = usePrivacySettings()
+
+  return (
+    <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm">
+      <Card.Header px={4} py={3} borderBottomWidth="1px" borderColor="border.default">
+        <Card.Title fontFamily="heading" fontSize="lg" fontWeight="700">
+          Confidentialité
+        </Card.Title>
+      </Card.Header>
+      <Card.Body p={4}>
+        <VStack gap={0} align="stretch">
+          <ToggleRow
+            label="Analyses anonymisées"
+            description="Contribuez à améliorer Unilien en partageant des données d'usage anonymisées (Plausible, sans cookies ni données personnelles)."
+            checked={analyticsEnabled}
+            onChange={(checked) => updateSettings({ analyticsEnabled: checked })}
+          />
+        </VStack>
+      </Card.Body>
+    </Card.Root>
   )
 }
 

--- a/src/services/privacySettingsService.test.ts
+++ b/src/services/privacySettingsService.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  getPrivacySettings,
+  upsertPrivacySettings,
+  PRIVACY_DEFAULTS,
+} from './privacySettingsService'
+import type { PrivacySettings } from './privacySettingsService'
+
+const mockFrom = vi.fn()
+
+vi.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
+function mockSupabaseQuery(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {}
+  chain.select = vi.fn().mockReturnValue(chain)
+  chain.upsert = vi.fn().mockReturnValue(chain)
+  chain.eq = vi.fn().mockReturnValue(chain)
+  chain.single = vi.fn().mockResolvedValue(result)
+  chain.then = vi.fn().mockImplementation((resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve(result))
+  )
+  mockFrom.mockImplementation(() => chain)
+  return chain
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+const PROFILE_ID = 'prof-abc'
+
+const DB_ROW = {
+  profile_id: PROFILE_ID,
+  analytics_enabled: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const MAPPED_SETTINGS: PrivacySettings = {
+  analyticsEnabled: false,
+}
+
+describe('getPrivacySettings', () => {
+  it('retourne les settings mappés depuis la DB', async () => {
+    mockSupabaseQuery({ data: DB_ROW, error: null })
+
+    const result = await getPrivacySettings(PROFILE_ID)
+
+    expect(result).toEqual(MAPPED_SETTINGS)
+  })
+
+  it('appelle supabase avec le bon profile_id', async () => {
+    const chain = mockSupabaseQuery({ data: DB_ROW, error: null })
+
+    await getPrivacySettings(PROFILE_ID)
+
+    expect(mockFrom).toHaveBeenCalledWith('privacy_settings')
+    expect(chain.eq).toHaveBeenCalledWith('profile_id', PROFILE_ID)
+    expect(chain.single).toHaveBeenCalled()
+  })
+
+  it('retourne les defaults si aucune ligne (PGRST116)', async () => {
+    mockSupabaseQuery({
+      data: null,
+      error: { code: 'PGRST116', message: 'No rows found' },
+    })
+
+    const result = await getPrivacySettings(PROFILE_ID)
+
+    expect(result).toEqual(PRIVACY_DEFAULTS)
+    expect(result.analyticsEnabled).toBe(true)
+  })
+
+  it('log l erreur si code != PGRST116', async () => {
+    const { logger } = await import('@/lib/logger')
+    const supabaseError = { code: '42P01', message: 'Table not found' }
+    mockSupabaseQuery({ data: null, error: supabaseError })
+
+    await getPrivacySettings(PROFILE_ID)
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Erreur chargement privacy settings:',
+      supabaseError
+    )
+  })
+
+  it('ne log pas pour PGRST116 (cas normal premier usage)', async () => {
+    const { logger } = await import('@/lib/logger')
+    mockSupabaseQuery({
+      data: null,
+      error: { code: 'PGRST116', message: 'No rows found' },
+    })
+
+    await getPrivacySettings(PROFILE_ID)
+
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('upsertPrivacySettings', () => {
+  it('appelle upsert avec les bons paramètres', async () => {
+    const chain = mockSupabaseQuery({ data: null, error: null })
+
+    await upsertPrivacySettings(PROFILE_ID, MAPPED_SETTINGS)
+
+    expect(mockFrom).toHaveBeenCalledWith('privacy_settings')
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile_id: PROFILE_ID,
+        analytics_enabled: false,
+      }),
+      { onConflict: 'profile_id' }
+    )
+  })
+
+  it('inclut updated_at en ISO string', async () => {
+    const chain = mockSupabaseQuery({ data: null, error: null })
+
+    await upsertPrivacySettings(PROFILE_ID, MAPPED_SETTINGS)
+
+    const upsertArg = (chain.upsert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(upsertArg.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('throw l erreur Supabase en cas d échec', async () => {
+    const supabaseError = { message: 'RLS violation', code: '42501' }
+    mockSupabaseQuery({ data: null, error: supabaseError })
+
+    await expect(
+      upsertPrivacySettings(PROFILE_ID, MAPPED_SETTINGS)
+    ).rejects.toEqual(supabaseError)
+  })
+
+  it('ne throw pas si pas d erreur', async () => {
+    mockSupabaseQuery({ data: null, error: null })
+
+    await expect(
+      upsertPrivacySettings(PROFILE_ID, MAPPED_SETTINGS)
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/services/privacySettingsService.ts
+++ b/src/services/privacySettingsService.ts
@@ -1,0 +1,58 @@
+/**
+ * Service CRUD pour les préférences de confidentialité (analytics).
+ * Table : privacy_settings (une ligne par utilisateur).
+ */
+
+import { supabase } from '@/lib/supabase/client'
+import { logger } from '@/lib/logger'
+import type { PrivacySettingsDbRow } from '@/types/database'
+
+export interface PrivacySettings {
+  analyticsEnabled: boolean
+}
+
+export const PRIVACY_DEFAULTS: PrivacySettings = {
+  analyticsEnabled: true,
+}
+
+function mapFromDb(row: PrivacySettingsDbRow): PrivacySettings {
+  return {
+    analyticsEnabled: row.analytics_enabled,
+  }
+}
+
+export async function getPrivacySettings(profileId: string): Promise<PrivacySettings> {
+  const { data, error } = await supabase
+    .from('privacy_settings')
+    .select('profile_id, analytics_enabled, created_at, updated_at')
+    .eq('profile_id', profileId)
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') return { ...PRIVACY_DEFAULTS }
+    logger.error('Erreur chargement privacy settings:', error)
+    return { ...PRIVACY_DEFAULTS }
+  }
+  return mapFromDb(data as PrivacySettingsDbRow)
+}
+
+export async function upsertPrivacySettings(
+  profileId: string,
+  settings: PrivacySettings,
+): Promise<void> {
+  const { error } = await supabase
+    .from('privacy_settings')
+    .upsert(
+      {
+        profile_id: profileId,
+        analytics_enabled: settings.analyticsEnabled,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'profile_id' },
+    )
+
+  if (error) {
+    logger.error('Erreur sauvegarde privacy settings:', error)
+    throw error
+  }
+}

--- a/src/stores/privacySettingsStore.ts
+++ b/src/stores/privacySettingsStore.ts
@@ -1,0 +1,95 @@
+/**
+ * Store Zustand pour les préférences de confidentialité.
+ * Double persistance : localStorage (immédiat) + Supabase (debounced).
+ */
+
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import {
+  getPrivacySettings,
+  upsertPrivacySettings,
+  PRIVACY_DEFAULTS,
+} from '@/services/privacySettingsService'
+import type { PrivacySettings } from '@/services/privacySettingsService'
+import { logger } from '@/lib/logger'
+
+interface PrivacySettingsState extends PrivacySettings {
+  isLoading: boolean
+  isSynced: boolean
+
+  updateSettings: (patch: Partial<PrivacySettings>) => void
+  resetToDefaults: () => void
+
+  loadFromDb: (profileId: string) => Promise<void>
+  saveToDb: (profileId: string) => Promise<void>
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function debouncedSave(profileId: string, state: PrivacySettingsState) {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    state.saveToDb(profileId)
+  }, 1500)
+}
+
+export const usePrivacySettingsStore = create<PrivacySettingsState>()(
+  persist(
+    (set, get) => ({
+      ...PRIVACY_DEFAULTS,
+      isLoading: false,
+      isSynced: false,
+
+      updateSettings: (patch) => {
+        set((prev) => ({ ...prev, ...patch }))
+      },
+
+      resetToDefaults: () => {
+        set({ ...PRIVACY_DEFAULTS })
+      },
+
+      loadFromDb: async (profileId) => {
+        set({ isLoading: true })
+        try {
+          const settings = await getPrivacySettings(profileId)
+          set({ ...settings, isSynced: true })
+        } catch (err) {
+          logger.error('Erreur chargement privacy settings depuis DB:', err)
+        } finally {
+          set({ isLoading: false })
+        }
+      },
+
+      saveToDb: async (profileId) => {
+        const { analyticsEnabled } = get()
+        try {
+          await upsertPrivacySettings(profileId, { analyticsEnabled })
+          set({ isSynced: true })
+        } catch (err) {
+          logger.error('Erreur sauvegarde privacy settings vers DB:', err)
+          set({ isSynced: false })
+        }
+      },
+    }),
+    {
+      name: 'unilien-privacy-settings',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        analyticsEnabled: state.analyticsEnabled,
+      }),
+    },
+  ),
+)
+
+/** Helper : sauvegarde debounced vers la DB après chaque changement */
+export function subscribeSyncToDb(profileId: string | undefined) {
+  const store = usePrivacySettingsStore
+  if (!profileId) return
+
+  return store.subscribe((state, prevState) => {
+    const changed = state.analyticsEnabled !== prevState.analyticsEnabled
+    if (changed && profileId) {
+      debouncedSave(profileId, state)
+    }
+  })
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -446,3 +446,14 @@ export interface ConventionSettingsDbRow {
   created_at: string
   updated_at: string
 }
+
+// ============================================================
+// PRIVACY SETTINGS
+// ============================================================
+
+export interface PrivacySettingsDbRow {
+  profile_id: string
+  analytics_enabled: boolean
+  created_at: string
+  updated_at: string
+}

--- a/supabase/migrations/057_privacy_settings.sql
+++ b/supabase/migrations/057_privacy_settings.sql
@@ -1,0 +1,19 @@
+-- Préférences de confidentialité par utilisateur
+-- Activation/désactivation des analytics (Plausible cookieless)
+
+CREATE TABLE privacy_settings (
+  profile_id UUID PRIMARY KEY REFERENCES profiles(id) ON DELETE CASCADE,
+
+  -- Analytics anonymisés (Plausible) — opt-in par défaut, cookieless
+  analytics_enabled BOOLEAN NOT NULL DEFAULT true,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE privacy_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own privacy settings"
+  ON privacy_settings FOR ALL
+  USING (profile_id = auth.uid())
+  WITH CHECK (profile_id = auth.uid());


### PR DESCRIPTION
## Summary
Préparation côté code de l'intégration Plausible (cookieless analytics, conforme RGPD sans bandeau). Tout est prêt à l'emploi : il ne reste plus qu'à déployer Plausible sur le VPS et configurer 2 env vars dans GitHub Actions pour l'activer en prod. Si les env vars sont absentes, le composant est silencieux — aucun risque en dev/staging.

### Changements

**DB**
- Migration `057_privacy_settings.sql` : table `privacy_settings(profile_id, analytics_enabled, created_at, updated_at)`, RLS owner-only

**Service / store / hook**
- `privacySettingsService.ts` : `getPrivacySettings` + `upsertPrivacySettings` avec defaults (`analyticsEnabled: true`)
- `privacySettingsStore.ts` : Zustand persist localStorage + sync DB debounced (1.5s) — pattern identique à `conventionSettings`
- `usePrivacySettings.ts` : wrapper hook auto-load au mount + auto-save subscription

**Composant Analytics**
- `Analytics.tsx` : injecte/retire le script Plausible dynamiquement selon `analyticsEnabled` ET `VITE_PLAUSIBLE_DOMAIN` + `VITE_PLAUSIBLE_SRC`. No-op si env vars absentes
- Monté dans `App.tsx`

**Settings**
- Carte *Confidentialité* enabled (était `disabled` + badge "Bientôt")
- Toggle *Analyses anonymisées* fonctionnel (persistance immédiate localStorage + DB debounced)
- Toggle *Cookies de performance* **supprimé** (Plausible étant cookieless, ce toggle perdait son sens)

**Docs**
- `ANALYTICS_IMPLEMENTATION.md` : statut → "Code app prêt", section *Activation prod* avec env vars + commande migration
- `PROTOTYPE_GAP_CHECKLIST.md` : item Settings > confidentialité coché

## Activation prod (post-merge, ~1h)
1. DNS : record A `plausible.unilien.app` → VPS
2. Docker compose Plausible CE sur VPS (port `localhost:8001`)
3. Caddyfile : bloc `plausible.unilien.app` + ajouter `https://plausible.unilien.app` à `script-src` et `connect-src` du CSP
4. Appliquer migration `057` côté Supabase prod
5. Créer site `unilien.app` dans l'UI Plausible
6. GitHub Actions env `env_unilien` : `VITE_PLAUSIBLE_DOMAIN=unilien.app` + `VITE_PLAUSIBLE_SRC=https://plausible.unilien.app/js/script.js` + update `deploy.yml`
7. Re-deploy front

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (2 warnings préexistants)
- [x] `npm run test:run` : **2306 passed / 4 skipped** (135 fichiers, +14 vs main)
- [ ] Test manuel post-merge en local : aller dans Paramètres > Données > Confidentialité, toggle ON/OFF, vérifier persistance après reload (sans env vars Plausible → aucun script injecté, c'est attendu)
- [ ] Activation prod : suivre les 7 étapes ci-dessus, vérifier dashboard Plausible après quelques pageviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)