### PR TITLE
feat(voice): visible feedback during Whisper transcription

### DIFF
--- a/src/components/voice/VoiceNavButton.test.tsx
+++ b/src/components/voice/VoiceNavButton.test.tsx
@@ -16,45 +16,75 @@ vi.mock('@/stores/authStore', async () => {
   }
 })
 
+// Override pour les tests de feedback : status forcé sans déclencher tout le flow audio
+const voiceState: {
+  enabled: boolean
+  status: 'idle' | 'loading-engine' | 'listening' | 'transcribing' | 'error'
+  engine: 'native' | 'whisper' | 'unsupported'
+} = { enabled: false, status: 'idle', engine: 'native' }
+vi.mock('@/hooks/useVoiceNavigation', () => ({
+  useVoiceNavigation: () => ({
+    enabled: voiceState.enabled,
+    status: voiceState.status,
+    engine: voiceState.engine,
+    transcript: '',
+    matched: null,
+    error: null,
+    modelProgress: 0,
+    speechDetected: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    toggle: vi.fn(),
+  }),
+}))
+
 import { VoiceNavButton } from './VoiceNavButton'
 
 describe('VoiceNavButton', () => {
   beforeEach(() => {
     accessibilityState.settings.voiceControlEnabled = false
+    voiceState.enabled = false
+    voiceState.status = 'idle'
+    voiceState.engine = 'native'
     Object.defineProperty(window, 'SpeechRecognition', { value: undefined, configurable: true })
     Object.defineProperty(window, 'webkitSpeechRecognition', { value: undefined, configurable: true })
   })
 
   it('does not render when voice control is disabled', () => {
-    accessibilityState.settings.voiceControlEnabled = false
+    voiceState.enabled = false
     renderWithProviders(<VoiceNavButton />)
     expect(screen.queryByLabelText(/navigation vocale/i)).not.toBeInTheDocument()
   })
 
   it('does not render when voice engine is unsupported', () => {
-    accessibilityState.settings.voiceControlEnabled = true
-    Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true })
+    voiceState.enabled = true
+    voiceState.engine = 'unsupported'
     renderWithProviders(<VoiceNavButton />)
     expect(screen.queryByLabelText(/navigation vocale/i)).not.toBeInTheDocument()
   })
 
   it('renders microphone button when enabled and engine is native', () => {
-    accessibilityState.settings.voiceControlEnabled = true
-    class FakeSR {
-      lang = ''
-      continuous = false
-      interimResults = false
-      maxAlternatives = 0
-      onresult: unknown = null
-      onend: unknown = null
-      onerror: unknown = null
-      start = vi.fn()
-      stop = vi.fn()
-      abort = vi.fn()
-    }
-    Object.defineProperty(window, 'SpeechRecognition', { value: FakeSR, configurable: true })
-
+    voiceState.enabled = true
+    voiceState.engine = 'native'
     renderWithProviders(<VoiceNavButton />)
     expect(screen.getByLabelText(/démarrer la navigation vocale/i)).toBeInTheDocument()
+  })
+
+  it('shows ANALYSE badge and "Transcription en cours" while transcribing', () => {
+    voiceState.enabled = true
+    voiceState.engine = 'whisper'
+    voiceState.status = 'transcribing'
+    renderWithProviders(<VoiceNavButton />)
+    expect(screen.getByText('ANALYSE')).toBeInTheDocument()
+    expect(screen.getByText(/transcription en cours/i)).toBeInTheDocument()
+  })
+
+  it('shows REC badge and "Parlez maintenant" while listening', () => {
+    voiceState.enabled = true
+    voiceState.engine = 'whisper'
+    voiceState.status = 'listening'
+    renderWithProviders(<VoiceNavButton />)
+    expect(screen.getByText('REC')).toBeInTheDocument()
+    expect(screen.getByText(/parlez maintenant/i)).toBeInTheDocument()
   })
 })

--- a/src/components/voice/VoiceNavButton.tsx
+++ b/src/components/voice/VoiceNavButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Box, Flex, IconButton, Text, VStack, HStack, Badge } from '@chakra-ui/react'
+import { Box, Flex, IconButton, Spinner, Text, VStack, HStack, Badge } from '@chakra-ui/react'
 import { NavIcon } from '@/components/ui'
 import { VoiceWave } from '@/components/voice/VoiceWave'
 import { useVoiceNavigation } from '@/hooks/useVoiceNavigation'
@@ -17,6 +17,9 @@ export function VoiceNavButton() {
     const handler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'v') {
         e.preventDefault()
+        // Affiche le popover même au raccourci clavier, sinon l'utilisateur n'a
+        // aucun feedback visuel pendant les 2-4s de transcription Whisper.
+        setShowHelp(true)
         toggle()
       }
     }
