### PR TITLE
feat(voice): add settings submenus and modal action intents

### DIFF
--- a/src/components/planning/PlanningPage.test.tsx
+++ b/src/components/planning/PlanningPage.test.tsx
@@ -23,11 +23,13 @@ vi.mock('@/components/planning/ShiftDetailModal', () => ({
 }))
 
 vi.mock('@/components/planning/NewShiftModal', () => ({
-  NewShiftModal: () => null,
+  NewShiftModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="new-shift-modal" /> : null,
 }))
 
 vi.mock('@/components/planning/AbsenceRequestModal', () => ({
-  AbsenceRequestModal: () => null,
+  AbsenceRequestModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="absence-request-modal" /> : null,
 }))
 
 vi.mock('@/components/planning/AbsenceDetailModal', () => ({
@@ -360,6 +362,51 @@ describe('PlanningPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/absence/i)).toBeInTheDocument()
+    })
+  })
+
+  // 13. URL intent ?action=new-shift ouvre la modale nouvelle intervention (employer)
+  describe('URL intent (voice nav actions)', () => {
+    beforeEach(() => {
+      // Reset l'URL entre chaque test pour ne pas polluer
+      window.history.replaceState({}, '', '/')
+    })
+
+    it('ouvre NewShiftModal pour un employer avec ?action=new-shift', async () => {
+      setupEmployerProfile()
+      window.history.replaceState({}, '', '/planning?action=new-shift')
+
+      renderWithProviders(<PlanningPage />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('new-shift-modal')).toBeInTheDocument()
+      })
+      // L'action a été nettoyée de l'URL
+      expect(window.location.search).not.toContain('action=new-shift')
+    })
+
+    it("n'ouvre pas NewShiftModal pour un employee même avec ?action=new-shift", async () => {
+      setupEmployeeProfile()
+      window.history.replaceState({}, '', '/planning?action=new-shift')
+
+      renderWithProviders(<PlanningPage />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('layout')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('new-shift-modal')).not.toBeInTheDocument()
+    })
+
+    it('ouvre AbsenceRequestModal pour un employee avec ?action=absence', async () => {
+      setupEmployeeProfile()
+      window.history.replaceState({}, '', '/planning?action=absence')
+
+      renderWithProviders(<PlanningPage />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('absence-request-modal')).toBeInTheDocument()
+      })
+      expect(window.location.search).not.toContain('action=absence')
     })
   })
 })

--- a/src/components/planning/PlanningPage.tsx
+++ b/src/components/planning/PlanningPage.tsx
@@ -115,6 +115,14 @@ export function PlanningPage() {
       newParams.delete('action')
       setSearchParams(newParams, { replace: true })
     }
+
+    // Ouvrir le modal nouvelle intervention si ?action=new-shift (employer uniquement)
+    if (searchParams.get('action') === 'new-shift' && profile?.role === 'employer') {
+      setIsNewShiftModalOpen(true)
+      const newParams = new URLSearchParams(searchParams)
+      newParams.delete('action')
+      setSearchParams(newParams, { replace: true })
+    }
   }, [searchParams, profile?.role, setSearchParams])
 
   // Calcul des dates selon le mode de vue

--- a/src/lib/voice/voiceCommands.test.ts
+++ b/src/lib/voice/voiceCommands.test.ts
@@ -114,10 +114,62 @@ describe('voiceCommands.matchCommand — fuzzy matching (Whisper typos)', () => 
   })
 })
 
