### PR TITLE
feat(auth): block dashboard access until onboarding profile is complete

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -109,6 +109,7 @@ describe('App', () => {
         isLoading: false,
         isInitialized: true,
         userRole: 'employer',
+        isProfileComplete: true,
       })
       renderApp('/connexion')
       await waitFor(() => {
@@ -139,6 +140,7 @@ describe('App', () => {
         isLoading: false,
         isInitialized: true,
         userRole: 'employer',
+        isProfileComplete: true,
       })
       renderApp('/tableau-de-bord')
       await waitFor(() => {
@@ -152,6 +154,7 @@ describe('App', () => {
         isLoading: false,
         isInitialized: true,
         userRole: 'employee',
+        isProfileComplete: true,
       })
       renderApp('/equipe')
       await waitFor(() => {
@@ -167,6 +170,7 @@ describe('App', () => {
         isLoading: false,
         isInitialized: true,
         userRole: 'employee',
+        isProfileComplete: true,
       })
       renderApp('/suivi-des-heures')
       await waitFor(() => {
@@ -180,10 +184,25 @@ describe('App', () => {
         isLoading: false,
         isInitialized: true,
         userRole: 'employer',
+        isProfileComplete: true,
       })
       renderApp('/equipe')
       await waitFor(() => {
         expect(screen.getByTestId('team-page')).toBeInTheDocument()
+      })
+    })
+
+    it('redirige vers /onboarding/role si profil incomplet', async () => {
+      mockUseAuth.mockReturnValue({
+        isAuthenticated: true,
+        isLoading: false,
+        isInitialized: true,
+        userRole: 'employer',
+        isProfileComplete: false,
+      })
+      renderApp('/tableau-de-bord')
+      await waitFor(() => {
+        expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument()
       })
     })
   })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,14 +64,14 @@ function LoadingPage() {
 
 // Composant de route publique (redirige si connecté)
 function PublicRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isInitialized } = useAuth()
+  const { isAuthenticated, isInitialized, isProfileComplete } = useAuth()
 
   if (!isInitialized) {
     return <LoadingPage />
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/tableau-de-bord" replace />
+    return <Navigate to={isProfileComplete ? '/tableau-de-bord' : '/onboarding/role'} replace />
   }
 
   return <>{children}</>
@@ -79,7 +79,7 @@ function PublicRoute({ children }: { children: React.ReactNode }) {
 
 // Composant de route protégée (redirige si non connecté)
 function ProtectedRoute({ children, allowedRoles }: { children: React.ReactNode; allowedRoles?: UserRole[] }) {
-  const { isAuthenticated, isLoading, isInitialized, userRole } = useAuth()
+  const { isAuthenticated, isLoading, isInitialized, userRole, isProfileComplete } = useAuth()
 
   if (!isInitialized || isLoading) {
     return <LoadingPage />
@@ -87,6 +87,10 @@ function ProtectedRoute({ children, allowedRoles }: { children: React.ReactNode;
 
   if (!isAuthenticated) {
     return <Navigate to="/connexion" replace />
+  }
+
+  if (!isProfileComplete) {
+    return <Navigate to="/onboarding/role" replace />
   }
 
   if (allowedRoles && userRole && !allowedRoles.includes(userRole)) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -137,6 +137,7 @@ export function useAuth() {
     reset,
     isAuthenticated,
     getUserRole,
+    isProfileComplete,
     setMfaPending,
   } = useAuthStore()
 
@@ -360,6 +361,7 @@ export function useAuth() {
     error,
     isAuthenticated: isAuthenticated(),
     userRole: getUserRole(),
+    isProfileComplete: isProfileComplete(),
 
     // Actions
     signUp,

--- a/src/pages/OnboardingRolePage.tsx
+++ b/src/pages/OnboardingRolePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
 import {
   Box,
   Flex,
@@ -15,6 +16,7 @@ import { AccessibleButton, AccessibleInput } from '@/components/ui'
 import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 import { sanitizeText } from '@/lib/sanitize'
+import { useAuth } from '@/hooks/useAuth'
 import type { UserRole } from '@/types'
 
 const roleOptions: { value: UserRole; label: string; description: string; icon: React.ReactNode }[] = [
@@ -55,6 +57,7 @@ const roleOptions: { value: UserRole; label: string; description: string; icon: 
 ]
 
 export default function OnboardingRolePage() {
+  const { isInitialized, isAuthenticated, isProfileComplete } = useAuth()
   const [selectedRole, setSelectedRole] = useState<UserRole | null>(null)
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
@@ -111,6 +114,14 @@ export default function OnboardingRolePage() {
       setError('Une erreur est survenue. Veuillez réessayer.')
       setIsLoading(false)
     }
+  }
+
+  // Garde-fous : pas d'accès direct sans session, pas de re-onboarding si déjà complet
+  if (isInitialized && !isAuthenticated) {
+    return <Navigate to="/connexion" replace />
+  }
+  if (isInitialized && isAuthenticated && isProfileComplete) {
+    return <Navigate to="/tableau-de-bord" replace />
   }
 
   if (!userId) {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -26,6 +26,7 @@ interface AuthState {
   // Computed
   isAuthenticated: () => boolean
   getUserRole: () => UserRole | null
+  isProfileComplete: () => boolean
 }
 
 const initialState = {
@@ -67,6 +68,17 @@ export const useAuthStore = create<AuthState>()(
       getUserRole: () => {
         const state = get()
         return state.profile?.role ?? null
+      },
+
+      // Onboarding considéré non complet si :
+      // - pas de profil
+      // - first_name vide
+      // - first_name = 'Utilisateur' (valeur par défaut posée par le trigger DB
+      //   handle_new_user pour les inscriptions OAuth, voir migration 024)
+      isProfileComplete: () => {
+        const state = get()
+        const firstName = state.profile?.firstName
+        return Boolean(firstName) && firstName !== 'Utilisateur'
       },
     }),
     {


### PR DESCRIPTION
## Summary

Empêche l'accès au dashboard tant que l'onboarding profil n'est pas terminé.

Symptôme actuel (signup OAuth Google) : si l'utilisateur quitte la page d'onboarding sans la finir (le UPSERT plante avec un `401 / role "" does not exist`), son `auth.users` existe + une ligne `profiles` minimale créée par le trigger `handle_new_user` (avec `first_name='Utilisateur'`). Au login suivant, `useAuth` retrouve un profile et marque `isAuthenticated=true` → l'utilisateur arrive sur `/tableau-de-bord` qui spinne dans le vide (pas de prénom, dashboard cassé).

Cette PR ajoute une garde "profile complet" dans le routing pour rediriger systématiquement vers l'onboarding tant qu'il n'est pas fini. Elle ne corrige PAS la cause racine du UPSERT 401 (suite dans une PR dédiée RPC `complete_onboarding`), mais elle bouchonne le trou tout de suite.

### Changements

- `authStore.ts` : nouveau computed `isProfileComplete()` — `false` si pas de profile, ou si `firstName` est vide / égal à `'Utilisateur'` (valeur posée par défaut par le trigger DB `handle_new_user` migration 024)
- `useAuth.ts` : expose `isProfileComplete` dans le retour du hook
- `App.tsx` :
  - `ProtectedRoute` redirige vers `/onboarding/role` si auth mais profile incomplet
  - `PublicRoute` redirige vers `/onboarding/role` plutôt que dashboard quand l'utilisateur authentifié n'a pas fini l'onboarding
- `OnboardingRolePage.tsx` : redirige vers `/connexion` si pas de session, vers `/tableau-de-bord` si profile déjà complet (évite l'accès direct à l'onboarding une fois fini)
- `App.test.tsx` : tests `isAuthenticated:true` mis à jour avec `isProfileComplete:true`, nouveau test pour la garde

## Test plan

- [x] `npm run lint` (0 erreurs, 2 warnings préexistants)
- [x] `npm run test:run` — 2307 passed / 4 skipped (135 fichiers)
- [ ] Manuel : signup Google qui foire l'onboarding → tenter d'arriver sur `/tableau-de-bord` → doit rebondir sur `/onboarding/role`
- [ ] Manuel : signup email/mdp classique avec `first_name` rempli → arrive bien sur le dashboard sans bounce

## Suite

Prochaines PR (déjà discutées) :
1. RPC `complete_onboarding` SECURITY DEFINER pour fixer le 401 du UPSERT profile
2. Propager le rôle sélectionné dans le SignupForm vers l'OAuth (sessionStorage avant redirect Google) — actuellement le rôle coché est ignoré

🤖 Generated with [Claude Code](https://claude.com/claude-code)