### PR TITLE
feat(voice): preprocess audio before Whisper (trim + normalize)

### DIFF
--- a/src/lib/voice/audioPreprocessing.test.ts
+++ b/src/lib/voice/audioPreprocessing.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeAmplitude, preprocessAudio, trimSilence } from './audioPreprocessing'
+
+const SAMPLE_RATE = 16000
+const WINDOW_SIZE = (SAMPLE_RATE * 20) / 1000 // 320
+
+function makeSine(durationMs: number, freq: number, amplitude: number): Float32Array {
+  const n = Math.floor((SAMPLE_RATE * durationMs) / 1000)
+  const out = new Float32Array(n)
+  for (let i = 0; i < n; i++) {
+    out[i] = amplitude * Math.sin((2 * Math.PI * freq * i) / SAMPLE_RATE)
+  }
+  return out
+}
+
+function makeSilence(durationMs: number): Float32Array {
+  const n = Math.floor((SAMPLE_RATE * durationMs) / 1000)
+  return new Float32Array(n)
+}
+
+function concat(...parts: Float32Array[]): Float32Array {
+  const total = parts.reduce((acc, p) => acc + p.length, 0)
+  const out = new Float32Array(total)
+  let offset = 0
+  for (const p of parts) {
+    out.set(p, offset)
+    offset += p.length
+  }
+  return out
+}
+
+function peak(audio: Float32Array): number {
+  let max = 0
+  for (let i = 0; i < audio.length; i++) {
+    const abs = Math.abs(audio[i])
+    if (abs > max) max = abs
+  }
+  return max
+}
+
+describe('normalizeAmplitude', () => {
+  it('boosts a quiet signal to peak 0.95', () => {
+    const quiet = makeSine(100, 440, 0.1)
+    const out = normalizeAmplitude(quiet)
+    expect(peak(out)).toBeCloseTo(0.95, 2)
+    expect(out.length).toBe(quiet.length)
+  })
+
+  it('does not amplify silence (peak = 0)', () => {
+    const silent = makeSilence(100)
+    const out = normalizeAmplitude(silent)
+    expect(peak(out)).toBe(0)
+  })
+
+  it('returns audio unchanged when already at or above target', () => {
+    const loud = makeSine(100, 440, 0.98)
+    const out = normalizeAmplitude(loud)
+    expect(out).toBe(loud)
+  })
+
+  it('handles empty input', () => {
+    expect(normalizeAmplitude(new Float32Array(0)).length).toBe(0)
+  })
+})
+
+describe('trimSilence', () => {
+  it('removes leading and trailing silence', () => {
+    const audio = concat(makeSilence(200), makeSine(500, 440, 0.5), makeSilence(200))
+    const out = trimSilence(audio)
+    expect(out.length).toBeLessThan(audio.length)
+    expect(out.length).toBeGreaterThan(0.4 * SAMPLE_RATE) // au moins la majorité du sinus
+  })
+
+  it('keeps the original buffer when there is no silence to trim', () => {
+    const audio = makeSine(500, 440, 0.5)
+    const out = trimSilence(audio)
+    expect(out.length).toBe(audio.length)
+  })
+
+  it('preserves attack and release by leaving one window margin', () => {
+    const audio = concat(makeSilence(100), makeSine(300, 440, 0.5), makeSilence(100))
+    const out = trimSilence(audio)
+    // Doit garder au moins 1 fenêtre de marge de chaque côté = 40ms ~ 640 samples
+    expect(out.length).toBeGreaterThanOrEqual(0.3 * SAMPLE_RATE + WINDOW_SIZE)
+  })
+
+  it('returns original on pure silence', () => {
+    const silent = makeSilence(500)
+    const out = trimSilence(silent)
+    expect(out.length).toBe(silent.length)
+  })
+
+  it('handles very short audio (no trim)', () => {
+    const tiny = makeSine(10, 440, 0.5) // 160 samples < 2 fenêtres
+    expect(trimSilence(tiny).length).toBe(tiny.length)
+  })
+})
+
+describe('preprocessAudio', () => {
+  it('trims silence and normalizes amplitude in one shot', () => {
+    const audio = concat(makeSilence(200), makeSine(500, 440, 0.08), makeSilence(200))
+    const out = preprocessAudio(audio)
+
+    // Trimmed
+    expect(out.length).toBeLessThan(audio.length)
+    // Normalized vers ~0.95
+    expect(peak(out)).toBeGreaterThan(0.9)
+    expect(peak(out)).toBeLessThanOrEqual(0.95 + 1e-6)
+  })
+
+  it('does not break on pure silence (no normalize boost of nothing)', () => {
+    const silent = makeSilence(500)
+    const out = preprocessAudio(silent)
+    expect(peak(out)).toBe(0)
+  })
+})

