### PR TITLE
fix(voice): multi-alternative matching + Edge phonetic variants

### DIFF
--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -47,14 +47,23 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
   const startWhisperRef = useRef<() => Promise<void>>(async () => {})
 
   const handleResult = useCallback(
-    (heard: string) => {
-      setTranscript(heard)
-      const cmd = matchCommand(heard, profile?.role ?? null)
+    (heard: string | string[]) => {
+      const candidates = Array.isArray(heard) ? heard : [heard]
+      const primary = candidates[0] ?? ''
+      // 1ère alternative affichée comme "transcript", peu importe ce qui matche
+      setTranscript(primary)
+
+      // Tente toutes les alternatives ; la 1ère qui matche gagne.
+      let cmd = null
+      for (const alt of candidates) {
+        cmd = matchCommand(alt, profile?.role ?? null)
+        if (cmd) break
+      }
       setMatched(cmd)
       if (cmd) {
         navigate(cmd.path)
-      } else if (heard) {
-        setError(`Commande non reconnue : "${heard}"`)
+      } else if (primary) {
+        setError(`Commande non reconnue : "${primary}"`)
       }
     },
     [navigate, profile?.role],
@@ -70,11 +79,17 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
     recognition.lang = 'fr-FR'
     recognition.continuous = false
     recognition.interimResults = false
-    recognition.maxAlternatives = 1
+    // Edge/Chrome renvoient souvent la bonne transcription en 2e/3e alternative
+    // (Edge en particulier déraille beaucoup sur le FR). On lit jusqu'à 5
+    // alternatives et on prend la 1ère qui matche une commande.
+    recognition.maxAlternatives = 5
 
     recognition.onresult = (e: SpeechRecognitionEvent) => {
-      const heard = e.results[0]?.[0]?.transcript ?? ''
-      handleResult(heard)
+      const result = e.results[0]
+      if (!result) return
+      const alternatives = Array.from({ length: result.length }, (_, i) => result[i]?.transcript ?? '')
+        .filter(Boolean)
+      handleResult(alternatives)
     }
     recognition.onspeechstart = () => setSpeechDetected(true)
     recognition.onspeechend = () => setSpeechDetected(false)

--- a/src/lib/voice/voiceCommands.ts
+++ b/src/lib/voice/voiceCommands.ts
@@ -10,7 +10,7 @@ export interface VoiceCommand {
 // par Whisper (liaisons cassées, homophones) — elles permettent un match exact
 // sans dépendre du fuzzy.
 export const VOICE_COMMANDS: VoiceCommand[] = [
-  { phrases: ['tableau de bord', 'accueil', 'dashboard', 'tableau bord'], path: '/tableau-de-bord' },
+  { phrases: ['tableau de bord', 'accueil', 'dashboard', 'tableau bord', "t'as pris le debout", "t'a pris le debout", 'tableau du bord', 'tablo de bord'], path: '/tableau-de-bord' },
   { phrases: ['planning', 'agenda', 'calendrier', 'planing', 'plannings'], path: '/planning' },
   { phrases: ['équipe', 'equipe', 'auxiliaires', 'auxiliaire', 'et quitte', 'et quipe', 'équipée', 'équipes'], path: '/equipe', roles: ['employer'] },
   { phrases: ['messagerie', 'messages', 'chat', 'messagère', 'messagerit'], path: '/messagerie' },


### PR DESCRIPTION
## Summary

Edge transcrit le FR avec beaucoup d'à-peu-près : "tableau de bord" → "T'as pris le debout" (vu en prod). Distance Levenshtein trop grande pour le fuzzy matching → "Commande non reconnue".

### Changements

- **`maxAlternatives` 1 → 5** côté Web Speech API : Edge/Chrome donnent souvent la bonne réponse en 2e/3e alternative, on ne lisait que la 1ère
- **`handleResult` boucle sur toutes les alternatives**, prend la 1ère qui matche une commande. Le transcript affiché à l'utilisateur reste la 1ère alternative (pour qu'il voie ce que Edge a "compris" en premier)
- **Variantes phonétiques** ajoutées pour "tableau de bord" : `t'as pris le debout`, `t'a pris le debout`, `tableau du bord`, `tablo de bord`
- `handleResult` accepte maintenant `string | string[]` (back-compat Whisper qui passe toujours un string unique)

## Test plan
- [x] `npm run test:run` → 2333 passed / 4 skipped
- [x] `npm run lint` → 0 errors
- [x] `npm run typecheck` → OK
- [x] Test manuel Edge : "tableau de bord" → navigation OK
- [x] Test manuel Edge sur les autres commandes (planning, équipe, messagerie, ...) — si ça déraille encore, ajouter d'autres variantes phonétiques au cas par cas

🤖 Generated with [Claude Code](https://claude.com/claude-code)