### PR TITLE
fix(privacy): use maybeSingle to avoid 406 when privacy_settings row is missing

### DIFF
--- a/src/services/privacySettingsService.test.ts
+++ b/src/services/privacySettingsService.test.ts
@@ -24,6 +24,7 @@ function mockSupabaseQuery(result: { data?: unknown; error?: unknown }) {
   chain.upsert = vi.fn().mockReturnValue(chain)
   chain.eq = vi.fn().mockReturnValue(chain)
   chain.single = vi.fn().mockResolvedValue(result)
+  chain.maybeSingle = vi.fn().mockResolvedValue(result)
   chain.then = vi.fn().mockImplementation((resolve: (v: unknown) => unknown) =>
     Promise.resolve(resolve(result))
   )
@@ -64,14 +65,11 @@ describe('getPrivacySettings', () => {
 
     expect(mockFrom).toHaveBeenCalledWith('privacy_settings')
     expect(chain.eq).toHaveBeenCalledWith('profile_id', PROFILE_ID)
-    expect(chain.single).toHaveBeenCalled()
+    expect(chain.maybeSingle).toHaveBeenCalled()
   })
 
-  it('retourne les defaults si aucune ligne (PGRST116)', async () => {
-    mockSupabaseQuery({
-      data: null,
-      error: { code: 'PGRST116', message: 'No rows found' },
-    })
+  it('retourne les defaults si aucune ligne (data null, sans erreur)', async () => {
+    mockSupabaseQuery({ data: null, error: null })
 
     const result = await getPrivacySettings(PROFILE_ID)
 
@@ -79,25 +77,23 @@ describe('getPrivacySettings', () => {
     expect(result.analyticsEnabled).toBe(true)
   })
 
-  it('log l erreur si code != PGRST116', async () => {
+  it('log l erreur Supabase et retourne les defaults', async () => {
     const { logger } = await import('@/lib/logger')
     const supabaseError = { code: '42P01', message: 'Table not found' }
     mockSupabaseQuery({ data: null, error: supabaseError })
 
-    await getPrivacySettings(PROFILE_ID)
+    const result = await getPrivacySettings(PROFILE_ID)
 
     expect(logger.error).toHaveBeenCalledWith(
       'Erreur chargement privacy settings:',
       supabaseError
     )
+    expect(result).toEqual(PRIVACY_DEFAULTS)
   })
 
-  it('ne log pas pour PGRST116 (cas normal premier usage)', async () => {
+  it('ne log pas quand data est null sans erreur (cas premier usage)', async () => {
     const { logger } = await import('@/lib/logger')
-    mockSupabaseQuery({
-      data: null,
-      error: { code: 'PGRST116', message: 'No rows found' },
-    })
+    mockSupabaseQuery({ data: null, error: null })
 
     await getPrivacySettings(PROFILE_ID)
 

--- a/src/services/privacySettingsService.ts
+++ b/src/services/privacySettingsService.ts
@@ -26,13 +26,13 @@ export async function getPrivacySettings(profileId: string): Promise<PrivacySett
     .from('privacy_settings')
     .select('profile_id, analytics_enabled, created_at, updated_at')
     .eq('profile_id', profileId)
-    .single()
+    .maybeSingle()
 
   if (error) {
-    if (error.code === 'PGRST116') return { ...PRIVACY_DEFAULTS }
     logger.error('Erreur chargement privacy settings:', error)
     return { ...PRIVACY_DEFAULTS }
   }
+  if (!data) return { ...PRIVACY_DEFAULTS }
   return mapFromDb(data as PrivacySettingsDbRow)
 }
 


### PR DESCRIPTION
## Summary

`getPrivacySettings` appelait `.single()` sur la table `privacy_settings`, ce qui fait remonter un `HTTP 406 / PGRST116` quand l'utilisateur n'a jamais touché au toggle analytics (= tous les nouveaux signups). Le service catchait déjà `PGRST116` pour retourner les valeurs par défaut, donc le comportement applicatif est correct, mais l'erreur 406 polluait la console réseau du navigateur à chaque chargement.

Passage à `.maybeSingle()` : PostgREST renvoie un `data: null, error: null` au lieu d'un 406 — plus de bruit côté DevTools, comportement applicatif inchangé.

### Changements

- `src/services/privacySettingsService.ts` : `.single()` → `.maybeSingle()`, simplification de la branche de fallback
- `src/services/privacySettingsService.test.ts` : tests mis à jour (mock `maybeSingle`, scénarios `data: null, error: null` au lieu du PGRST116 simulé)

## Test plan

- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` — 2307 passed / 4 skipped
- [x] Tests ciblés `privacySettingsService.test.ts` — 9 passed
- [ ] Manuel : nouveau signup → ouvrir Settings > Confidentialité → plus de 406 dans les DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)