### PR TITLE
feat(auth): replace onboarding profile upsert with SECURITY DEFINER RPC

### DIFF
--- a/src/pages/OnboardingRolePage.tsx
+++ b/src/pages/OnboardingRolePage.tsx
@@ -64,13 +64,11 @@ export default function OnboardingRolePage() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [userId, setUserId] = useState<string | null>(null)
-  const [userEmail, setUserEmail] = useState<string | null>(null)
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) return
       setUserId(user.id)
-      setUserEmail(user.email ?? null)
 
       // Pré-remplir depuis les métadonnées OAuth
       const fullName: string = user.user_metadata?.full_name || user.user_metadata?.name || ''
@@ -96,16 +94,13 @@ export default function OnboardingRolePage() {
     setIsLoading(true)
 
     try {
-      const { error: upsertError } = await supabase.from('profiles').upsert({
-        id: userId,
-        role: selectedRole,
-        first_name: cleanFirst,
-        last_name: cleanLast,
-        email: userEmail,
-        updated_at: new Date().toISOString(),
+      const { error: rpcError } = await supabase.rpc('complete_onboarding', {
+        p_role: selectedRole,
+        p_first_name: cleanFirst,
+        p_last_name: cleanLast,
       })
 
-      if (upsertError) throw upsertError
+      if (rpcError) throw rpcError
 
       // Recharger pour que useAuth récupère le profil à jour
       window.location.href = '/tableau-de-bord'

--- a/supabase/migrations/059_complete_onboarding_rpc.sql
+++ b/supabase/migrations/059_complete_onboarding_rpc.sql
@@ -1,0 +1,93 @@
+-- Migration 059 : RPC complete_onboarding
+--
+-- Remplace l'UPSERT direct sur la table profiles depuis OnboardingRolePage
+-- (qui plantait avec un 401 + "role '' does not exist" sur certains signups
+-- OAuth, vraisemblablement à cause d'un timing/JWT mal résolu côté PostgREST).
+--
+-- La RPC est SECURITY DEFINER → tourne avec les privilèges de l'owner et
+-- vérifie auth.uid() côté serveur. Atomique : update profile + crée la ligne
+-- role-specific (employers/employees) + nettoie l'ancienne ligne orpheline
+-- si le rôle change (cas typique : OAuth crée un employer par défaut, l'user
+-- choisit ensuite employee/caregiver dans l'onboarding).
+--
+-- Caregivers : pas de création de ligne caregivers ici — un caregiver est
+-- censé entrer dans l'app via une invitation employeur (Edge Function
+-- invite-caregiver + addCaregiverToEmployer). L'auto-inscription caregiver
+-- reste dans son état actuel (profile.role = 'caregiver' sans ligne liée),
+-- à reprendre dans une PR dédiée.
+
+CREATE OR REPLACE FUNCTION complete_onboarding(
+  p_role text,
+  p_first_name text,
+  p_last_name text DEFAULT ''
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_old_role text;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Non authentifié' USING ERRCODE = '28000';
+  END IF;
+
+  IF p_role NOT IN ('employer', 'employee', 'caregiver') THEN
+    RAISE EXCEPTION 'Rôle invalide: %', p_role USING ERRCODE = '22023';
+  END IF;
+
+  IF p_first_name IS NULL OR length(trim(p_first_name)) = 0 THEN
+    RAISE EXCEPTION 'Le prénom est obligatoire' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT role INTO v_old_role FROM profiles WHERE id = v_user_id;
+
+  UPDATE profiles
+  SET
+    role       = p_role,
+    first_name = p_first_name,
+    last_name  = COALESCE(p_last_name, ''),
+    updated_at = now()
+  WHERE id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Profil introuvable pour l''utilisateur %', v_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Création de la ligne role-specific (idempotent)
+  IF p_role = 'employer' THEN
+    INSERT INTO employers (profile_id, address, pch_beneficiary, emergency_contacts)
+    VALUES (v_user_id, '{}'::jsonb, false, ARRAY[]::jsonb[])
+    ON CONFLICT (profile_id) DO NOTHING;
+  ELSIF p_role = 'employee' THEN
+    INSERT INTO employees (profile_id)
+    VALUES (v_user_id)
+    ON CONFLICT (profile_id) DO NOTHING;
+  END IF;
+
+  -- Nettoyage de la ligne orpheline si le rôle a changé.
+  -- Tolère un échec FK (au cas où des contrats existeraient — improbable au
+  -- stade onboarding mais on ne veut pas bloquer l'utilisateur pour ça).
+  IF v_old_role IS NOT NULL AND v_old_role <> p_role THEN
+    BEGIN
+      IF v_old_role = 'employer' THEN
+        DELETE FROM employers WHERE profile_id = v_user_id;
+      ELSIF v_old_role = 'employee' THEN
+        DELETE FROM employees WHERE profile_id = v_user_id;
+      END IF;
+    EXCEPTION
+      WHEN foreign_key_violation THEN
+        -- Ligne référencée ailleurs : on laisse en l'état, à corriger manuellement.
+        NULL;
+    END;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION complete_onboarding(text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION complete_onboarding(text, text, text) TO authenticated;
+
+COMMENT ON FUNCTION complete_onboarding(text, text, text)
+  IS 'Onboarding utilisateur (SECURITY DEFINER) : update profile + crée la ligne employers/employees selon le rôle, nettoie l''orpheline si le rôle change. Caregiver = update profile uniquement (entrée via invitation employeur).';


### PR DESCRIPTION
## Summary

Suite directe de #346. Cette PR remplace le UPSERT direct sur `profiles` depuis `OnboardingRolePage` (qui plantait avec un `401 + role "" does not exist` lors des signups OAuth Google) par une RPC SECURITY DEFINER atomique.

### Cause racine

L'UPSERT côté client dépend de la RLS profile + d'une bonne résolution du JWT par PostgREST. Sur certains contextes OAuth callback, le timing fait que la requête arrive avec un claim mal résolu → PostgREST tente un `SET LOCAL ROLE TO ''` → erreur 22023 / 401. La RPC SECURITY DEFINER tourne avec les privilèges de l'owner (postgres) et n'a besoin que de `auth.uid()`, ce qui est plus robuste.

### Changements

**Migration 059** : `complete_onboarding(p_role, p_first_name, p_last_name)`
- Vérifie `auth.uid()` côté serveur
- Update `profiles` (role + first_name + last_name)
- INSERT idempotent sur `employers` ou `employees` selon le rôle
- Si le rôle change (typique : OAuth crée un employer par défaut, l'user passe sur employee dans l'onboarding) → DELETE de la ligne orpheline
- Caregiver : update profile uniquement, pas de ligne `caregivers` (entrée officielle = invitation employeur via Edge Function `invite-caregiver`). À revoir dans une PR dédiée.

**OnboardingRolePage**
- Appelle `supabase.rpc('complete_onboarding', ...)` au lieu de `from('profiles').upsert(...)`
- Retire la state `userEmail` (plus utilisé, l'email reste celui posé par le trigger DB)

## Déploiement

⚠️ Après merge, **appliquer la migration 059 en prod** sur le VPS via `psql -U supabase_admin` (la RPC doit exister côté DB avant que le front la consomme).

## Test plan

- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` — 2307 passed / 4 skipped (135 fichiers)
- [ ] Manuel après application de la migration : signup Google → choisir un rôle → la RPC s'exécute, le dashboard charge avec le bon rôle
- [ ] Manuel : changer de rôle dans l'onboarding (employer → employee) → vérifier que la ligne `employers` orpheline est bien supprimée

## Suite

PR suivantes :
3. Propager le rôle sélectionné dans `SignupForm` vers l'OAuth (sessionStorage avant redirect Google) — actuellement le rôle coché est ignoré
4. Gestion d'erreur fine `OnboardingRolePage` (retry sur 401, message clair, bouton "Se déconnecter")
5. Décision produit caregiver auto-inscrit (option A/B/C discutée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)