### PR TITLE
feat(voice): Silero VAD + speech-detected wave + anti-hallucination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
         "react-router-dom": "^7.14.0",
-        "vite-plugin-static-copy": "^2.3.2",
         "xlsx": "npm:@e965/xlsx@^0.20.3",
         "zod": "^4.3.5",
         "zustand": "^5.0.12"
@@ -54,6 +53,7 @@
         "typescript-eslint": "^8.58.1",
         "vite": "^7.2.4",
         "vite-plugin-pwa": "^1.2.0",
+        "vite-plugin-static-copy": "^4.1.0",
         "vitest": "^4.0.17"
       },
       "optionalDependencies": {
@@ -3393,41 +3393,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@pandacss/is-valid-prop": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.8.2.tgz",
@@ -4487,7 +4452,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6002,6 +5967,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -6015,6 +5981,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6349,6 +6316,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6379,6 +6347,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -6563,6 +6532,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -6587,6 +6557,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -7543,34 +7514,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7601,15 +7544,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -7698,6 +7632,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7853,6 +7788,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8138,6 +8074,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/guid-typescript": {
@@ -8452,6 +8389,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8544,6 +8482,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8589,6 +8528,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8634,6 +8574,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -9088,6 +9029,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -9369,40 +9311,6 @@
       "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9494,6 +9402,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9724,6 +9633,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
       "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10113,26 +10023,6 @@
         "inherits": "~2.0.3"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -10228,6 +10118,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -10240,6 +10131,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10415,16 +10307,6 @@
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -10500,29 +10382,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -11336,6 +11195,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -11653,6 +11513,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -11843,36 +11704,26 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
-      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.1.0.tgz",
+      "integrity": "sha512-9XOarNV7LgP0KBB7AApxdgFikLXx3daZdqjC3AevYsL6MrUH62zphonLUs2a6LZc1HN1GY+vQdheZ8VVJb6dQQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "p-map": "^7.0.3",
-        "picocolors": "^1.0.0"
+        "chokidar": "^3.6.0",
+        "p-map": "^7.0.4",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.15"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sapphi-red"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/vite-plugin-static-copy/node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@huggingface/transformers": "^4.2.0",
         "@react-pdf/renderer": "^4.4.1",
+        "@ricky0123/vad-web": "^0.0.30",
         "@supabase/supabase-js": "^2.103.3",
         "date-fns": "^4.1.0",
         "dompurify": "^3.4.0",
@@ -23,6 +24,7 @@
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.72.1",
         "react-router-dom": "^7.14.0",
+        "vite-plugin-static-copy": "^2.3.2",
         "xlsx": "npm:@e965/xlsx@^0.20.3",
         "zod": "^4.3.5",
         "zustand": "^5.0.12"
@@ -31,6 +33,7 @@
         "@axe-core/react": "^4.11.0",
         "@eslint/js": "^9.39.1",
         "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -3390,6 +3393,41 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pandacss/is-valid-prop": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.8.2.tgz",
@@ -3650,6 +3688,35 @@
         "@react-pdf/font": "^4.0.6",
         "@react-pdf/primitives": "^4.2.0",
         "@react-pdf/stylesheet": "^6.1.4"
+      }
+    },
+    "node_modules/@ricky0123/vad-web": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@ricky0123/vad-web/-/vad-web-0.0.30.tgz",
+      "integrity": "sha512-cJyYrh4YeeUBJcbR9Bic/bFDyB9qBkAepvpuWM3vLxnAi7bC3VHzf51UeNdT+OtY4D7MLAgV8iJMc4z41ZnaWg==",
+      "license": "ISC",
+      "dependencies": {
+        "onnxruntime-web": "^1.17.0"
+      }
+    },
+    "node_modules/@ricky0123/vad-web/node_modules/onnxruntime-common": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.25.1.tgz",
+      "integrity": "sha512-kKvYQFdos4LWJqhZ+nmKu3NT8NXzw8I5x9fNUKe1rNKcPfNKnYXUtW7JBpcKFsvLtrJashRgVYSbFap4cHxvNg==",
+      "license": "MIT"
+    },
+    "node_modules/@ricky0123/vad-web/node_modules/onnxruntime-web": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.25.1.tgz",
+      "integrity": "sha512-mgs61sJ9m3hLa5jGRr9Pen3kkG00vlxmrcRL6FufYpSWBZKaklo0sotQCq2fLjgDVLnW57jrDcLqzYJNKeZskQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.25.1",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4223,7 +4290,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4312,8 +4378,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4422,7 +4487,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5913,7 +5978,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5932,6 +5996,31 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/argparse": {
@@ -6256,6 +6345,18 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -6272,6 +6373,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/brotli": {
@@ -6444,6 +6557,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/clone": {
@@ -6814,8 +6963,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.0",
@@ -7395,6 +7543,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7425,6 +7601,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -7507,6 +7692,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-root": {
@@ -7656,7 +7853,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7942,7 +8138,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/guid-typescript": {
@@ -8253,6 +8448,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -8337,7 +8544,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8383,7 +8589,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8423,6 +8628,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -8874,7 +9088,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -9066,7 +9279,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9157,6 +9369,40 @@
       "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9243,6 +9489,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/normalize-svg-path": {
       "version": "1.1.0",
@@ -9460,6 +9715,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9748,7 +10015,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9764,7 +10030,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9777,8 +10042,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -9848,6 +10112,26 @@
       "dependencies": {
         "inherits": "~2.0.3"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -9938,6 +10222,30 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -10107,6 +10415,16 @@
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -10182,6 +10500,29 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -10991,6 +11332,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -11300,7 +11653,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -11488,6 +11840,39 @@
         "@vite-pwa/assets-generator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "p-map": "^7.0.3",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",
     "react-router-dom": "^7.14.0",
-    "vite-plugin-static-copy": "^2.3.2",
     "xlsx": "npm:@e965/xlsx@^0.20.3",
     "zod": "^4.3.5",
     "zustand": "^5.0.12"
@@ -64,6 +63,7 @@
     "typescript-eslint": "^8.58.1",
     "vite": "^7.2.4",
     "vite-plugin-pwa": "^1.2.0",
+    "vite-plugin-static-copy": "^4.1.0",
     "vitest": "^4.0.17"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@huggingface/transformers": "^4.2.0",
     "@react-pdf/renderer": "^4.4.1",
+    "@ricky0123/vad-web": "^0.0.30",
     "@supabase/supabase-js": "^2.103.3",
     "date-fns": "^4.1.0",
     "dompurify": "^3.4.0",
@@ -33,6 +34,7 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",
     "react-router-dom": "^7.14.0",
+    "vite-plugin-static-copy": "^2.3.2",
     "xlsx": "npm:@e965/xlsx@^0.20.3",
     "zod": "^4.3.5",
     "zustand": "^5.0.12"
@@ -41,6 +43,7 @@
     "@axe-core/react": "^4.11.0",
     "@eslint/js": "^9.39.1",
     "@playwright/test": "^1.59.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/components/voice/VoiceNavButton.tsx
+++ b/src/components/voice/VoiceNavButton.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react'
 import { Box, Flex, IconButton, Text, VStack, HStack, Badge } from '@chakra-ui/react'
 import { NavIcon } from '@/components/ui'
+import { VoiceWave } from '@/components/voice/VoiceWave'
 import { useVoiceNavigation } from '@/hooks/useVoiceNavigation'
 import { listAvailableCommands } from '@/lib/voice/voiceCommands'
 import { useAuth } from '@/hooks/useAuth'
 
 export function VoiceNavButton() {
   const { profile } = useAuth()
-  const { enabled, status, engine, transcript, matched, error, modelProgress, toggle } = useVoiceNavigation()
+  const { enabled, status, engine, transcript, matched, error, modelProgress, speechDetected, toggle } = useVoiceNavigation()
   const [showHelp, setShowHelp] = useState(false)
 
   // Raccourci clavier : Ctrl/Cmd + Shift + V
@@ -32,7 +33,7 @@ export function VoiceNavButton() {
   const statusLabel = (() => {
     switch (status) {
       case 'loading-engine': return modelProgress > 0 ? `Chargement du moteur… ${modelProgress}%` : 'Chargement du moteur…'
-      case 'listening': return 'Parlez maintenant…'
+      case 'listening': return speechDetected ? 'Je vous écoute…' : 'Parlez maintenant…'
       case 'transcribing': return 'Transcription en cours…'
       case 'error': return error ?? 'Erreur'
       default: return 'Cliquez pour parler'
@@ -132,7 +133,11 @@ export function VoiceNavButton() {
             '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
           }}
         >
-          <NavIcon name={isListening ? 'mic-off' : 'mic'} size={22} />
+          {isListening ? (
+            <VoiceWave size={22} active={speechDetected} />
+          ) : (
+            <NavIcon name="mic" size={22} />
+          )}
         </IconButton>
 
         {isListening && (

--- a/src/components/voice/VoiceWave.tsx
+++ b/src/components/voice/VoiceWave.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from 'react'
+import { Box, HStack } from '@chakra-ui/react'
+
+interface VoiceWaveProps {
+  /** Hauteur totale de l'onde en px (default 22, aligné sur l'icône mic). */
+  size?: number
+  /** Couleur des barres (default white pour fond rouge). */
+  color?: string
+  /**
+   * `true` = parole détectée → barres dansent.
+   * `false` = mic ouvert mais silence → barres figées basses (état d'attente).
+   */
+  active?: boolean
+}
+
+const BARS = [
+  { duration: '0.65s', delay: '0s', anim: 'voice-wave-a' },
+  { duration: '0.78s', delay: '0.08s', anim: 'voice-wave-b' },
+  { duration: '0.55s', delay: '0.18s', anim: 'voice-wave-b' },
+  { duration: '0.70s', delay: '0.04s', anim: 'voice-wave-a' },
+]
+
+const STYLE_ID = 'voice-wave-keyframes'
+const KEYFRAMES_CSS = `
+@keyframes voice-wave-a {
+  0%, 100% { transform: scaleY(0.30); }
+  50% { transform: scaleY(0.85); }
+}
+@keyframes voice-wave-b {
+  0%, 100% { transform: scaleY(0.40); }
+  50% { transform: scaleY(1.0); }
+}
+`
+
+/**
+ * Onde animée pendant l'écoute. En mode passif (silence) : barres basses figées.
+ * En mode actif (parole détectée par Silero VAD) : barres montent/descendent
+ * avec timings individualisés. Respecte prefers-reduced-motion.
+ */
+export function VoiceWave({ size = 22, color = 'white', active = false }: VoiceWaveProps) {
+  // Injecte les @keyframes globaux une seule fois — le css prop de Chakra
+  // n'extrait pas les règles @keyframes définies dynamiquement par clé.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    if (document.getElementById(STYLE_ID)) return
+    const style = document.createElement('style')
+    style.id = STYLE_ID
+    style.textContent = KEYFRAMES_CSS
+    document.head.appendChild(style)
+  }, [])
+
+  const barWidth = 3
+  const gap = 3
+
+  return (
+    <HStack
+      gap={`${gap}px`}
+      align="center"
+      justify="center"
+      h={`${size}px`}
+      w="auto"
+      aria-hidden
+    >
+      {BARS.map((bar, i) => (
+        <Box
+          key={i}
+          w={`${barWidth}px`}
+          h={`${size}px`}
+          bg={color}
+          borderRadius="full"
+          opacity={active ? 1 : 0.55}
+          css={{
+            transformOrigin: 'center',
+            willChange: active ? 'transform' : undefined,
+            ...(active
+              ? {
+                  animation: `${bar.anim} ${bar.duration} cubic-bezier(0.4, 0, 0.6, 1) ${bar.delay} infinite`,
+                }
+              : {
+                  transform: 'scaleY(0.35)',
+                }),
+            '@media (prefers-reduced-motion: reduce)': {
+              animation: 'none',
+              transform: 'scaleY(0.6)',
+            },
+          }}
+        />
+      ))}
+    </HStack>
+  )
+}
+
+export default VoiceWave

--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -16,6 +16,7 @@ export interface UseVoiceNavigationReturn {
   matched: VoiceCommand | null
   error: string | null
   modelProgress: number
+  speechDetected: boolean
   start: () => Promise<void>
   stop: () => void
   toggle: () => Promise<void>
@@ -39,6 +40,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
   const [matched, setMatched] = useState<VoiceCommand | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [modelProgress, setModelProgress] = useState(0)
+  const [speechDetected, setSpeechDetected] = useState(false)
 
   const nativeRef = useRef<SpeechRecognition | null>(null)
   const abortRef = useRef(false)
@@ -74,7 +76,12 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       const heard = e.results[0]?.[0]?.transcript ?? ''
       handleResult(heard)
     }
-    recognition.onend = () => setStatus((s) => (s === 'listening' ? 'idle' : s))
+    recognition.onspeechstart = () => setSpeechDetected(true)
+    recognition.onspeechend = () => setSpeechDetected(false)
+    recognition.onend = () => {
+      setSpeechDetected(false)
+      setStatus((s) => (s === 'listening' ? 'idle' : s))
+    }
     recognition.onerror = (e: SpeechRecognitionErrorEvent) => {
       if (e.error === 'aborted' || e.error === 'no-speech') {
         setStatus('idle')
@@ -109,6 +116,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
     setError(null)
     setTranscript('')
     setMatched(null)
+    setSpeechDetected(false)
     setStatus('listening')
     try {
       nativeRef.current.start()
@@ -122,6 +130,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
     setError(null)
     setTranscript('')
     setMatched(null)
+    setSpeechDetected(false)
     abortRef.current = false
 
     try {
@@ -143,8 +152,15 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
         return
       }
 
-      setStatus('listening')
-      const { audio } = await captureAudio()
+      // Reste en 'loading-engine' tant que le VAD n'est pas prêt (modèle ONNX
+      // se charge ~1-3s la première fois). Passe à 'listening' uniquement
+      // quand MicVAD est réellement à l'écoute → évite que l'utilisateur
+      // parle avant que le VAD soit branché sur le micro.
+      const { audio } = await captureAudio({
+        onReady: () => setStatus('listening'),
+        onSpeechStart: () => setSpeechDetected(true),
+      })
+      setSpeechDetected(false)
       if (abortRef.current) {
         setStatus('idle')
         return
@@ -183,6 +199,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
         /* noop */
       }
     }
+    setSpeechDetected(false)
     setStatus('idle')
   }, [engine])
 
@@ -202,6 +219,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
     matched,
     error,
     modelProgress,
+    speechDetected,
     start,
     stop,
     toggle,

--- a/src/lib/voice/audioCapture.ts
+++ b/src/lib/voice/audioCapture.ts
@@ -1,74 +1,93 @@
 import { logger } from '@/lib/logger'
 
-const SAMPLE_RATE = 16000
-const MAX_DURATION_MS = 5000
-
 export interface CaptureResult {
   audio: Float32Array
   durationMs: number
 }
 
-export async function captureAudio(maxDurationMs = MAX_DURATION_MS): Promise<CaptureResult> {
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: { echoCancellation: true, noiseSuppression: true, channelCount: 1 },
-  })
+export interface CaptureOptions {
+  /** Délai max sans parole détectée avant abandon (default 12s). */
+  maxDurationMs?: number
+  /** Appelé quand l'utilisateur commence vraiment à parler. */
+  onSpeechStart?: () => void
+  /** Permet d'annuler la capture en cours. */
+  signal?: AbortSignal
+}
+
+/**
+ * Capture audio via Silero VAD (@ricky0123/vad-web). Le VAD coupe
+ * automatiquement à la fin de la parole — pas de timeout fixe.
+ * Retourne un Float32Array à 16 kHz mono prêt pour Whisper.
+ *
+ * Config conforme à la doc officielle docs.vad.ricky0123.com :
+ * assets servis à la racine via vite-plugin-static-copy.
+ */
+export async function captureAudio(options: CaptureOptions = {}): Promise<CaptureResult> {
+  const { maxDurationMs = 20000, onSpeechStart, signal } = options
+  const { MicVAD } = await import('@ricky0123/vad-web')
 
   return new Promise<CaptureResult>((resolve, reject) => {
-    const recorder = new MediaRecorder(stream)
-    const chunks: Blob[] = []
+    let vad: Awaited<ReturnType<typeof MicVAD.new>> | null = null
     const startedAt = performance.now()
 
-    recorder.ondataavailable = (e) => {
-      if (e.data.size > 0) chunks.push(e.data)
+    const cleanup = () => {
+      vad?.destroy()
+      vad = null
     }
 
-    recorder.onerror = (e) => {
-      stream.getTracks().forEach((t) => t.stop())
-      reject(e)
-    }
+    const timeoutId = setTimeout(() => {
+      cleanup()
+      reject(new Error('Aucune parole détectée. Cliquez à nouveau et parlez.'))
+    }, maxDurationMs)
 
-    recorder.onstop = async () => {
-      stream.getTracks().forEach((t) => t.stop())
-      try {
-        const blob = new Blob(chunks, { type: chunks[0]?.type ?? 'audio/webm' })
-        const buffer = await blob.arrayBuffer()
-        const audio = await decodeToMono16k(buffer)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeoutId)
+        cleanup()
+        reject(new DOMException('Capture aborted', 'AbortError'))
+      },
+      { once: true },
+    )
+
+    MicVAD.new({
+      baseAssetPath: '/',
+      onnxWASMBasePath: '/',
+      model: 'v5',
+      // Seuils permissifs pour les commandes courtes ("aide", "planning") :
+      // - threshold bas (0.35) → détecte voix faible / bruyante
+      // - minSpeechFrames=1 → autorise mots monosyllabiques
+      // - redemptionFrames=12 → laisse 12 frames (~384ms) de marge avant de
+      //   couper, évite de couper en plein mot.
+      positiveSpeechThreshold: 0.35,
+      negativeSpeechThreshold: 0.25,
+      redemptionFrames: 12,
+      minSpeechFrames: 1,
+      onSpeechStart: () => {
+        onSpeechStart?.()
+      },
+      onSpeechEnd: (audio: Float32Array) => {
+        clearTimeout(timeoutId)
+        cleanup()
         resolve({ audio, durationMs: performance.now() - startedAt })
-      } catch (err) {
+      },
+    })
+      .then((instance) => {
+        if (signal?.aborted) {
+          instance.destroy()
+          clearTimeout(timeoutId)
+          reject(new DOMException('Capture aborted', 'AbortError'))
+          return
+        }
+        vad = instance
+        vad.start()
+      })
+      .catch((err) => {
+        clearTimeout(timeoutId)
+        logger.error('MicVAD init failed', err)
         reject(err)
-      }
-    }
-
-    recorder.start()
-    setTimeout(() => recorder.state === 'recording' && recorder.stop(), maxDurationMs)
+      })
   })
-}
-
-async function decodeToMono16k(buffer: ArrayBuffer): Promise<Float32Array> {
-  const AudioCtx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
-  const ctx = new AudioCtx()
-  try {
-    const decoded = await ctx.decodeAudioData(buffer.slice(0))
-    if (decoded.sampleRate === SAMPLE_RATE && decoded.numberOfChannels === 1) {
-      return decoded.getChannelData(0).slice()
-    }
-    return resample(decoded, SAMPLE_RATE)
-  } catch (err) {
-    logger.warn('decodeAudioData failed', err)
-    throw err
-  } finally {
-    await ctx.close().catch(() => {})
-  }
-}
-
-async function resample(buffer: AudioBuffer, target: number): Promise<Float32Array> {
-  const offline = new OfflineAudioContext(1, Math.ceil((buffer.duration * target)), target)
-  const src = offline.createBufferSource()
-  src.buffer = buffer
-  src.connect(offline.destination)
-  src.start()
-  const rendered = await offline.startRendering()
-  return rendered.getChannelData(0).slice()
 }
 
 export async function ensureMicPermission(): Promise<boolean> {

--- a/src/lib/voice/audioCapture.ts
+++ b/src/lib/voice/audioCapture.ts
@@ -6,8 +6,10 @@ export interface CaptureResult {
 }
 
 export interface CaptureOptions {
-  /** Délai max sans parole détectée avant abandon (default 12s). */
+  /** Délai max sans parole détectée avant abandon (default 20s). */
   maxDurationMs?: number
+  /** Appelé quand le VAD est réellement prêt à écouter (modèle ONNX chargé). */
+  onReady?: () => void
   /** Appelé quand l'utilisateur commence vraiment à parler. */
   onSpeechStart?: () => void
   /** Permet d'annuler la capture en cours. */
@@ -23,11 +25,12 @@ export interface CaptureOptions {
  * assets servis à la racine via vite-plugin-static-copy.
  */
 export async function captureAudio(options: CaptureOptions = {}): Promise<CaptureResult> {
-  const { maxDurationMs = 20000, onSpeechStart, signal } = options
+  const { maxDurationMs = 20000, onReady, onSpeechStart, signal } = options
   const { MicVAD } = await import('@ricky0123/vad-web')
 
   return new Promise<CaptureResult>((resolve, reject) => {
     let vad: Awaited<ReturnType<typeof MicVAD.new>> | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
     const startedAt = performance.now()
 
     const cleanup = () => {
@@ -35,15 +38,10 @@ export async function captureAudio(options: CaptureOptions = {}): Promise<Captur
       vad = null
     }
 
-    const timeoutId = setTimeout(() => {
-      cleanup()
-      reject(new Error('Aucune parole détectée. Cliquez à nouveau et parlez.'))
-    }, maxDurationMs)
-
     signal?.addEventListener(
       'abort',
       () => {
-        clearTimeout(timeoutId)
+        if (timeoutId) clearTimeout(timeoutId)
         cleanup()
         reject(new DOMException('Capture aborted', 'AbortError'))
       },
@@ -54,36 +52,56 @@ export async function captureAudio(options: CaptureOptions = {}): Promise<Captur
       baseAssetPath: '/',
       onnxWASMBasePath: '/',
       model: 'v5',
-      // Seuils permissifs pour les commandes courtes ("aide", "planning") :
-      // - threshold bas (0.35) → détecte voix faible / bruyante
-      // - minSpeechFrames=1 → autorise mots monosyllabiques
-      // - redemptionFrames=12 → laisse 12 frames (~384ms) de marge avant de
-      //   couper, évite de couper en plein mot.
-      positiveSpeechThreshold: 0.35,
-      negativeSpeechThreshold: 0.25,
-      redemptionFrames: 12,
-      minSpeechFrames: 1,
+      // Stream personnalisé : on coupe noiseSuppression / echoCancellation /
+      // autoGainControl. Activés par défaut par Firefox/Chrome, ils tuent
+      // le signal vocal continu et ne laissent que des transitoires →
+      // VAD voit "click click" au lieu de "voix" → misfire systématique.
+      getStream: async () => {
+        return navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+          },
+        })
+      },
+      positiveSpeechThreshold: 0.30,
+      negativeSpeechThreshold: 0.20,
+      redemptionFrames: 24,
+      minSpeechFrames: 2,
+      // 10 frames (~320ms) d'audio AVANT le speech-start envoyés à Whisper.
+      // Whisper hallucine sur 1s brut sans contexte → ce padding réduit
+      // drastiquement les transcriptions inventées sur commandes courtes.
+      preSpeechPadFrames: 10,
       onSpeechStart: () => {
         onSpeechStart?.()
       },
       onSpeechEnd: (audio: Float32Array) => {
-        clearTimeout(timeoutId)
+        if (timeoutId) clearTimeout(timeoutId)
         cleanup()
         resolve({ audio, durationMs: performance.now() - startedAt })
+      },
+      onVADMisfire: () => {
+        logger.warn('VAD misfire (speech too short, ignored)')
       },
     })
       .then((instance) => {
         if (signal?.aborted) {
           instance.destroy()
-          clearTimeout(timeoutId)
           reject(new DOMException('Capture aborted', 'AbortError'))
           return
         }
         vad = instance
         vad.start()
+        onReady?.()
+        // Démarre le timeout APRÈS que le VAD soit prêt — sinon on consomme
+        // une partie du délai pendant le chargement du modèle ONNX.
+        timeoutId = setTimeout(() => {
+          cleanup()
+          reject(new Error('Aucune parole détectée. Cliquez à nouveau et parlez.'))
+        }, maxDurationMs)
       })
       .catch((err) => {
-        clearTimeout(timeoutId)
         logger.error('MicVAD init failed', err)
         reject(err)
       })

--- a/src/lib/voice/voiceCommands.ts
+++ b/src/lib/voice/voiceCommands.ts
@@ -17,7 +17,7 @@ export const VOICE_COMMANDS: VoiceCommand[] = [
   { phrases: ['cahier de liaison', 'liaison', 'cahier', 'cayer'], path: '/cahier-de-liaison' },
   { phrases: ['conformité', 'conformite', 'conformités'], path: '/conformite', roles: ['employer'] },
   { phrases: ['documents', 'document', 'bulletins', 'bulletin', 'documan'], path: '/documents', roles: ['employer', 'employee'] },
-  { phrases: ['analytique', 'analytics', 'statistiques', 'stats', 'analyse'], path: '/analytique' },
+  { phrases: ['analytique', 'analytics', 'statistiques', 'stats', 'analyse', 'annelitique', 'analitique'], path: '/analytique' },
   { phrases: ['profil', 'mon profil', 'compte', 'profile'], path: '/profil' },
   { phrases: ['paramètres', 'parametres', 'réglages', 'reglages', 'settings', 'paramètre'], path: '/parametres' },
   { phrases: ['aide', 'help', 'faq'], path: '/aide' },

--- a/src/lib/voice/whisperEngine.ts
+++ b/src/lib/voice/whisperEngine.ts
@@ -39,7 +39,11 @@ export async function getTranscriber(): Promise<Transcriber> {
 
   transcriberPromise = (async () => {
     emit({ status: 'init' })
-    const { pipeline } = await import('@huggingface/transformers')
+    const { pipeline, env } = await import('@huggingface/transformers')
+
+    // Réutilise les WASM onnxruntime self-hostés (copiés à la racine par
+    // vite-plugin-static-copy). Évite la dépendance à cdn.jsdelivr.net.
+    env.backends.onnx.wasm.wasmPaths = '/'
 
     const transcriber = await pipeline('automatic-speech-recognition', WHISPER_MODEL, {
       // Cast volontaire : la signature dtype permet string | record selon le modèle,
@@ -68,7 +72,17 @@ export async function getTranscriber(): Promise<Transcriber> {
 
 export async function transcribe(audio: Float32Array): Promise<string> {
   const transcriber = await getTranscriber()
-  const result = await transcriber(audio, { language: 'french', task: 'transcribe' })
+  // Anti-hallucination Whisper sur commandes courtes :
+  // - no_repeat_ngram_size : empêche "X. X. X." en boucle
+  // - temperature 0 : déterministe, pas de fallback aléatoire
+  // - compression_ratio_threshold : rejette segments trop répétitifs
+  const result = await transcriber(audio, {
+    language: 'french',
+    task: 'transcribe',
+    no_repeat_ngram_size: 3,
+    temperature: 0,
+    compression_ratio_threshold: 2.4,
+  } as { language: string; task: string })
   return (result?.text ?? '').trim()
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,13 +8,15 @@ export default defineConfig({
   plugins: [
     react(),
     // Config officielle docs.vad.ricky0123.com — assets à la racine de outDir.
+    // v4 du plugin préserve l'arborescence source par défaut, d'où le
+    // `rename: { stripBase: true }` pour aplatir la copie dans dist/.
     viteStaticCopy({
       targets: [
-        { src: 'node_modules/@ricky0123/vad-web/dist/vad.worklet.bundle.min.js', dest: './' },
-        { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_v5.onnx', dest: './' },
-        { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_legacy.onnx', dest: './' },
-        { src: 'node_modules/onnxruntime-web/dist/*.wasm', dest: './' },
-        { src: 'node_modules/onnxruntime-web/dist/*.mjs', dest: './' },
+        { src: 'node_modules/@ricky0123/vad-web/dist/vad.worklet.bundle.min.js', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_v5.onnx', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_legacy.onnx', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/onnxruntime-web/dist/*.wasm', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/onnxruntime-web/dist/*.mjs', dest: './', rename: { stripBase: true } },
       ],
     }),
     VitePWA({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
+    // Config officielle docs.vad.ricky0123.com — assets à la racine de outDir.
+    viteStaticCopy({
+      targets: [
+        { src: 'node_modules/@ricky0123/vad-web/dist/vad.worklet.bundle.min.js', dest: './' },
+        { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_v5.onnx', dest: './' },
+        { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_legacy.onnx', dest: './' },
+        { src: 'node_modules/onnxruntime-web/dist/*.wasm', dest: './' },
+        { src: 'node_modules/onnxruntime-web/dist/*.mjs', dest: './' },
+      ],
+    }),
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'robots.txt', 'apple-touch-icon.png', 'sw-push.js'],
@@ -122,7 +133,6 @@ export default defineConfig({
       '@': '/src'
     }
   },
-  optimizeDeps: {
-    exclude: ['@huggingface/transformers']
-  }
+  // Pas d'optimizeDeps.exclude — la doc officielle de @ricky0123/vad-web
+  // ne recommande rien de particulier. Laisser esbuild gérer.
 })


### PR DESCRIPTION
## Summary

Branche v2 de l'intégration Silero VAD (la v1 PR #361 avait été abandonnée pour incompatibilité Vite). Cette fois on suit la doc officielle `@ricky0123/vad-web` (assets servis à la racine via `vite-plugin-static-copy`) et tout marche.

Bonus : on **self-host onnxruntime-web** au passage → plus de dépendance à `cdn.jsdelivr.net` dans la CSP (TODO mémoire nav vocale ✅).

### Changements

**VAD côté capture audio**
- Coupe `echoCancellation` / `noiseSuppression` / `autoGainControl` — Firefox/Chrome traitaient la voix continue comme bruit, ne laissant que des pics → misfire systématique
- Seuils tunés pour commandes FR courtes : `positiveSpeechThreshold=0.30`, `redemptionFrames=24`, `minSpeechFrames=2`, `preSpeechPadFrames=10`
- Timeout démarre uniquement quand le VAD est prêt (callback `onReady`)

**Feedback visuel**
- Nouveau composant `VoiceWave` : 4 barres dansantes avec `@keyframes` globaux injectés une fois (le `css` prop de Chakra n'extrait pas les keyframes dynamiques par clé template-literal)
- `useVoiceNavigation` expose `speechDetected` (Silero `onSpeechStart` côté Whisper, `onspeechstart` côté Web Speech API native)
- Le FAB micro affiche l'onde dansante au lieu de l'icône `mic` pendant l'écoute, label "Je vous écoute…" quand parole détectée
- `prefers-reduced-motion` géré

**Anti-hallucination Whisper**
- `no_repeat_ngram_size=3` tue les "Amené, titu. Amené, titu. Amené, titu."
- `temperature=0` + `compression_ratio_threshold=2.4` rejettent les segments faibles
- `env.backends.onnx.wasm.wasmPaths='/'` pour pointer sur les WASM self-hostés

**Misc**
- Variantes Whisper FR ajoutées : `annelitique`, `analitique` → `/analytique`
- Fix peer dep `@testing-library/dom` manquante (les `npm install` antérieurs l'avaient virée → 75 fichiers de tests cassés silencieusement)

## Test plan
- [x] `npm run test:run` → 2333 passed / 4 skipped
- [x] `npm run lint` → 0 errors (2 warnings préexistants)
- [x] `npm run typecheck` → OK
- [x] `npm run build` → OK, assets `silero_vad_v5.onnx` + `vad.worklet.bundle.min.js` + `ort-wasm-*` à la racine `dist/`
- [x] Test manuel Firefox : commande vocale "analytique" → navigation OK
- [x] Test manuel Chromium : commande vocale OK
- [ ] Follow-up : retirer `cdn.jsdelivr.net` de la CSP Caddyfile prod (le self-host le rend inutile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)