### PR TITLE
fix(voice): fall back to Whisper on native network errors

### DIFF
--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -33,7 +33,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
   const { profile } = useAuth()
   const enabled = useAccessibilityStore((s) => s.settings.voiceControlEnabled)
 
-  const [engine] = useState<VoiceEngine>(() => detectEngine())
+  const [engine, setEngine] = useState<VoiceEngine>(() => detectEngine())
   const [status, setStatus] = useState<VoiceStatus>('idle')
   const [transcript, setTranscript] = useState('')
   const [matched, setMatched] = useState<VoiceCommand | null>(null)
@@ -42,6 +42,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
 
   const nativeRef = useRef<SpeechRecognition | null>(null)
   const abortRef = useRef(false)
+  const startWhisperRef = useRef<() => Promise<void>>(async () => {})
 
   const handleResult = useCallback(
     (heard: string) => {
@@ -73,11 +74,21 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       const heard = e.results[0]?.[0]?.transcript ?? ''
       handleResult(heard)
     }
-    recognition.onend = () => setStatus('idle')
+    recognition.onend = () => setStatus((s) => (s === 'listening' ? 'idle' : s))
     recognition.onerror = (e: SpeechRecognitionErrorEvent) => {
       if (e.error === 'aborted' || e.error === 'no-speech') {
         setStatus('idle')
         return
+      }
+      // Chromium open-source n'a pas les clés Google Speech → "network" systématique.
+      // On bascule définitivement sur Whisper local pour cette session.
+      if (e.error === 'network' || e.error === 'service-not-allowed') {
+        if (typeof navigator !== 'undefined' && navigator.mediaDevices?.getUserMedia) {
+          logger.info('Native voice engine unavailable, falling back to Whisper')
+          setEngine('whisper')
+          startWhisperRef.current()
+          return
+        }
       }
       setError(`Erreur reconnaissance : ${e.error}`)
       setStatus('error')
@@ -151,6 +162,11 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       setStatus('error')
     }
   }, [handleResult])
+
+  // Garde la dernière référence à startWhisper pour la bascule depuis onerror native.
+  useEffect(() => {
+    startWhisperRef.current = startWhisper
+  }, [startWhisper])
 
   const start = useCallback(async () => {
     if (!enabled) return


### PR DESCRIPTION
## Summary

Sur **Chromium** (build open-source) et certains dérivés, la Web Speech API renvoie systématiquement `Erreur reconnaissance : network` car ces builds n'ont pas les **clés API Google Speech** (réservées à Chrome propriétaire). Cette erreur peut aussi survenir ponctuellement sur Chrome si l'API Google est down.

Cette PR bascule **automatiquement et silencieusement** sur Whisper local quand le moteur natif renvoie `network` ou `service-not-allowed`. L'utilisateur voit « Chargement du moteur… » au lieu d'un message d'erreur, puis peut parler normalement.

### Changements

- `src/hooks/useVoiceNavigation.ts` :
  - `engine` devient mutable pour la bascule runtime
  - `onerror` natif avec `network` / `service-not-allowed` → switch sur Whisper + relance immédiate
  - Bonus : `onend` ne reset le status que si on était `listening` (sinon il écrasait le `loading-engine` de la bascule)

### Pourquoi pas tout de suite Whisper sur Chromium ?

Chrome propriétaire marche très bien en natif (faible latence, modèle Google de qualité). La bascule au 1er échec couvre Chromium/Brave/Vivaldi sans pénaliser les utilisateurs Chrome.

## Test plan

- [ ] Chromium : erreur silencieuse → téléchargement Whisper → transcription locale OK
- [ ] Chrome stable : reste sur natif, pas de téléchargement inutile
- [ ] Firefox : passe directement par Whisper
- [x] Typecheck + lint OK
- [x] Tests voice 16/16

Chaîne : PR #355 (init) → #358 (CSP jsdelivr) → cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)