### PR TITLE
feat(auth): propagate signup role across OAuth redirect via sessionStorage

### DIFF
--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -368,7 +368,7 @@ export function SignupForm() {
 
         {/* Social login */}
         <Box mt={4}>
-          <SocialLoginButtons />
+          <SocialLoginButtons pendingRole={watchedRole ? (watchedRole as UserRole) : undefined} />
         </Box>
 
         {/* Lien connexion */}

--- a/src/components/auth/SocialLoginButtons.tsx
+++ b/src/components/auth/SocialLoginButtons.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { Button, Flex, Separator, Text } from '@chakra-ui/react'
 import { signInWithGoogle, signInWithMicrosoft } from '@/lib/supabase/auth'
+import { setPendingRole } from '@/lib/auth/pendingRole'
+import type { UserRole } from '@/types'
 
 function GoogleIcon() {
   return (
@@ -24,7 +26,16 @@ function MicrosoftIcon() {
   )
 }
 
-export function SocialLoginButtons() {
+interface SocialLoginButtonsProps {
+  /**
+   * Rôle pré-sélectionné dans le formulaire de signup. Stocké en sessionStorage
+   * avant le redirect OAuth et récupéré par OnboardingRolePage au retour.
+   * Ignoré si non fourni (cas LoginForm).
+   */
+  pendingRole?: UserRole
+}
+
+export function SocialLoginButtons({ pendingRole }: SocialLoginButtonsProps = {}) {
   const [loadingGoogle, setLoadingGoogle] = useState(false)
   const [loadingMicrosoft, setLoadingMicrosoft] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -32,6 +43,7 @@ export function SocialLoginButtons() {
   async function handleGoogle() {
     setError(null)
     setLoadingGoogle(true)
+    if (pendingRole) setPendingRole(pendingRole)
     try {
       await signInWithGoogle()
     } catch {
@@ -43,6 +55,7 @@ export function SocialLoginButtons() {
   async function handleMicrosoft() {
     setError(null)
     setLoadingMicrosoft(true)
+    if (pendingRole) setPendingRole(pendingRole)
     try {
       await signInWithMicrosoft()
     } catch {

--- a/src/lib/auth/pendingRole.ts
+++ b/src/lib/auth/pendingRole.ts
@@ -1,0 +1,35 @@
+/**
+ * Stockage temporaire du rôle sélectionné dans le SignupForm avant un
+ * redirect OAuth. Permet de pré-remplir l'onboarding au retour, sans dépendre
+ * d'une intégration côté provider OAuth (Google/Microsoft n'envoient pas de
+ * `role` métier dans leur token).
+ *
+ * Persisté en sessionStorage : survit au redirect OAuth, tombe avec l'onglet.
+ */
+
+import type { UserRole } from '@/types'
+
+const STORAGE_KEY = 'unilien-pending-role'
+const VALID_ROLES: readonly UserRole[] = ['employer', 'employee', 'caregiver']
+
+export function setPendingRole(role: UserRole): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, role)
+  } catch {
+    // sessionStorage indisponible (mode privé / quota) → on ignore silencieusement
+  }
+}
+
+/**
+ * Lit le rôle pending et le supprime du storage (one-shot).
+ */
+export function consumePendingRole(): UserRole | null {
+  try {
+    const value = sessionStorage.getItem(STORAGE_KEY)
+    if (!value) return null
+    sessionStorage.removeItem(STORAGE_KEY)
+    return VALID_ROLES.includes(value as UserRole) ? (value as UserRole) : null
+  } catch {
+    return null
+  }
+}

--- a/src/pages/OnboardingRolePage.tsx
+++ b/src/pages/OnboardingRolePage.tsx
@@ -17,6 +17,7 @@ import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 import { sanitizeText } from '@/lib/sanitize'
 import { useAuth } from '@/hooks/useAuth'
+import { consumePendingRole } from '@/lib/auth/pendingRole'
 import type { UserRole } from '@/types'
 
 const roleOptions: { value: UserRole; label: string; description: string; icon: React.ReactNode }[] = [
@@ -66,6 +67,10 @@ export default function OnboardingRolePage() {
   const [userId, setUserId] = useState<string | null>(null)
 
   useEffect(() => {
+    // Récupérer le rôle pending posé par le SignupForm avant le redirect OAuth
+    const pending = consumePendingRole()
+    if (pending) setSelectedRole(pending)
+
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) return
       setUserId(user.id)


### PR DESCRIPTION
## Summary

Le rôle sélectionné dans `SignupForm` était jusqu'ici **silencieusement ignoré** quand l'utilisateur cliquait "Google" ou "Microsoft" : le flow OAuth ne transporte pas de claim métier, donc l'utilisateur arrivait toujours sur `/onboarding/role` sans rôle présélectionné et devait le re-choisir.

Cette PR ajoute un petit helper sessionStorage (`setPendingRole` / `consumePendingRole`, one-shot) qui stocke le rôle avant le redirect OAuth et le récupère au retour sur `OnboardingRolePage` pour pré-sélectionner le bouton. Le choix de l'utilisateur survit donc au redirect Google/Microsoft.

### Pourquoi sessionStorage et pas localStorage

- Pas besoin de persister entre sessions
- Tombe avec l'onglet → pas de données fantômes si l'utilisateur abandonne le flow
- Survit au redirect OAuth (storage navigateur n'est pas vidé sur cross-origin redirect)

### Changements

- `src/lib/auth/pendingRole.ts` (nouveau) — helpers `setPendingRole(role)` et `consumePendingRole()` (validation enum, try/catch sur sessionStorage indispo)
- `src/components/auth/SocialLoginButtons.tsx` — accepte `pendingRole?: UserRole`, stocke avant `signInWithGoogle`/`signInWithMicrosoft`
- `src/components/auth/SignupForm.tsx` — passe `watchedRole` à `SocialLoginButtons`
- `src/pages/OnboardingRolePage.tsx` — `consumePendingRole()` au mount → `setSelectedRole()` si trouvé

`LoginForm` continue d'instancier `SocialLoginButtons` sans prop → comportement inchangé.

## Test plan

- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` — 2307 passed / 4 skipped
- [x] Manuel : sur `/inscription`, cocher "Auxiliaire" → cliquer "Google" → après callback, l'onboarding doit avoir "Auxiliaire" déjà sélectionné
- [x] Manuel : `/connexion` → cliquer "Google" → comportement inchangé (pas de pendingRole)

## Suite

Reste de la roadmap initiale onboarding (étape 4 : gestion d'erreur fine `OnboardingRolePage`) est devenue moins prioritaire depuis le fix racine #348. À évaluer en fonction des erreurs réellement rencontrées en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)