### PR TITLE
chore(csp): remove cdn.jsdelivr.net from prod CSP

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -9,7 +9,7 @@ unilien.app, www.unilien.app {
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "camera=(), microphone=(self), geolocation=()"
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://plausible.unilien.app https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://plausible.unilien.app https://huggingface.co https://*.huggingface.co https://*.hf.co https://cdn.jsdelivr.net; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://plausible.unilien.app; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://plausible.unilien.app https://huggingface.co https://*.huggingface.co https://*.hf.co; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
 
     @assets path /assets/*


### PR DESCRIPTION
## Summary

Suite de la PR #362 (Silero VAD shippé). On self-host désormais les assets `onnxruntime-web` (`.wasm` + `.mjs`) via `vite-plugin-static-copy` à la racine de `dist/`, donc `cdn.jsdelivr.net` n'est plus chargé nulle part.

### Changements

- Caddyfile prod : retrait de `https://cdn.jsdelivr.net` de `script-src` et `connect-src`

## Test plan
- [x] Vérification locale : `grep jsdelivr infra/caddy/Caddyfile` → 0 résultat
- [ ] **Déploiement VPS prod** (manuel, par toi) :
  ```bash
  scp infra/caddy/Caddyfile <vps>:/tmp/Caddyfile.new
  ssh <vps> "sudo caddy validate --config /tmp/Caddyfile.new --adapter caddyfile && sudo cp /tmp/Caddyfile.new /etc/caddy/Caddyfile && sudo systemctl reload caddy"
  ```
- [ ] Smoke test post-deploy : ouvrir unilien.app, navigation vocale (FAB micro) → pas d'erreur CSP dans la console, VAD se charge depuis `/silero_vad_v5.onnx` et pas depuis jsdelivr

🤖 Generated with [Claude Code](https://claude.com/claude-code)