### PR TITLE
fix(voice): translate browser mic errors into actionable French messages

### DIFF
--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAccessibilityStore } from '@/stores/authStore'
 import { useAuth } from '@/hooks/useAuth'
 import { matchCommand, type VoiceCommand } from '@/lib/voice/voiceCommands'
+import { formatVoiceError } from '@/lib/voice/errors'
 import { logger } from '@/lib/logger'
 
 export type VoiceEngine = 'native' | 'whisper' | 'unsupported'
@@ -188,8 +189,7 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       setStatus('idle')
     } catch (err) {
       logger.error('Whisper voice flow error', err)
-      const message = err instanceof Error ? err.message : 'Erreur inconnue'
-      setError(`Erreur micro/transcription : ${message}`)
+      setError(formatVoiceError(err))
       setStatus('error')
     }
   }, [handleResult])

--- a/src/lib/voice/errors.test.ts
+++ b/src/lib/voice/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { formatVoiceError } from './errors'
+
+describe('formatVoiceError', () => {
+  it('maps NotAllowedError to a permission-denied message', () => {
+    const err = new DOMException('blocked', 'NotAllowedError')
+    expect(formatVoiceError(err)).toContain('cadenas')
+  })
+
+  it('maps NotFoundError to a no-mic message', () => {
+    const err = new DOMException('no device', 'NotFoundError')
+    expect(formatVoiceError(err)).toContain('Aucun micro')
+  })
+
+  it('maps NotReadableError to a busy-mic message', () => {
+    const err = new DOMException('busy', 'NotReadableError')
+    expect(formatVoiceError(err)).toContain('autre application')
+  })
+
+  it('maps SecurityError to an HTTPS message', () => {
+    const err = new DOMException('insecure', 'SecurityError')
+    expect(formatVoiceError(err)).toContain('HTTPS')
+  })
+
+  it('falls back to the error message for unknown errors', () => {
+    expect(formatVoiceError(new Error('boom'))).toBe('boom')
+  })
+
+  it('falls back to a generic message for non-Error inputs', () => {
+    expect(formatVoiceError('weird')).toBe('Erreur inconnue')
+    expect(formatVoiceError(null)).toBe('Erreur inconnue')
+  })
+})

--- a/src/lib/voice/errors.ts
+++ b/src/lib/voice/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * Traduit les erreurs typiques du flow nav vocale (getUserMedia, MicVAD,
+ * Whisper) en messages français actionnables. Les codes DOMException de
+ * getUserMedia sont stables cross-browser ; on s'appuie dessus plutôt que
+ * sur les .message qui varient (ex: Firefox renvoie "The request is not
+ * allowed by the user agent or the platform in the current context" pour
+ * NotAllowedError, Chrome "Permission denied").
+ */
+export function formatVoiceError(err: unknown): string {
+  if (err instanceof DOMException || (err instanceof Error && 'name' in err)) {
+    switch (err.name) {
+      case 'NotAllowedError':
+        return "Accès au micro refusé. Clique sur l'icône cadenas à gauche de l'URL pour autoriser le micro, puis réessaie."
+      case 'NotFoundError':
+      case 'DevicesNotFoundError':
+        return 'Aucun micro détecté. Branche un micro et réessaie.'
+      case 'NotReadableError':
+      case 'TrackStartError':
+        return 'Micro inaccessible : il est probablement utilisé par une autre application.'
+      case 'OverconstrainedError':
+      case 'ConstraintNotSatisfiedError':
+        return "Le micro ne supporte pas la configuration requise."
+      case 'SecurityError':
+        return 'Le micro nécessite une connexion sécurisée (HTTPS) ou localhost.'
+      case 'AbortError':
+        return 'Capture annulée.'
+    }
+  }
+  if (err instanceof Error) return err.message
+  return 'Erreur inconnue'
+}


### PR DESCRIPTION
## Summary

Map les erreurs typiques de `getUserMedia` (DOMException codes) vers des messages français actionnables. Avant : on affichait le `err.message` brut du browser, par exemple sur Firefox `"The request is not allowed by the user agent or the platform in the current context"` — incompréhensible et non-actionnable pour un end-user. Après : `"Accès au micro refusé. Clique sur l'icône cadenas à gauche de l'URL pour autoriser le micro, puis réessaie."`

### Changements

- `src/lib/voice/errors.ts` — nouvelle fonction `formatVoiceError(err)` qui mappe les codes DOMException (`NotAllowedError`, `NotFoundError`, `NotReadableError`, `OverconstrainedError`, `SecurityError`, `AbortError`) vers des messages FR
- `src/lib/voice/errors.test.ts` — 6 tests unitaires
- `src/hooks/useVoiceNavigation.ts` — `startWhisper` utilise désormais `formatVoiceError(err)` au lieu du brut

## Test plan

- [x] `npm run lint` ✅
- [x] `npm run test:run` ✅ (2339 tests, +6)
- [x] Tester sur Firefox local : refuser la permission micro et vérifier que le message pointe vers l'icône cadenas
- [x] Vérifier que les autres flows (NotFoundError sur device sans micro, etc.) restent cohérents

🤖 Generated with [Claude Code](https://claude.com/claude-code)