### PR TITLE
fix(auth): force auth.users.role='authenticated' via trigger to unblock OAuth Google

### DIFF
--- a/supabase/migrations/060_ensure_auth_user_role.sql
+++ b/supabase/migrations/060_ensure_auth_user_role.sql
@@ -1,0 +1,38 @@
+-- Migration 060 : Forcer auth.users.role = 'authenticated' par défaut
+--
+-- Bug observé en prod : GoTrue v2.186.0 (self-host) ne set pas
+-- auth.users.role pour les signups OAuth Google → role = '' → le claim
+-- JWT `role` est vide → PostgREST échoue avec
+-- "role '' does not exist" (code 22023) sur toutes les requêtes du user.
+--
+-- Les autres providers (email/mdp, Azure, magic link) posent bien
+-- role='authenticated'. C'est spécifique au flux Google sur ce setup.
+--
+-- Le trigger BEFORE INSERT/UPDATE force le défaut côté DB. Plus robuste
+-- qu'un ALTER COLUMN ... SET DEFAULT (GoTrue peut redéfinir le schéma
+-- auth.* lors de ses migrations internes — un trigger sur public.*
+-- survit, contrairement à un default sur auth.users).
+--
+-- Idempotent : peut être rejouée. Doit être appliquée via
+-- `psql -U supabase_admin` (création de trigger sur le schéma auth).
+
+CREATE OR REPLACE FUNCTION public.ensure_auth_user_role()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.role IS NULL OR NEW.role = '' THEN
+    NEW.role := 'authenticated';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.ensure_auth_user_role()
+  IS 'Trigger BEFORE INSERT/UPDATE sur auth.users : force role=''authenticated'' si vide. Contournement bug GoTrue v2.186 sur OAuth Google qui laisse le role vide.';
+
+DROP TRIGGER IF EXISTS ensure_auth_user_role_before_write ON auth.users;
+CREATE TRIGGER ensure_auth_user_role_before_write
+BEFORE INSERT OR UPDATE OF role ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.ensure_auth_user_role();


### PR DESCRIPTION
## Summary

**Cause racine** du bug onboarding signalée hier (PR #346 + #347) : GoTrue v2.186.0 sur le self-host ne pose pas `auth.users.role='authenticated'` pour les signups OAuth Google. La colonne reste à `''` (chaîne vide), valeur qui se propage ensuite dans le claim `role` du JWT. PostgREST tente alors `SET LOCAL ROLE TO ''` → erreur `22023 / role "" does not exist` sur **toutes** les requêtes du user (lecture profile, fallback, RPC, etc.).

Les autres providers (email/mdp, Azure, magic link) posent bien `'authenticated'`. Spécifique à Google sur cette config.

### Vérification en prod

```sql
SELECT role, count(*) FROM auth.users GROUP BY role;
   role     | count
------------+-------
 (vide)     |   2     -- les 2 derniers signups Google
 authenticated | 12  -- tout le reste
```

### Pourquoi un trigger plutôt qu'un DEFAULT

`ALTER TABLE auth.users ALTER COLUMN role SET DEFAULT 'authenticated'` aurait pu marcher, mais GoTrue rejoue ses migrations sur le schéma `auth.*` à chaque démarrage / mise à jour, et un `DROP DEFAULT` interne pourrait l'effacer silencieusement. Un trigger BEFORE INSERT/UPDATE sur une fonction `public.*` survit aux migrations GoTrue.

### Changements

- **Migration 060** : `public.ensure_auth_user_role()` + trigger `ensure_auth_user_role_before_write` sur `auth.users`. Force `role='authenticated'` si `NULL` ou `''`. Idempotent.
- Application en prod : doit être exécutée via `psql -U supabase_admin` (CREATE TRIGGER sur `auth.*` nécessite des privilèges étendus).

### Hot fix déjà appliqué

Les 2 users impactés ont été corrigés manuellement :
```sql
UPDATE auth.users SET role = 'authenticated' WHERE role IS NULL OR role = '';
-- UPDATE 2
```

Ils doivent se déconnecter/reconnecter pour générer un nouveau JWT avec le bon claim (le token actuel a 1h de TTL — `GOTRUE_JWT_EXP=3600`).

## Test plan

- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` — 2307 passed / 4 skipped
- [x] Trigger testé en prod via INSERT en transaction rollback : `role=''` devient `'authenticated'` ✅
- [x] Migration 060 déjà appliquée en prod (à formaliser après merge — la migration tracking est uniquement basée sur le repo)
- [ ] Manuel : nouveau signup OAuth Google → `auth.users.role` doit être `'authenticated'` directement, plus de 22023

## Suite

Bug racine résolu. Reste du plan d'origine :
3. Propager le rôle sélectionné dans `SignupForm` → OAuth (sessionStorage avant redirect Google) — actuellement le rôle coché est ignoré
4. Gestion d'erreur fine `OnboardingRolePage` (retry / message clair)
5. Décision produit caregiver auto-inscrit

🤖 Generated with [Claude Code](https://claude.com/claude-code)