### PR TITLE
feat(voice): pre-warm Whisper model on login when voice nav is enabled

### DIFF
--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -199,6 +199,33 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
     startWhisperRef.current = startWhisper
   }, [startWhisper])
 
+  // Pre-warm Whisper en background dès qu'on sait que la nav vocale est
+  // activée et que l'engine cible est Whisper. Évite ~12s de cold start au
+  // 1er clic FAB. Délai de 2s pour laisser le boot principal de l'app finir
+  // (le téléchargement modèle est ~400 Mo, on ne veut pas bouffer la bande
+  // passante pendant le 1er render).
+  useEffect(() => {
+    if (!enabled) return
+    if (engine !== 'whisper') return
+    let cancelled = false
+    const t = setTimeout(async () => {
+      if (cancelled) return
+      try {
+        const { getTranscriber, isWhisperLoaded } = await import('@/lib/voice/whisperEngine')
+        if (isWhisperLoaded()) return
+        logger.info('Whisper pre-warm starting')
+        await getTranscriber()
+        if (!cancelled) logger.info('Whisper pre-warm done')
+      } catch (err) {
+        logger.warn('Whisper pre-warm failed (non-fatal)', err)
+      }
+    }, 2000)
+    return () => {
+      cancelled = true
+      clearTimeout(t)
+    }
+  }, [enabled, engine])
+
   const start = useCallback(async () => {
     if (!enabled) return
     if (engine === 'native') startNative()


### PR DESCRIPTION
## Summary

Charge le modèle Whisper en background dès l'arrivée sur une page authentifiée si la nav vocale est activée (`voiceControlEnabled`) et que l'engine cible est Whisper (Firefox & browsers sans Web Speech API native). **Élimine les ~12s de cold start au 1er clic FAB.**

Délai de 2s avant de lancer le download (~400 Mo) pour ne pas concurrencer le boot principal de l'app.

### Changements

- `src/hooks/useVoiceNavigation.ts` — nouvel `useEffect` qui appelle `getTranscriber()` en background si `enabled && engine === 'whisper'`. Vérifie `isWhisperLoaded()` avant pour rester idempotent. Cleanup propre (cancelled flag + clearTimeout).

### Conditions de déclenchement

- User authentifié (le FAB n'est rendu que dans `DashboardLayout`)
- Toggle Paramètres > Accessibilité > Navigation vocale = ON
- Engine = `whisper` (Firefox principalement ; pas Chrome/Edge qui ont l'API native)
- Modèle pas encore chargé en cache mémoire (le browser cache via Cache API persiste entre sessions de toute façon)

## Test plan

- [ ] `npm run lint` ✅
- [ ] `npm run test:run` ✅ (2339 tests)
- [ ] Tester sur Firefox local : login → ouvrir DevTools console → après ~2s voir le log `Whisper pre-warm starting` puis `Whisper pre-warm done`
- [ ] Cliquer sur le FAB micro après le pre-warm : le `loading-engine` doit être quasi-instantané au lieu de ~12s
- [ ] Vérifier que sur Chrome/Edge (engine native) aucun pre-warm ne se déclenche (pas de log, pas de download)
- [ ] Désactiver le toggle nav vocale dans Paramètres → vérifier qu'aucun pre-warm n'est déclenché

🤖 Generated with [Claude Code](https://claude.com/claude-code)