### PR TITLE
fix(planning): show employee name instead of contract id in shift detail

### DIFF
--- a/src/components/planning/ShiftDetailView.tsx
+++ b/src/components/planning/ShiftDetailView.tsx
@@ -178,7 +178,7 @@ export function ShiftDetailView({
       {/* Auxiliaire */}
       {!isLoadingContract && contract && (
         <DetailRow label="Auxiliaire">
-          <Text>Contrat #{contract.id.slice(0, 8)}</Text>
+          <Text>{shift.employeeName || `Contrat #${contract.id.slice(0, 8)}`}</Text>
           <Text fontSize="12px" color="text.muted" mt="2px">
             {contract.contractType} · {contract.hourlyRate.toFixed(2)} €/h
           </Text>


### PR DESCRIPTION
## Summary

Sur le détail d'une intervention, la ligne "Auxiliaire" affichait `Contrat #bb3ee2ff` (les 8 premiers caractères de l'ID du contrat) au lieu du prénom + nom de l'auxiliaire.

Le `Shift` porte déjà `employeeName` (rempli par `getShifts` via le JOIN `contract → profile`), donc on l'affiche en priorité. Le slice de l'ID reste comme fallback si la donnée n'est pas dispo (cas marginal : shift chargé sans JOIN).

### Changement

- `src/components/planning/ShiftDetailView.tsx` : `Contrat #{contract.id.slice(0,8)}` → `{shift.employeeName || \`Contrat #${contract.id.slice(0,8)}\`}`

## Test plan

- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` — 2307 passed / 4 skipped
- [x] Manuel : ouvrir le détail d'une intervention sur le planning → la ligne "Auxiliaire" doit afficher "Prénom Nom"

🤖 Generated with [Claude Code](https://claude.com/claude-code)