### PR TITLE
fix(voice): revert manual decoder_input_ids prompt biasing

### DIFF
--- a/src/lib/voice/whisperEngine.ts
+++ b/src/lib/voice/whisperEngine.ts
@@ -1,112 +1,31 @@
 import { logger } from '@/lib/logger'
 import { preprocessAudio } from './audioPreprocessing'
 
-// Le vocabulaire à biaiser dans Whisper. Whisper interprète ces mots comme du
-// "contexte" précédent (via le token <|startofprev|>) et augmente sensiblement
-// la probabilité de les prédire. C'est l'équivalent du `initial_prompt`
-// d'OpenAI Whisper pour les commandes courtes à vocabulaire fixe.
-const VOCABULARY_PROMPT =
-  'tableau de bord, planning, équipe, messagerie, cahier de liaison, conformité, documents, analytique, paramètres, profil, aide, contact'
+// Note historique — Vocabulary prompt biasing (PR #366) retiré.
+//
+// L'idée originale : injecter "tableau de bord, planning, équipe..." dans
+// le préfixe `<|startofprev|>` pour biaiser Whisper vers nos commandes.
+//
+// Le problème observé en prod (11/05/2026) : Whisper régurgite le prompt
+// entier dans la sortie au lieu de l'utiliser comme contexte, puis génère
+// "et" et s'arrête. Latence +50% à cause de num_beams=3 × la regen du prompt.
+//
+// Cause racine : `transformers.js` ne supporte pas vraiment le pattern
+// `prompt_ids` du Whisper Python. L'override manuel via `decoder_input_ids`
+// fait que le decoder voit son propre prefix comme tokens à régénérer.
+//
+// Solution : revenir au décodage classique. Le matcher fuzzy + variantes
+// phonétiques dans `voiceCommands.ts` compense largement pour 12 commandes
+// courtes. Si on voulait revenir à du biasing, il faudrait passer par du
+// keyword spotting / acoustic matching, pas par le prompt prefix.
 
-type WhisperTokenizer = {
-  encode(text: string, options?: { add_special_tokens?: boolean }): number[]
-  convert_tokens_to_ids<T extends string | string[]>(tokens: T): T extends string ? number : number[]
-}
-
-type Transcriber = ((
+type Transcriber = (
   audio: Float32Array,
   options: Record<string, unknown>
-) => Promise<{ text: string }>) & {
-  tokenizer: WhisperTokenizer
-}
+) => Promise<{ text: string }>
 
 let transcriberPromise: Promise<Transcriber> | null = null
-let cachedDecoderInputIds: number[] | null = null
 let downloadProgress = 0
