### PR TITLE
feat(security): encrypt employer health data columns with pgsodium

### DIFF
--- a/docs/MEDICAL_DATA_COMPLIANCE.md
+++ b/docs/MEDICAL_DATA_COMPLIANCE.md
@@ -138,7 +138,7 @@ La certification HDS (articles L.1111-8 et R.1111-8-8 du Code de la sante publiq
 
 | Mesure | Priorite | Description |
 |--------|----------|-------------|
-| **Chiffrement colonnes** | Haute | Chiffrer `handicap_type`, `handicap_name`, `specific_needs` avec `pgsodium` — en attente migration Supabase self-hosted |
+| ~~**Chiffrement colonnes**~~ | ~~Haute~~ | ✅ pgsodium AEAD-det sur `handicap_type`, `handicap_name`, `specific_needs` (migration 058, PR à venir). Vue `employer_health_data_v` pour lecture, RPC `upsert_employer_health_data` pour écriture |
 | ~~**Duree de conservation**~~ | ~~Moyenne~~ | ✅ Table `data_retention_policy` + RPC `purge_expired_data()` (migration 050) |
 | **Registre des traitements** | Basse | Document formel pour la CNIL |
 
@@ -167,20 +167,28 @@ La certification HDS (articles L.1111-8 et R.1111-8-8 du Code de la sante publiq
 - **Double confirmation UI** : saisie manuelle "SUPPRIMER" / "SUPPRIMER MON COMPTE"
 - Accessible dans Parametres > Zone de danger
 
-### Phase 4 — Chiffrement colonnes (a venir)
+### Phase 4 — Chiffrement colonnes ✅ (migration 058, 04/05/2026)
 
-**Colonnes a chiffrer** (table `employer_health_data`) :
-- `handicap_type`
-- `handicap_name`
-- `specific_needs`
+**Colonnes chiffrees** (table `employer_health_data`) :
+- `handicap_type` — bytea (AEAD-det, AAD = profile_id)
+- `handicap_name` — bytea (AEAD-det, AAD = profile_id)
+- `specific_needs` — bytea (AEAD-det, AAD = profile_id)
 
-```sql
--- Activer pgsodium (disponible apres migration Supabase self-hosted)
-CREATE EXTENSION IF NOT EXISTS pgsodium;
-SELECT pgsodium.create_key(name := 'medical_data_key');
+**Mecanisme** : pgsodium AEAD-det (`crypto_aead_det_encrypt` / `crypto_aead_det_decrypt`) avec cle dediee `medical_data_key` dans le keyring pgsodium. L'AAD = `profile_id` rend les ciphertexts uniques par utilisateur (deux users avec "moteur" → ciphertexts differents).
+
+**Acces cote app** :
+- **Lecture** : via vue `employer_health_data_v` (security_invoker = true, RLS heritee)
+- **Ecriture** : via RPC `upsert_employer_health_data(p_handicap_type, p_handicap_name, p_specific_needs)` qui chiffre cote serveur
+- ⚠️ Ne JAMAIS faire `.from('employer_health_data').select/insert/upsert` directement — les colonnes sont en bytea
+
+**Activation prod** :
+```bash
+ssh unilien-test
+sudo docker compose -f /opt/supabase/docker/docker-compose.yml exec -T db \
+  psql -U postgres -d postgres < <(curl -s https://raw.githubusercontent.com/zephdev-92/Unilien/main/supabase/migrations/058_pgsodium_health_data.sql)
 ```
 
-> **Statut** : en attente de la migration vers Supabase self-hosted. Les donnees sont protegees par RLS owner-only en attendant.
+> **Filet de securite** : faire un `pg_dump` complet AVANT (cf. `infra/...` ou backup manuel dans `/opt/supabase/backups/`).
 
 ---
 
@@ -225,7 +233,7 @@ SELECT pgsodium.create_key(name := 'medical_data_key');
 - [x] Journal d'acces aux donnees sensibles (table `audit_logs` + `auditService.ts`) — migration 044
 - [x] Droit a l'effacement donnees (RPC `delete_own_data`) — migration 047
 - [x] Suppression de compte (RPC `delete_own_account` + double confirmation UI) — migration 047
-- [ ] Chiffrer les colonnes sensibles (pgsodium) — en attente migration self-hosted
+- [x] Chiffrer les colonnes sensibles (pgsodium) — migration 058, 04/05/2026
 - [x] Definir la duree de conservation et la politique de purge — migration 050 (`data_retention_policy` + `purge_expired_data()`)
 - [ ] Creer le registre des traitements (document CNIL)
 - [ ] Activer l'execution automatique de `purge_expired_data()` via pg_cron (Supabase Pro) ou Edge Function schedulee

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -66,26 +66,18 @@ export interface Database {
           emergency_contacts?: Record<string, unknown>[]
         }
       }
+      // ⚠️ Table chiffrée côté DB (pgsodium, migration 058)
+      // Lire via la vue `employer_health_data_v` (Views) pour déchiffrer.
+      // Écrire via la RPC `upsert_employer_health_data` (Functions) qui chiffre côté serveur.
+      // Ne JAMAIS faire .from('employer_health_data').select/insert/upsert : les colonnes sont en bytea.
       employer_health_data: {
         Row: {
           profile_id: string
-          handicap_type: string | null
-          handicap_name: string | null
-          specific_needs: string | null
+          handicap_type: Uint8Array | null
+          handicap_name: Uint8Array | null
+          specific_needs: Uint8Array | null
           created_at: string
           updated_at: string
-        }
-        Insert: {
-          profile_id: string
-          handicap_type?: string | null
-          handicap_name?: string | null
-          specific_needs?: string | null
-        }
-        Update: {
-          handicap_type?: string | null
-          handicap_name?: string | null
-          specific_needs?: string | null
-          updated_at?: string
         }
       }
       employees: {
@@ -447,8 +439,30 @@ export interface Database {
         }
       }
     }
-    Views: Record<string, never>
-    Functions: Record<string, never>
+    Views: {
+      // Vue déchiffrée d'employer_health_data (chiffrement pgsodium, migration 058)
+      employer_health_data_v: {
+        Row: {
+          profile_id: string
+          handicap_type: string | null
+          handicap_name: string | null
+          specific_needs: string | null
+          created_at: string
+          updated_at: string
+        }
+      }
+    }
+    Functions: {
+      // Upsert chiffré côté serveur (pgsodium, migration 058)
+      upsert_employer_health_data: {
+        Args: {
+          p_handicap_type?: string | null
+          p_handicap_name?: string | null
+          p_specific_needs?: string | null
+        }
+        Returns: undefined
+      }
+    }
     Enums: {
       user_role: 'employer' | 'employee' | 'caregiver'
       contract_type: 'CDI' | 'CDD'

--- a/src/services/profileService.test.ts
+++ b/src/services/profileService.test.ts
@@ -23,6 +23,7 @@ const mockUpsert = vi.fn()
 const mockInsert = vi.fn()
 const mockEq = vi.fn()
 const mockMaybeSingle = vi.fn()
+const mockRpc = vi.fn()
 
 vi.mock('@/lib/supabase/client', () => ({
   supabase: {
@@ -32,6 +33,7 @@ vi.mock('@/lib/supabase/client', () => ({
       upsert: mockUpsert,
       insert: mockInsert,
     })),
+    rpc: (...args: unknown[]) => mockRpc(...args),
     storage: {
       from: vi.fn(() => ({
         upload: mockUpload,
@@ -76,6 +78,7 @@ describe('profileService', () => {
     mockEq.mockResolvedValue({ error: null })
     mockSelect.mockReturnValue({ eq: vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle }) })
     mockUpsert.mockResolvedValue({ error: null })
+    mockRpc.mockResolvedValue({ data: null, error: null })
   })
 
   describe('updateProfile', () => {

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -250,8 +250,9 @@ export async function getEmployer(profileId: string): Promise<Employer | null> {
   if (!data) return null
 
   // Données de santé (RLS strict : propriétaire uniquement)
+  // Lecture via vue déchiffrée (pgsodium, migration 058)
   const { data: healthData } = await supabase
-    .from('employer_health_data')
+    .from('employer_health_data_v')
     .select('handicap_type, handicap_name, specific_needs')
     .eq('profile_id', profileId)
     .maybeSingle()
@@ -311,20 +312,19 @@ export async function upsertEmployer(profileId: string, data: Partial<Employer>)
     throw new Error(error.message)
   }
 
-  // Données de santé (table séparée, RLS strict)
+  // Données de santé (table séparée, RLS strict, chiffrées pgsodium)
+  // Écriture via RPC qui chiffre côté serveur (migration 058)
   const hasHealthData = data.handicapType || data.handicapName || data.specificNeeds
   if (hasHealthData !== undefined) {
-    const healthPayload = {
-      profile_id: profileId,
-      handicap_type: data.handicapType && VALID_HANDICAP_TYPES.includes(data.handicapType) ? data.handicapType : null,
-      handicap_name: data.handicapName ? sanitizeText(data.handicapName) : null,
-      specific_needs: data.specificNeeds ? sanitizeText(data.specificNeeds) : null,
-      updated_at: new Date().toISOString(),
-    }
+    const healthType = data.handicapType && VALID_HANDICAP_TYPES.includes(data.handicapType) ? data.handicapType : null
+    const healthName = data.handicapName ? sanitizeText(data.handicapName) : null
+    const healthNeeds = data.specificNeeds ? sanitizeText(data.specificNeeds) : null
 
-    const { error: healthError } = await supabase
-      .from('employer_health_data')
-      .upsert(healthPayload, { onConflict: 'profile_id' })
+    const { error: healthError } = await supabase.rpc('upsert_employer_health_data', {
+      p_handicap_type: healthType,
+      p_handicap_name: healthName,
+      p_specific_needs: healthNeeds,
+    })
 
     if (healthError) {
       logger.error('Erreur mise à jour données santé employeur:', healthError)

--- a/supabase/migrations/058_pgsodium_health_data.sql
+++ b/supabase/migrations/058_pgsodium_health_data.sql
@@ -1,0 +1,182 @@
+-- Migration 058 : Chiffrement applicatif des colonnes santé via pgsodium
+-- Conformité RGPD art. 9 — défense en profondeur au-delà de la RLS owner-only
+--
+-- Approche :
+-- 1. Active pgsodium (extension dispo dans l'image Supabase Postgres)
+-- 2. Crée une clé dédiée 'medical_data_key' dans le keyring pgsodium
+-- 3. Convertit les colonnes text → bytea avec backfill chiffré (mode AEAD déterministe + AAD = profile_id pour éviter les fuites par pattern entre utilisateurs)
+-- 4. Crée une vue déchiffrée `employer_health_data_v` (RLS héritée via security_invoker)
+-- 5. Crée une RPC `upsert_employer_health_data` qui chiffre côté serveur avant écriture
+--
+-- Le code app lit via la vue et écrit via la RPC. La table de base ne contient que des bytea.
+
+-- ── 1. Extension ─────────────────────────────────────────────────────────────
+CREATE EXTENSION IF NOT EXISTS pgsodium;
+
+-- ── 2. Clé (idempotent) ──────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pgsodium.key WHERE name = 'medical_data_key') THEN
+    PERFORM pgsodium.create_key(name := 'medical_data_key');
+  END IF;
+END $$;
+
+-- ── 3. Migration des colonnes : text → bytea avec backfill chiffré ──────────
+-- Ajout des colonnes encrypted en parallèle pour éviter de perdre les données en cas d'erreur
+ALTER TABLE employer_health_data
+  ADD COLUMN IF NOT EXISTS handicap_type_enc bytea,
+  ADD COLUMN IF NOT EXISTS handicap_name_enc bytea,
+  ADD COLUMN IF NOT EXISTS specific_needs_enc bytea;
+
+-- Backfill : chiffrer les valeurs existantes (AAD = profile_id pour unicité par user)
+UPDATE employer_health_data
+SET
+  handicap_type_enc = CASE
+    WHEN handicap_type IS NOT NULL THEN pgsodium.crypto_aead_det_encrypt(
+      convert_to(handicap_type, 'utf8'),
+      convert_to(profile_id::text, 'utf8'),
+      (SELECT id FROM pgsodium.key WHERE name = 'medical_data_key')
+    )
+  END,
+  handicap_name_enc = CASE
+    WHEN handicap_name IS NOT NULL THEN pgsodium.crypto_aead_det_encrypt(
+      convert_to(handicap_name, 'utf8'),
+      convert_to(profile_id::text, 'utf8'),
+      (SELECT id FROM pgsodium.key WHERE name = 'medical_data_key')
+    )
+  END,
+  specific_needs_enc = CASE
+    WHEN specific_needs IS NOT NULL THEN pgsodium.crypto_aead_det_encrypt(
+      convert_to(specific_needs, 'utf8'),
+      convert_to(profile_id::text, 'utf8'),
+      (SELECT id FROM pgsodium.key WHERE name = 'medical_data_key')
+    )
+  END;
+
+-- Drop des colonnes en clair après backfill
+ALTER TABLE employer_health_data
+  DROP COLUMN handicap_type,
+  DROP COLUMN handicap_name,
+  DROP COLUMN specific_needs;
+
+-- Renommage : on garde les noms d'origine côté schéma (l'app verra des bytea)
+ALTER TABLE employer_health_data RENAME COLUMN handicap_type_enc TO handicap_type;
+ALTER TABLE employer_health_data RENAME COLUMN handicap_name_enc TO handicap_name;
+ALTER TABLE employer_health_data RENAME COLUMN specific_needs_enc TO specific_needs;
+
+-- ── 4. Vue déchiffrée (lecture côté app) ────────────────────────────────────
+-- security_invoker=true → la RLS de la table de base s'applique aussi à la vue
+CREATE OR REPLACE VIEW employer_health_data_v
+WITH (security_invoker = true)
+AS
+SELECT
+  profile_id,
+  CASE WHEN handicap_type IS NOT NULL THEN
+    convert_from(
+      pgsodium.crypto_aead_det_decrypt(
+        handicap_type,
+        convert_to(profile_id::text, 'utf8'),
+        (SELECT id FROM pgsodium.key WHERE name = 'medical_data_key')
+      ),
+      'utf8'
+    )
+  END AS handicap_type,
+  CASE WHEN handicap_name IS NOT NULL THEN
+    convert_from(
+      pgsodium.crypto_aead_det_decrypt(
+        handicap_name,
+        convert_to(profile_id::text, 'utf8'),
+        (SELECT id FROM pgsodium.key WHERE name = 'medical_data_key')
+      ),
+      'utf8'
+    )
+  END AS handicap_name,
+  CASE WHEN specific_needs IS NOT NULL THEN
+    convert_from(
+      pgsodium.crypto_aead_det_decrypt(
+        specific_needs,
+        convert_to(profile_id::text, 'utf8'),
+        (SELECT id FROM pgsodium.key WHERE name = 'medical_data_key')
+      ),
+      'utf8'
+    )
+  END AS specific_needs,
+  created_at,
+  updated_at
+FROM employer_health_data;
+
+GRANT SELECT ON employer_health_data_v TO authenticated;
+
+-- ── 5. RPC d'upsert (écriture côté app) ─────────────────────────────────────
+-- L'app passe les valeurs en clair, la fonction chiffre côté serveur et upsert.
+-- SECURITY INVOKER → la RLS owner-only s'applique aussi à l'upsert.
+CREATE OR REPLACE FUNCTION upsert_employer_health_data(
+  p_handicap_type text DEFAULT NULL,
+  p_handicap_name text DEFAULT NULL,
+  p_specific_needs text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pgsodium
+AS $$
+DECLARE
+  v_profile_id uuid := auth.uid();
+  v_key_id uuid;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Non authentifié';
+  END IF;
+
+  SELECT id INTO v_key_id FROM pgsodium.key WHERE name = 'medical_data_key';
+  IF v_key_id IS NULL THEN
+    RAISE EXCEPTION 'Clé medical_data_key introuvable';
+  END IF;
+
+  INSERT INTO employer_health_data (profile_id, handicap_type, handicap_name, specific_needs, updated_at)
+  VALUES (
+    v_profile_id,
+    CASE WHEN p_handicap_type IS NOT NULL THEN
+      pgsodium.crypto_aead_det_encrypt(
+        convert_to(p_handicap_type, 'utf8'),
+        convert_to(v_profile_id::text, 'utf8'),
+        v_key_id
+      )
+    END,
+    CASE WHEN p_handicap_name IS NOT NULL THEN
+      pgsodium.crypto_aead_det_encrypt(
+        convert_to(p_handicap_name, 'utf8'),
+        convert_to(v_profile_id::text, 'utf8'),
+        v_key_id
+      )
+    END,
+    CASE WHEN p_specific_needs IS NOT NULL THEN
+      pgsodium.crypto_aead_det_encrypt(
+        convert_to(p_specific_needs, 'utf8'),
+        convert_to(v_profile_id::text, 'utf8'),
+        v_key_id
+      )
+    END,
+    now()
+  )
+  ON CONFLICT (profile_id) DO UPDATE SET
+    handicap_type  = EXCLUDED.handicap_type,
+    handicap_name  = EXCLUDED.handicap_name,
+    specific_needs = EXCLUDED.specific_needs,
+    updated_at     = now();
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION upsert_employer_health_data(text, text, text) TO authenticated;
+
+-- ── 6. Commentaires ─────────────────────────────────────────────────────────
+COMMENT ON COLUMN employer_health_data.handicap_type
+  IS 'CHIFFRÉ pgsodium AEAD-det (clé medical_data_key, AAD = profile_id). Lire via la vue employer_health_data_v.';
+COMMENT ON COLUMN employer_health_data.handicap_name
+  IS 'CHIFFRÉ pgsodium AEAD-det (clé medical_data_key, AAD = profile_id). Lire via la vue employer_health_data_v.';
+COMMENT ON COLUMN employer_health_data.specific_needs
+  IS 'CHIFFRÉ pgsodium AEAD-det (clé medical_data_key, AAD = profile_id). Lire via la vue employer_health_data_v.';
+COMMENT ON VIEW employer_health_data_v
+  IS 'Vue déchiffrée d''employer_health_data. RLS héritée via security_invoker. Utiliser pour la lecture côté app.';
+COMMENT ON FUNCTION upsert_employer_health_data(text, text, text)
+  IS 'Upsert santé chiffré côté serveur. Utiliser pour l''écriture côté app (au lieu d''un .from(employer_health_data).upsert).';


### PR DESCRIPTION
## Summary
Conformité RGPD art. 9 — défense en profondeur sur les colonnes santé en plus du RLS owner-only existant.

⚠️ **Cette PR a une procédure de déploiement spéciale** — voir section *Déploiement* en bas. La migration DB doit être appliquée **AVANT** le redeploy front, sinon le front appelle une vue qui n'existe pas.

### Changements

**DB (migration 058)**
- `CREATE EXTENSION pgsodium` + création de la clé dédiée `medical_data_key` (idempotent)
- Conversion `handicap_type` / `handicap_name` / `specific_needs` : `text` → `bytea` avec backfill chiffré (AEAD-det + AAD = `profile_id` pour éviter les fuites par pattern entre utilisateurs)
- Vue `employer_health_data_v` (`security_invoker = true`) pour la lecture déchiffrée, RLS héritée de la table de base
- RPC `upsert_employer_health_data(p_handicap_type, p_handicap_name, p_specific_needs)` qui chiffre côté serveur avant `INSERT/UPDATE` (SECURITY INVOKER → RLS appliquée)
- Comments `COMMENT ON COLUMN` qui avertissent "chiffré, lire via la vue"

**App**
- `profileService.getEmployer` : lit `employer_health_data_v` au lieu de la table de base
- `profileService.upsertEmployer` : appelle `rpc('upsert_employer_health_data')` au lieu d'un upsert direct
- `lib/supabase/types.ts` : ajoute `Views` + `Functions`, marque les colonnes de base en `Uint8Array | null` avec commentaire "ne pas accéder directement"
- `profileService.test` : mock `supabase.rpc`

**Doc**
- `MEDICAL_DATA_COMPLIANCE.md` : Phase 4 marquée ✅, mécanisme documenté + commande d'activation prod

## Threat model
- **Avant** : RLS owner-only protégeait contre les accès depuis l'app, mais un attaquant avec accès Postgres direct (credentials, dump, fuite via bug) pouvait lire les données en clair
- **Après** : même avec un `pg_dump` complet, les colonnes sortent en bytea ; il faut la clé pgsodium pour les déchiffrer (stockée dans le keyring Postgres, isolée du dump applicatif)

## Volumétrie en prod
- 3 lignes dans `employer_health_data`, 2 avec données → migration rapide et faible risque

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (2 warnings préexistants)
- [x] `npm run test:run` : **2306 passed / 4 skipped** (135 fichiers)
- [ ] **Backup obligatoire avant migration prod** : `pg_dump -U postgres -d postgres > /opt/supabase/backups/pre-pgsodium-$(date +%Y%m%d-%H%M%S).sql`
- [ ] Appliquer migration 058 en prod
- [ ] Vérifier `SELECT * FROM employer_health_data_v` → 2 lignes lisibles
- [ ] Vérifier en UI Paramètres > Profil employeur > Ma situation : valeurs santé existantes affichées + modification fonctionne

## Déploiement (ordre critique)

1. **Backup DB prod** (commande dans la doc)
2. **Appliquer la migration 058** (commande dans `MEDICAL_DATA_COMPLIANCE.md` ou via Studio Supabase)
3. **Vérifier** : `SELECT count(*) FROM employer_health_data_v` retourne 3 lignes lisibles
4. **Merger la PR** → redeploy auto du front (qui passe alors aux nouvelles vue/RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)