### PR TITLE
docs(privacy): mention Plausible audience measurement in privacy/legal pages and settings

### DIFF
--- a/src/pages/LegalPage.tsx
+++ b/src/pages/LegalPage.tsx
@@ -121,8 +121,17 @@ export default function LegalPage() {
           <Section title="6. Cookies et stockage local">
             <Text>
               Unilien utilise exclusivement des <strong>cookies strictement nécessaires</strong> au
-              fonctionnement de l&apos;application. Aucun cookie publicitaire, analytique ou de suivi
+              fonctionnement de l&apos;application. Aucun cookie publicitaire ou de suivi
               n&apos;est déposé.
+            </Text>
+            <Text>
+              La mesure d&apos;audience est assurée par{' '}
+              <strong>Plausible Analytics auto-hébergé</strong>, sans cookie ni identifiant
+              persistant — voir la{' '}
+              <Link as={RouterLink} to="/politique-confidentialite" color="brand.solid">
+                politique de confidentialité, section&nbsp;10
+              </Link>
+              .
             </Text>
             <Box bg="bg.surface" borderWidth="1px" borderColor="border.default" borderRadius="10px" overflow="hidden">
               <Flex bg="bg.muted" px={4} py={2} fontWeight="700" fontSize="xs" color="text.default" gap={4}>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -183,13 +183,41 @@ export default function PrivacyPage() {
           <Section title="9. Cookies et stockage local">
             <Text>
               Unilien utilise uniquement des <strong>cookies strictement nécessaires</strong> au
-              fonctionnement (session, préférences). Aucun cookie publicitaire ou analytique n&apos;est
+              fonctionnement (session, préférences). Aucun cookie publicitaire n&apos;est
               déposé. Le détail des cookies est disponible dans les{' '}
               <Link as={RouterLink} to="/mentions-legales" color="brand.solid">mentions légales</Link>.
             </Text>
           </Section>
 
-          <Section title="10. Modifications">
+          <Section title="10. Mesure d'audience">
+            <Text>
+              Unilien utilise <strong>Plausible Analytics</strong> pour mesurer l&apos;audience du
+              site et améliorer l&apos;expérience utilisateur. Cet outil de mesure d&apos;audience
+              est <strong>auto-hébergé</strong> sur nos serveurs (Union européenne) et fonctionne{' '}
+              <strong>sans cookie</strong> ni identifiant persistant.
+            </Text>
+            <Text>
+              Les données collectées sont anonymisées et ne permettent pas de vous identifier :
+            </Text>
+            <Box as="ul" pl={5} listStyleType="disc">
+              <Box as="li">Pages visitées et durée approximative</Box>
+              <Box as="li">Source de la visite (site référent)</Box>
+              <Box as="li">Pays (déduit de l&apos;adresse IP, qui n&apos;est jamais stockée)</Box>
+              <Box as="li">Type d&apos;appareil et navigateur (catégories génériques)</Box>
+            </Box>
+            <Text>
+              Conformément aux{' '}
+              <Link href="https://www.cnil.fr/fr/cookies-et-autres-traceurs/regles/cookies-solutions-pour-les-outils-de-mesure-daudience" color="brand.solid" target="_blank" rel="noopener noreferrer">
+                recommandations de la CNIL
+              </Link>
+              , les outils de mesure d&apos;audience sans cookie et limités à l&apos;analyse
+              statistique du site sont exemptés de consentement préalable. Vous pouvez néanmoins{' '}
+              <strong>désactiver cette mesure d&apos;audience à tout moment</strong> depuis
+              Paramètres &gt; Données &gt; Confidentialité.
+            </Text>
+          </Section>
+
+          <Section title="11. Modifications">
             <Text>
               La présente politique peut être modifiée pour refléter les évolutions du Service ou
               de la réglementation. Les utilisateurs seront informés des modifications substantielles
@@ -197,7 +225,7 @@ export default function PrivacyPage() {
             </Text>
           </Section>
 
-          <Section title="11. Contact">
+          <Section title="12. Contact">
             <Text>
               Pour toute question relative à cette politique ou à vos données personnelles :{' '}
               <Link href="mailto:contact@unilien.app" color="brand.solid">contact@unilien.app</Link>

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -325,7 +325,7 @@ describe('SettingsPage', () => {
       expect(screen.getByText(/Exporter toutes les données/)).toBeInTheDocument()
       expect(screen.getByText(/Exporter le planning/)).toBeInTheDocument()
       expect(screen.getByText('Confidentialité')).toBeInTheDocument()
-      expect(screen.getByText('Analyses anonymisées')).toBeInTheDocument()
+      expect(screen.getByText("Mesure d'audience")).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -25,7 +25,9 @@ import {
   Table,
   Spinner,
   Center,
+  Link as ChakraLink,
 } from '@chakra-ui/react'
+import { Link as RouterLink } from 'react-router-dom'
 import { DashboardLayout } from '@/components/dashboard'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccessibilityStore, useAuthStore } from '@/stores/authStore'
@@ -2170,13 +2172,20 @@ function PrivacySettingsCard() {
         </Card.Title>
       </Card.Header>
       <Card.Body p={4}>
-        <VStack gap={0} align="stretch">
+        <VStack gap={3} align="stretch">
           <ToggleRow
-            label="Analyses anonymisées"
-            description="Contribuez à améliorer Unilien en partageant des données d'usage anonymisées (Plausible, sans cookies ni données personnelles)."
+            label="Mesure d'audience"
+            description="Pages visitées, source de visite, pays — sans cookie ni identifiant personnel. Données auto-hébergées (UE), traitées par Plausible Analytics."
             checked={analyticsEnabled}
             onChange={(checked) => updateSettings({ analyticsEnabled: checked })}
           />
+          <Text fontSize="xs" color="text.muted">
+            En savoir plus dans la{' '}
+            <ChakraLink as={RouterLink} to="/politique-confidentialite#10" color="brand.solid" textDecoration="underline">
+              politique de confidentialité
+            </ChakraLink>
+            .
+          </Text>
         </VStack>
       </Card.Body>
     </Card.Root>


### PR DESCRIPTION
## Summary
Maintenant que Plausible Analytics est actif en prod, alignement des pages user-facing pour rester transparent et conforme RGPD (transparence + droit d'opposition).

### Changements

**PrivacyPage** (`/politique-confidentialite`)
- Section 9 (Cookies) : retire la mention trompeuse "ou analytique" (Plausible n'est pas un cookie)
- **Nouvelle section 10 — Mesure d'audience** : décrit Plausible (auto-hébergé UE, sans cookie ni identifiant), liste précisément les données collectées (pages, source, pays, device — anonymes, pas d'IP stockée), mentionne l'exemption CNIL et explique l'opt-out via Settings
- Sections suivantes renumérotées (10→11 Modifications, 11→12 Contact)

**LegalPage** (`/mentions-legales`)
- Section 6 (Cookies) : "Aucun cookie publicitaire ou de suivi" (retrait de "analytique"), ajout d'une phrase courte renvoyant vers PrivacyPage §10

**SettingsPage > Données > Confidentialité**
- Label toggle : "Analyses anonymisées" → **"Mesure d'audience"** (terme CNIL plus précis)
- Description toggle : plus concrète (liste exacte des données, mention auto-hébergement UE)
- Nouveau lien sous le toggle : *"En savoir plus dans la politique de confidentialité"* → ancre `#10`
- Test associé mis à jour

**CookieConsentBanner** : volontairement non touché — Plausible étant cookieless, le bandeau actuel reste correct.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (2 warnings préexistants)
- [x] `npm run test:run` : **2306 passed / 4 skipped** (135 fichiers)
- [x] Test manuel local : toggle ON/OFF persiste, lien "En savoir plus" → ancre PrivacyPage §10
- [x] Test post-deploy : sur prod, toggle OFF retire bien le script Plausible (DevTools > Network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)