### PR TITLE
fix(csp): allow cdn.jsdelivr.net for onnxruntime-web wasm runtime

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -9,7 +9,7 @@ unilien.app, www.unilien.app {
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "camera=(), microphone=(self), geolocation=()"
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://plausible.unilien.app; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://plausible.unilien.app https://huggingface.co https://*.huggingface.co https://*.hf.co; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://plausible.unilien.app https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://plausible.unilien.app https://huggingface.co https://*.huggingface.co https://*.hf.co https://cdn.jsdelivr.net; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
 
     @assets path /assets/*


### PR DESCRIPTION
## Summary

Fix navigation vocale cassée sur **Firefox en prod** (PR #355) avec :

```
no available backend found. ERR: [wasm] TypeError: error loading
dynamically imported module: https://cdn.jsdelivr.net/npm/onnxruntime-web@.../dist/ort-wasm-simd-threaded.asyncify.mjs
```

`@huggingface/transformers@4` charge dynamiquement les runtimes WASM/MJS d'`onnxruntime-web` depuis `cdn.jsdelivr.net` (ce ne sont pas bundlés dans le package npm). Notre CSP bloquait l'import.

### Changements

- `infra/caddy/Caddyfile` — ajout de `https://cdn.jsdelivr.net` dans `script-src` (pour les `.mjs`) et `connect-src` (pour les `.wasm`)

**Déjà déployé manuellement sur le VPS prod** (validate + reload OK, `curl unilien.app` confirme la nouvelle CSP).

### Follow-up (à prévoir, pas dans cette PR)

Self-host les assets `onnxruntime-web/dist/` dans `public/onnxruntime/` + configurer `env.backends.onnx.wasm.wasmPaths` dans `whisperEngine.ts`. Avantages :
- Plus aucune dépendance externe (résilience + perf)
- Meilleure posture RGPD (pas de fuite IP utilisateurs vers jsdelivr/Cloudflare)
- Versionnage maîtrisé (jsdelivr utilise une dev-version `1.26.0-dev.20260416-b7804b056c` non stable)

## Test plan

- [x] Caddyfile validé (`caddy validate`)
- [x] Caddy reload sans downtime
- [x] CSP servie en prod contient bien `cdn.jsdelivr.net`
- [x] Firefox prod : activer nav vocale → téléchargement modèle puis transcription OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)