@@ -27,7 +30,8 @@ export function VoiceNavButton() {
   if (!enabled || engine === 'unsupported') return null
 
   const isListening = status === 'listening'
-  const isLoading = status === 'loading-engine' || status === 'transcribing'
+  const isTranscribing = status === 'transcribing'
+  const isLoading = status === 'loading-engine' || isTranscribing
   const commands = listAvailableCommands(profile?.role ?? null)
 
   const statusLabel = (() => {
@@ -68,9 +72,14 @@ export function VoiceNavButton() {
             </IconButton>
           </Flex>
 
-          <Text fontSize="xs" color="text.muted" mb={3} role="status" aria-live="polite">
-            {statusLabel}
-          </Text>
+          <HStack gap={2} mb={3} align="center" role="status" aria-live="polite">
+            {(isLoading || isTranscribing) && (
+              <Spinner size="xs" color="brand.500" borderWidth="2px" />
+            )}
+            <Text fontSize="xs" color="text.muted">
+              {statusLabel}
+            </Text>
+          </HStack>
 
           {transcript && (
             <Box mb={3} p={2} bg="bg.surface.hover" borderRadius="sm">
@@ -130,6 +139,16 @@ export function VoiceNavButton() {
                 '100%': { boxShadow: '0 0 0 0 rgba(229, 62, 62, 0)' },
               },
             }),
+            // Pulse plus douce en couleur brand pendant la transcription :
+            // signale visuellement que ça mouline (vs FAB neutre + spinner discret).
+            ...(isTranscribing && {
+              animation: 'voice-pulse-brand 1.2s ease-in-out infinite',
+              '@keyframes voice-pulse-brand': {
+                '0%': { boxShadow: '0 0 0 0 rgba(99, 102, 241, 0.45)' },
+                '70%': { boxShadow: '0 0 0 12px rgba(99, 102, 241, 0)' },
+                '100%': { boxShadow: '0 0 0 0 rgba(99, 102, 241, 0)' },
+              },
+            }),
             '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
           }}
         >
@@ -152,6 +171,21 @@ export function VoiceNavButton() {
             zIndex={1}
           >
             REC
+          </Badge>
+        )}
+
+        {isTranscribing && (
+          <Badge
+            colorPalette="brand"
+            position="absolute"
+            top="-4px"
+            right="-4px"
+            borderRadius="full"
+            fontSize="2xs"
+            px={2}
+            zIndex={1}
+          >
+            ANALYSE
           </Badge>
         )}
       </Box>

--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -46,9 +46,21 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
   const nativeRef = useRef<SpeechRecognition | null>(null)
   const abortRef = useRef(false)
   const startWhisperRef = useRef<() => Promise<void>>(async () => {})
+  // Timestamp de fin de parole (côté user) pour mesurer la latence perçue
+  // jusqu'à l'affichage du résultat. Whisper logge sa propre latence pipeline,
+  // ce ref capte la latence end-to-end ressentie par l'utilisateur.
+  const speechEndAtRef = useRef<number | null>(null)
 
   const handleResult = useCallback(
     (heard: string | string[]) => {
+      // Latence perçue : depuis la fin de parole jusqu'à l'affichage du
+      // résultat. Utile pour comparer engine natif vs Whisper en prod.
+      if (speechEndAtRef.current !== null) {
+        const latencyMs = Math.round(performance.now() - speechEndAtRef.current)
+        logger.info(`[Voice] end-to-end latency: ${latencyMs}ms`)
+        speechEndAtRef.current = null
+      }
+
       const candidates = Array.isArray(heard) ? heard : [heard]
       const primary = candidates[0] ?? ''
       // 1ère alternative affichée comme "transcript", peu importe ce qui matche
@@ -93,7 +105,10 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       handleResult(alternatives)
     }
     recognition.onspeechstart = () => setSpeechDetected(true)
-    recognition.onspeechend = () => setSpeechDetected(false)
+    recognition.onspeechend = () => {
+      setSpeechDetected(false)
+      speechEndAtRef.current = performance.now()
+    }
     recognition.onend = () => {
       setSpeechDetected(false)
       setStatus((s) => (s === 'listening' ? 'idle' : s))
@@ -176,6 +191,9 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
         onReady: () => setStatus('listening'),
         onSpeechStart: () => setSpeechDetected(true),
       })
+      // captureAudio resolve sur le speech end côté VAD → marque le moment T0
+      // pour mesurer la latence perçue jusqu'à handleResult.
+      speechEndAtRef.current = performance.now()
       setSpeechDetected(false)
       if (abortRef.current) {
         setStatus('idle')


### PR DESCRIPTION
## Summary
La phase `transcribing` (~2-4s avec whisper-small + beam search) était quasi muette visuellement : le FAB redevenait neutre, le seul indice était un petit spinner Chakra discret, et le raccourci clavier `Ctrl+Maj+V` n'ouvrait jamais le popover. Résultat : impossible de savoir si ça moulinait ou si c'était planté.

### Changements
- **`VoiceNavButton.tsx`**
  - Spinner animé Chakra à côté de "Transcription en cours…" dans le popover
  - Badge `ANALYSE` (couleur brand) + pulse douce brand sur le FAB pendant `transcribing` (vs `REC` rouge pendant `listening`)
  - `setShowHelp(true)` aussi au raccourci clavier — le popover s'ouvre toujours, plus juste au click
- **`useVoiceNavigation.ts`**
  - `speechEndAtRef` capturé à `onSpeechEnd` (chemin natif ET chemin Whisper)
  - Log `[Voice] end-to-end latency: Xms` dans `handleResult` — surfaces la latence perçue côté user à comparer à la latence pipeline interne loguée par `whisperEngine`

### Pourquoi pas étendre le mock useVoiceNavigation à toute la suite
Les 3 tests existants utilisaient le vrai hook avec mocks de deps. Pour tester `status: 'transcribing'` sans déclencher tout le flow audio, j'ai mocké le hook directement — refacto minimal, comportement vérifié au bon niveau d'isolation.

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2365 passed / 4 skipped (+2 nouveaux : badge ANALYSE + REC visibility)
- [ ] Test manuel Whisper : "planning" → après speech end, voir le badge ANALYSE + pulse brand + spinner popover pendant ~2-3s
- [ ] Test manuel raccourci clavier `Ctrl+Maj+V` : popover s'ouvre directement
- [ ] Vérifier en DevTools console : `[Voice] end-to-end latency: Xms` après chaque commande