--- a/src/lib/voice/audioPreprocessing.ts
+++ b/src/lib/voice/audioPreprocessing.ts
@@ -1,0 +1,83 @@
+// Preprocessing audio avant Whisper. But : compenser un micro faible et virer
+// le silence ajouté par le padding VAD (preSpeechPadFrames + redemptionFrames)
+// qui fait halluciner Whisper sur du quasi-rien.
+
+const SAMPLE_RATE = 16000
+const WINDOW_MS = 20
+const WINDOW_SIZE = (SAMPLE_RATE * WINDOW_MS) / 1000 // 320 samples
+const PEAK_TARGET = 0.95
+const SILENCE_RATIO = 10 // seuil dynamique = maxRMS / SILENCE_RATIO
+
+/**
+ * Normalise l'amplitude vers `PEAK_TARGET` (anti-clip headroom). No-op si
+ * l'audio est déjà silencieux (évite de booster un signal nul à l'infini).
+ */
+export function normalizeAmplitude(audio: Float32Array): Float32Array {
+  if (audio.length === 0) return audio
+
+  let peak = 0
+  for (let i = 0; i < audio.length; i++) {
+    const abs = Math.abs(audio[i])
+    if (abs > peak) peak = abs
+  }
+  if (peak === 0 || peak >= PEAK_TARGET) return audio
+
+  const gain = PEAK_TARGET / peak
+  const out = new Float32Array(audio.length)
+  for (let i = 0; i < audio.length; i++) out[i] = audio[i] * gain
+  return out
+}
+
+function rms(audio: Float32Array, start: number, end: number): number {
+  let sum = 0
+  for (let i = start; i < end; i++) sum += audio[i] * audio[i]
+  return Math.sqrt(sum / (end - start))
+}
+
+/**
+ * Trim le silence en tête et queue du buffer (laisse l'intérieur intact).
+ * Approche énergétique par fenêtre de 20ms, seuil dynamique relatif au pic.
+ * Garde une marge de 1 fenêtre de chaque côté pour ne pas couper l'attaque
+ * d'un phonème ou la fin d'une syllabe.
+ */
+export function trimSilence(audio: Float32Array): Float32Array {
+  if (audio.length <= WINDOW_SIZE * 2) return audio
+
+  const windowCount = Math.floor(audio.length / WINDOW_SIZE)
+  const rmsValues = new Float32Array(windowCount)
+  let maxRms = 0
+  for (let w = 0; w < windowCount; w++) {
+    const r = rms(audio, w * WINDOW_SIZE, (w + 1) * WINDOW_SIZE)
+    rmsValues[w] = r
+    if (r > maxRms) maxRms = r
+  }
+
+  if (maxRms === 0) return audio
+  const threshold = maxRms / SILENCE_RATIO
+
+  let firstActive = 0
+  while (firstActive < windowCount && rmsValues[firstActive] < threshold) firstActive++
+
+  let lastActive = windowCount - 1
+  while (lastActive > firstActive && rmsValues[lastActive] < threshold) lastActive--
+
+  // Marge d'une fenêtre de chaque côté pour préserver l'attaque/queue
+  const startWindow = Math.max(0, firstActive - 1)
+  const endWindow = Math.min(windowCount - 1, lastActive + 1)
+
+  const startSample = startWindow * WINDOW_SIZE
+  const endSample = (endWindow + 1) * WINDOW_SIZE
+
+  // Si le trim ne gagne rien (< 1 fenêtre de chaque côté), retourne l'original
+  if (startSample === 0 && endSample >= audio.length) return audio
+
+  return audio.slice(startSample, endSample)
+}
+
+/**
+ * Pipeline complet : trim d'abord (pour que le normalize calibre sur le vrai
+ * signal vocal et pas sur du silence), puis normalize.
+ */
+export function preprocessAudio(audio: Float32Array): Float32Array {
+  return normalizeAmplitude(trimSilence(audio))
+}