+describe('voiceCommands.matchCommand — submenu navigation (settings)', () => {
+  it('matches "paramètres apparence" → /parametres#apparence (longer phrase wins)', () => {
+    const cmd = matchCommand('paramètres apparence', 'employer')
+    expect(cmd?.path).toBe('/parametres#apparence')
+  })
+
+  it('matches "paramètres notifications" → /parametres#notifications', () => {
+    const cmd = matchCommand('paramètres notifications', 'employee')
+    expect(cmd?.path).toBe('/parametres#notifications')
+  })
+
+  it('matches "paramètres sécurité" → /parametres#securite', () => {
+    const cmd = matchCommand('paramètres sécurité', 'caregiver')
+    expect(cmd?.path).toBe('/parametres#securite')
+  })
+
+  it('matches "paramètres accessibilité" → /parametres#accessibilite', () => {
+    const cmd = matchCommand('paramètres accessibilité', 'employer')
+    expect(cmd?.path).toBe('/parametres#accessibilite')
+  })
+
+  it('falls back to /parametres when only the prefix is heard', () => {
+    const cmd = matchCommand('paramètres', 'employer')
+    expect(cmd?.path).toBe('/parametres')
+  })
+})
+
+describe('voiceCommands.matchCommand — modal action intents', () => {
+  it('opens new shift modal for employer: "ajouter intervention"', () => {
+    const cmd = matchCommand('ajouter intervention', 'employer')
+    expect(cmd?.path).toBe('/planning?action=new-shift')
+  })
+
+  it('does not open new shift modal for employee (role gating)', () => {
+    const cmd = matchCommand('ajouter intervention', 'employee')
+    expect(cmd).toBeNull()
+  })
+
+  it('opens absence request modal for employee: "demander congé"', () => {
+    const cmd = matchCommand('demander congé', 'employee')
+    expect(cmd?.path).toBe('/planning?action=absence')
+  })
+
+  it('does not open absence modal for employer (role gating)', () => {
+    const cmd = matchCommand('demander absence', 'employer')
+    expect(cmd).toBeNull()
+  })
+})
+
 describe('voiceCommands.listAvailableCommands', () => {
-  it('returns all commands for employer', () => {
+  it('returns every command accessible to employer (including employer-only, excluding employee-only)', () => {
     const list = listAvailableCommands('employer')
-    expect(list.length).toBe(VOICE_COMMANDS.length)
+    const expected = VOICE_COMMANDS.filter((c) => !c.roles || c.roles.includes('employer'))
+    expect(list).toHaveLength(expected.length)
+    expect(list.find((c) => c.path === '/equipe')).toBeDefined()
+    expect(list.find((c) => c.path === '/planning?action=absence')).toBeUndefined()
   })
 
   it('filters out employer-only commands for caregiver', () => {

--- a/src/lib/voice/voiceCommands.ts
+++ b/src/lib/voice/voiceCommands.ts
@@ -22,6 +22,19 @@ export const VOICE_COMMANDS: VoiceCommand[] = [
   { phrases: ['paramètres', 'parametres', 'réglages', 'reglages', 'settings', 'paramètre'], path: '/parametres' },
   { phrases: ['aide', 'help', 'faq'], path: '/aide' },
   { phrases: ['contact', 'contacter', 'contacts'], path: '/contact' },
+
+  // Sous-menus paramètres — le matcher choisit la phrase la plus longue, donc
+  // "paramètres apparence" l'emporte sur "paramètres" seul.
+  { phrases: ['paramètres profil', 'parametres profil', 'paramètres informations', 'parametres informations'], path: '/parametres#profil' },
+  { phrases: ['paramètres sécurité', 'parametres securite', 'paramètres securite'], path: '/parametres#securite' },
+  { phrases: ['paramètres notifications', 'parametres notifications', 'paramètres notification', 'parametres notification'], path: '/parametres#notifications' },
+  { phrases: ['paramètres apparence', 'parametres apparence', 'apparence paramètres', 'paramètres thème', 'parametres theme'], path: '/parametres#apparence' },
+  { phrases: ['paramètres accessibilité', 'parametres accessibilite', 'paramètres accessibilite', 'accessibilité paramètres'], path: '/parametres#accessibilite' },
+
+  // Actions — pattern URL intent (?action=...). La page cible lit le query au
+  // mount, ouvre la modale, puis efface le param. Marche cross-page (nav + open).
+  { phrases: ['ajouter intervention', 'nouvelle intervention', 'créer intervention', 'creer intervention', 'ajouter une intervention', 'ajouter shift'], path: '/planning?action=new-shift', roles: ['employer'] },
+  { phrases: ['demander congé', 'demander conge', 'demander absence', 'demande absence', 'demande congé', 'demande conge', 'nouvelle absence'], path: '/planning?action=absence', roles: ['employee'] },
 ]
 
 const DIACRITICS = /[̀-ͯ]/g

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -122,6 +122,22 @@ describe('SettingsPage', () => {
       fireEvent.click(screen.getByText('Sécurité'))
       expect(screen.getByText('Changer le mot de passe')).toBeInTheDocument()
     })
+
+    it('réagit à un changement de hash pour la nav vocale (#apparence)', () => {
+      renderWithProviders(<SettingsPage />)
+      // Par défaut on est sur Profil
+      expect(screen.getByText('Informations personnelles')).toBeInTheDocument()
+
+      // Simule navigate('/parametres#apparence')
+      window.location.hash = '#apparence'
+      fireEvent(window, new HashChangeEvent('hashchange'))
+
+      // Le panel Apparence est maintenant actif (titre unique de la section)
+      expect(screen.getByText('Mode sombre')).toBeInTheDocument()
+
+      // Cleanup pour ne pas polluer le test suivant
+      window.location.hash = ''
+    })
   })
 
   // ── Panneau Profil ──

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -111,14 +111,28 @@ const NAV_SECTIONS: NavSection[] = [
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
+const VALID_PANELS: PanelId[] = ['profil', 'securite', 'abonnement', 'notifications', 'convention', 'pch', 'apparence', 'accessibilite', 'donnees']
+
+function panelFromHash(): PanelId | null {
+  const hash = window.location.hash.replace('#', '') as PanelId
+  return VALID_PANELS.includes(hash) ? hash : null
+}
+
 export function SettingsPage() {
   const { profile, userRole } = useAuth()
-  const initialPanel = (() => {
-    const hash = window.location.hash.replace('#', '') as PanelId
-    const validPanels: PanelId[] = ['profil', 'securite', 'abonnement', 'notifications', 'convention', 'pch', 'apparence', 'accessibilite', 'donnees']
-    return validPanels.includes(hash) ? hash : 'profil'
-  })()
-  const [activePanel, setActivePanel] = useState<PanelId>(initialPanel)
+  const [activePanel, setActivePanel] = useState<PanelId>(() => panelFromHash() ?? 'profil')
+
+  // Permet à la nav vocale de switcher de panel via /parametres#apparence même
+  // quand on est déjà sur la page (sans cet effect, navigate() change le hash
+  // mais le state interne reste sur l'ancien panel).
+  useEffect(() => {
+    const onHashChange = () => {
+      const next = panelFromHash()
+      if (next) setActivePanel(next)
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
   const navRef = useRef<HTMLDivElement>(null)
   const [showPrev, setShowPrev] = useState(false)
   const [showNext, setShowNext] = useState(false)


### PR DESCRIPTION
## Summary
Étend la nav vocale au-delà des pages top-level :
- **5 sous-menus paramètres** : "paramètres apparence/sécurité/notifications/profil/accessibilité" → `/parametres#<panel>`. `SettingsPage` écoute désormais `hashchange` pour réagir aussi quand on est déjà sur la page (sans cet effect, `navigate()` change le hash mais le state interne reste sur l'ancien panel).
- **2 actions via URL intent** (`?action=...`) :
  - "ajouter intervention" → `/planning?action=new-shift` (employer) ouvre `NewShiftModal`
  - "demander congé/absence" → `/planning?action=absence` (employee) ouvre `AbsenceRequestModal` (le handler existait déjà via `QuickActionsWidget`, maintenant atteignable par la voix)

### Pourquoi URL intent vs event bus / store global
- **Découplé** : la modale n'a besoin de rien savoir de la nav vocale, juste lire son `?action`
- **Bookmarkable / partageable** : `/planning?action=new-shift` reste utilisable hors voix
- **Résilient au "not mounted yet"** : on navigue d'abord, la page se monte, l'effect ouvre la modale → pas de race condition à gérer

### Changements
- `src/lib/voice/voiceCommands.ts` — 7 nouvelles commandes avec variantes phonétiques
- `src/pages/SettingsPage.tsx` — effect `hashchange` + extraction `panelFromHash()`
- `src/components/planning/PlanningPage.tsx` — bloc `?action=new-shift` (employer-only)
- Tests : `voiceCommands.test.ts` (+9), `SettingsPage.test.tsx` (+1), `PlanningPage.test.tsx` (+3)

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2363 passed / 4 skipped (+13 nouveaux)
- [x] Test manuel nav vocale : "paramètres apparence" doit ouvrir le panneau Apparence depuis n'importe quelle page
- [x] Test manuel nav vocale (employer) : "ajouter intervention" doit nav vers Planning + ouvrir la modale
- [x] Test manuel nav vocale (employee) : "demander congé" doit nav vers Planning + ouvrir la modale absence
- [x] Vérifier que l'URL est bien nettoyée après ouverture (pas de `?action=...` qui traîne)