-
-/**
- * Whisper décode le préfixe `<|startofprev|>...prompt...` dans le texte de
- * sortie au lieu de le strip (contrairement au comportement Python d'OpenAI
- * Whisper). On retire manuellement le prompt du début de la transcription.
- *
- * Compare en mode normalisé (lowercase + sans accents + sans ponctuation/espaces)
- * pour résister aux libertés que Whisper peut prendre sur le prompt
- * (capitalisation, virgules, etc.).
- */
-function stripVocabularyPrefix(text: string): string {
-  const normalize = (s: string) =>
-    s
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/[̀-ͯ]/g, '')
-      .replace(/[\s,.;:!?'"`-]/g, '')
-  const normPrompt = normalize(VOCABULARY_PROMPT)
-  const normText = normalize(text)
-  if (!normText.startsWith(normPrompt)) return text
-
-  // Avance dans le texte original jusqu'à avoir consommé l'équivalent normalisé
-  // du prompt — c'est plus fiable que de slicer par longueur car Whisper peut
-  // ajouter/enlever espaces et ponctuation.
-  let i = 0
-  let consumed = 0
-  while (i < text.length && consumed < normPrompt.length) {
-    const c = normalize(text[i])
-    consumed += c.length
-    i++
-  }
-  return text.slice(i).trim()
-}
-
-/**
- * Construit le `decoder_input_ids` pour Whisper avec un préfixe de vocabulaire
- * cible. Format multilingual :
- *   [<|startofprev|>, ...promptTokens, <|startoftranscript|>, <|fr|>,
- *    <|transcribe|>, <|notimestamps|>]
- *
- * Mémoïsé : le prompt ne change pas pendant la session.
- */
-function buildDecoderInputIds(transcriber: Transcriber): number[] | null {
-  if (cachedDecoderInputIds) return cachedDecoderInputIds
-  try {
-    const tok = transcriber.tokenizer
-    const startOfPrev = tok.convert_tokens_to_ids('<|startofprev|>')
-    const startOfTranscript = tok.convert_tokens_to_ids('<|startoftranscript|>')
-    const lang = tok.convert_tokens_to_ids('<|fr|>')
-    const transcribeTok = tok.convert_tokens_to_ids('<|transcribe|>')
-    const noTimestamps = tok.convert_tokens_to_ids('<|notimestamps|>')
-
-    if (
-      typeof startOfPrev !== 'number' ||
-      typeof startOfTranscript !== 'number' ||
-      typeof lang !== 'number' ||
-      typeof transcribeTok !== 'number' ||
-      typeof noTimestamps !== 'number'
-    ) {
-      logger.warn('[Whisper] special tokens missing, skipping vocabulary prompt')
-      return null
-    }
-
-    // Espace en tête : convention Whisper (le tokenizer BPE génère un meilleur
-    // segmentage avec un espace prefix sur du texte non-initial).
-    const promptIds = tok.encode(' ' + VOCABULARY_PROMPT, { add_special_tokens: false })
-
-    cachedDecoderInputIds = [
-      startOfPrev,
-      ...promptIds,
-      startOfTranscript,
-      lang,
-      transcribeTok,
-      noTimestamps,
-    ]
-    logger.info(
-      `[Whisper] decoder prefix built: ${cachedDecoderInputIds.length} tokens (${promptIds.length} for vocabulary)`,
-    )
-    return cachedDecoderInputIds
-  } catch (err) {
-    logger.warn('[Whisper] could not build decoder prefix, falling back to default', err)
-    return null
-  }
-}
 
 // Bump quand on change de modèle pour purger l'ancien cache des users existants.
 // Sans ça, l'ancien whisper-base resterait dans le Cache API du browser ad vitam.
@@ -208,34 +127,22 @@ export async function transcribe(audio: Float32Array): Promise<string> {
   )
   const t0 = performance.now()
   try {
-    const decoder_input_ids = buildDecoderInputIds(transcriber)
-    // Décodage déterministe (temperature 0) — base commune.
-    // num_beams=3 : beam search au lieu du greedy decoding. Compatible avec
-    // decoder_input_ids (pas de conflit comme no_repeat_ngram_size). Latence
-    // +50% environ, mais qualité notablement meilleure sur audio court / commandes.
+    // Décodage classique + anti-hallucination — pas de prompt biasing (cf.
+    // note historique en haut de fichier). num_beams=3 reste pour explorer
+    // plusieurs hypothèses sur les commandes courtes.
     const options: Record<string, unknown> = {
       language: 'french',
       task: 'transcribe',
       temperature: 0,
       num_beams: 3,
-    }
-    if (decoder_input_ids) {
-      // Avec prompt : on biaise déjà vers notre vocabulaire, donc l'anti-
-      // hallucination devient contre-productive (no_repeat_ngram_size=3 bloque
-      // les commandes du prompt comme "tableau de bord" puisque leur 3-gram
-      // existe déjà dans le préfixe → Whisper s'arrête au 1er mot).
-      options.decoder_input_ids = decoder_input_ids
-    } else {
-      // Sans prompt : anti-hallucination classique sur commandes courtes.
-      options.no_repeat_ngram_size = 3
-      options.compression_ratio_threshold = 2.4
+      no_repeat_ngram_size: 3,
+      compression_ratio_threshold: 2.4,
     }
 
     const result = await transcriber(processed, options)
-    const rawText = (result?.text ?? '').trim()
-    const text = decoder_input_ids ? stripVocabularyPrefix(rawText) : rawText
+    const text = (result?.text ?? '').trim()
     logger.info(
-      `[Whisper] transcribe done in ${Math.round(performance.now() - t0)}ms → "${text}"${rawText !== text ? ` (raw: "${rawText.slice(0, 60)}...")` : ''}`,
+      `[Whisper] transcribe done in ${Math.round(performance.now() - t0)}ms → "${text}"`,
     )
     return text
   } catch (err) {


### PR DESCRIPTION
## Summary
En prod (11/05/2026), Whisper se met à renvoyer "et" tout seul sur 3s de parole, avec la sortie brute qui régurgite le vocabulary prompt complet (`"tableau de bord, planning, équipe, messagerie, cahier de lia..."`) puis lâche "et" et s'arrête. Latence : ~12s.

Logs :
```
[Whisper] transcribe done in 11518ms → "et" (raw: "tableau de bord, planning, équipe, messagerie, cahier de lia...")
[Voice] end-to-end latency: 11536ms
```

### Cause racine
`transformers.js` ne supporte pas vraiment le pattern `prompt_ids` de Whisper Python. L'override manuel via `kwargs.decoder_input_ids` (PR #366) faisait que le decoder voyait son propre vocabulary prefix comme des tokens à **régénérer**, puis terminait la transcription quasi-immédiatement. `num_beams=3` (PR #367) amplifiait le coût en explorant 3 beams qui convergeaient tous vers la même impasse.

Le piège était déjà documenté dans la mémoire des PRs (`no_repeat_ngram_size` conflit avec `prompt_ids`, transformers.js déclare `prompt_ids` mais ne l'utilise pas dans le pipeline ASR) — la conclusion logique aurait été de ne PAS forcer le decoder.

### Changements
- `whisperEngine.ts` :
  - Supprime `VOCABULARY_PROMPT`, `buildDecoderInputIds`, `stripVocabularyPrefix`, `cachedDecoderInputIds`
  - Réactive `no_repeat_ngram_size=3` + `compression_ratio_threshold=2.4` (anti-hallucination classique, qui n'entrait en conflit qu'avec le prompt biasing désormais retiré)
  - Garde `num_beams=3` — indépendant du sujet, utile sur les commandes courtes
- Note historique laissée en haut de fichier pour ne pas re-tomber dans le piège.

### Pourquoi pas de fallback compensatoire ajouté
Le fuzzy matching de `voiceCommands.ts` + les variantes phonétiques manuelles (variantes Whisper FR mal segmentées, alternatives Edge) couvrent déjà largement les 12 commandes, y compris pour des transcriptions imparfaites — ce qui sert aussi les utilisateurs à voix atypique (cible Unilien).

### Suite éventuelle
Si la transcription "vanille" reste insuffisante pour les voix très atypiques, un chantier V2 envisageable : **keyword spotting acoustique** (matcher l'audio directement aux 12 commandes via embeddings type wav2vec, sans passer par la transcription). Pas dans le scope de cette PR.

## Test plan
- [x] `npm run typecheck` — OK
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2365 passed / 4 skipped (les tests existants ne mockaient pas le prompt biasing, rien à ajuster)
- [ ] Test manuel Whisper : "planning" / "tableau de bord" / "paramètres" sur voix standard → transcription correcte, latence ~3-4s
- [ ] Vérifier en DevTools : plus de log `[Whisper] decoder prefix built: 42 tokens` au démarrage
- [ ] Vérifier que la raw output ne contient plus le vocabulary prompt regurgité