--- a/src/lib/voice/whisperEngine.ts
+++ b/src/lib/voice/whisperEngine.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/lib/logger'
+import { preprocessAudio } from './audioPreprocessing'
 
 // Le vocabulaire à biaiser dans Whisper. Whisper interprète ces mots comme du
 // "contexte" précédent (via le token <|startofprev|>) et augmente sensiblement
@@ -199,7 +200,12 @@ export async function getTranscriber(): Promise<Transcriber> {
 
 export async function transcribe(audio: Float32Array): Promise<string> {
   const transcriber = await getTranscriber()
-  logger.info(`[Whisper] transcribe start, audio.length=${audio.length} (${(audio.length / 16000).toFixed(2)}s)`)
+  // Trim silences (head/tail) + peak-normalize. Évite les hallucinations sur le
+  // padding VAD et compense un mic faible avant que Whisper voie le signal.
+  const processed = preprocessAudio(audio)
+  logger.info(
+    `[Whisper] transcribe start, audio.length=${processed.length} (${(processed.length / 16000).toFixed(2)}s, raw=${audio.length})`,
+  )
   const t0 = performance.now()
   try {
     const decoder_input_ids = buildDecoderInputIds(transcriber)
@@ -225,7 +231,7 @@ export async function transcribe(audio: Float32Array): Promise<string> {
       options.compression_ratio_threshold = 2.4
     }
 
-    const result = await transcriber(audio, options)
+    const result = await transcriber(processed, options)
     const rawText = (result?.text ?? '').trim()
     const text = decoder_input_ids ? stripVocabularyPrefix(rawText) : rawText
     logger.info(


### PR DESCRIPTION
## Summary
Ajoute un preprocessing audio entre la capture VAD et l'appel Whisper. Deux opérations chaînées sur le `Float32Array` 16 kHz :

1. **`trimSilence`** — découpe le silence en tête/queue via RMS par fenêtre 20ms, seuil dynamique `maxRMS / 10`, marge d'1 fenêtre de chaque côté pour préserver attaque/queue. Vise le padding VAD (`preSpeechPadFrames=10` + `redemptionFrames=48`) qui injecte du quasi-silence et fait halluciner Whisper.
2. **`normalizeAmplitude`** — peak-normalize à 0.95 (headroom anti-clip). Compense les micros faibles qui plafonnent à ~0.1-0.2 et restent sous la dynamique effective de Whisper.

L'ordre (trim → normalize) est important : sans trim d'abord, la normalisation se calibrerait sur du bruit/silence et boosterait des transitoires parasites.

### Changements
- `src/lib/voice/audioPreprocessing.ts` (nouveau) — helpers purs `normalizeAmplitude`, `trimSilence`, `preprocessAudio`
- `src/lib/voice/audioPreprocessing.test.ts` (nouveau) — 11 tests unitaires (sine waves, silence edges, edge cases)
- `src/lib/voice/whisperEngine.ts` — appel `preprocessAudio(audio)` en début de `transcribe()`, log élargi avec `raw=` pour debug du gain de trim

### Pourquoi pas l'approche "fenêtre `probs.isSpeech > 0.5`" (note V2 mémoire)
`@ricky0123/vad-web` n'expose pas les probas dans `onSpeechEnd` (juste le buffer concaténé avec padding). Faudrait accumuler manuellement via `onFrameProcessed` — complexité disproportionnée vs gain. Le trim énergétique simple coupe le même silence.

## Test plan
- [x] `npm run lint` — 0 erreur (2 warnings pré-existants hors scope)
- [x] `npm run test:run` — 2350 passed / 4 skipped (+11 nouveaux tests)
- [ ] Test manuel : commande vocale courte ("planning") — doit transcrire plus vite/proprement, surtout sur micro faible
- [ ] Vérifier logs DevTools : `audio.length=X (Xs, raw=Y)` avec `Y > X` quand trim effectif