### PR TITLE
feat(dashboard): add empty state for employee dashboard

### DIFF
--- a/docs/PROTOTYPE_GAP_CHECKLIST.md
+++ b/docs/PROTOTYPE_GAP_CHECKLIST.md
@@ -47,7 +47,7 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 - [x] **Tendances stats** — indicateurs tendance sur les stats cards (fleche haut/bas, +1, +8%) ✅
 - [x] **Quick actions** — grille 2x2/4 de boutons par role (existait deja : QuickActionsWidget) ✅
 - [x] **Alertes conformite sidebar** — liste detaillee des alertes (icone, titre, description, niveau) ✅
-- [ ] **Empty state dashboard** — variante onboarding quand aucun employe/intervention
+- [x] **Empty state dashboard** — variante onboarding quand aucun employe/intervention ✅ _(EmployerDashboard.tsx:30 + EmployeeDashboard.tsx:24 — "Aucun contrat actif" pour auxi)_
 
 ---
 
@@ -180,7 +180,7 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 | Bloc | Items | Done | Priorite |
 |------|-------|------|----------|
 | Settings | 22 | 22 | ✅ Termine |
-| Dashboard | 11 | 9 | Basse (demo banner, empty state) |
+| Dashboard | 11 | 10 | Basse (demo banner) |
 | Landing | 11 | 11 | ✅ Termine |
 | Compliance | 9 | 9 | ✅ Termine |
 | Profile | 9 | 9 | ✅ Termine |
@@ -192,4 +192,4 @@ Page `/parametres` implementee avec navigation par panneaux (SettingsPage.tsx).
 | Planning | 4 | 4 | ✅ Termine |
 | Documents | 3 | 3 | ✅ Termine |
 | Patterns UI | 4 | 3 | Basse |
-| **Total** | **102** | **99** | — |
+| **Total** | **102** | **100** | — |

--- a/src/components/dashboard/EmployeeDashboard.test.tsx
+++ b/src/components/dashboard/EmployeeDashboard.test.tsx
@@ -55,6 +55,16 @@ vi.mock('@/services/shiftService', () => ({
   getShifts: (...args: unknown[]) => mockGetShifts(...args),
 }))
 
+// Mock Supabase — requête contracts pour hasContracts
+const mockSupabaseChain = {
+  from: vi.fn(),
+}
+vi.mock('@/lib/supabase/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockSupabaseChain.from(...args),
+  },
+}))
+
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const profile = createMockProfile({ id: 'employee-1', role: 'employee', firstName: 'Marc' })
@@ -62,9 +72,20 @@ const profile = createMockProfile({ id: 'employee-1', role: 'employee', firstNam
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('EmployeeDashboard', () => {
+  function mockHasContracts(count: number) {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn((cb: (v: { count: number }) => void) => Promise.resolve(cb({ count }))),
+    }
+    mockSupabaseChain.from.mockReturnValue(chain)
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetShifts.mockResolvedValue([])
+    // Par défaut : 1 contrat actif → affiche les widgets principaux
+    mockHasContracts(1)
   })
 
   describe('Composition des widgets', () => {
@@ -149,6 +170,49 @@ describe('EmployeeDashboard', () => {
       await waitFor(() => {
         expect(screen.getByTestId('welcome-card')).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('Empty state — aucun contrat actif', () => {
+    it('affiche le message vide et masque les widgets principaux quand aucun contrat actif', async () => {
+      mockHasContracts(0)
+      renderWithProviders(<EmployeeDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByText('Aucun contrat actif pour le moment')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('stats-widget')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('employee-shift-timeline')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('employee-hours-progress')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('employee-leave-widget')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('employee-documents-widget')).not.toBeInTheDocument()
+    })
+
+    it('affiche les CTAs "Compléter mon profil" et "Centre d\'aide" dans le empty state', async () => {
+      mockHasContracts(0)
+      renderWithProviders(<EmployeeDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByText('Compléter mon profil')).toBeInTheDocument()
+        expect(screen.getByText("Centre d'aide")).toBeInTheDocument()
+      })
+    })
+
+    it('affiche toujours WelcomeCard et OnboardingWidget même en empty state', async () => {
+      mockHasContracts(0)
+      renderWithProviders(<EmployeeDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByTestId('welcome-card')).toBeInTheDocument()
+        expect(screen.getByTestId('onboarding-widget')).toBeInTheDocument()
+      })
+    })
+
+    it('affiche les widgets principaux quand il y a des contrats actifs', async () => {
+      mockHasContracts(2)
+      renderWithProviders(<EmployeeDashboard profile={profile} />)
+      await waitFor(() => {
+        expect(screen.getByTestId('employee-shift-timeline')).toBeInTheDocument()
+        expect(screen.getByTestId('stats-widget')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Aucun contrat actif pour le moment')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/dashboard/EmployeeDashboard.tsx
+++ b/src/components/dashboard/EmployeeDashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
-import { Grid, GridItem } from '@chakra-ui/react'
+import { Link as RouterLink } from 'react-router-dom'
+import { Box, Flex, Grid, GridItem, Text } from '@chakra-ui/react'
 import type { Profile, Shift } from '@/types'
 import {
   WelcomeCard,
@@ -12,9 +13,62 @@ import {
   ClockInWidget,
   OnboardingWidget,
 } from './widgets'
+import { AccessibleButton } from '@/components/ui'
 import { getShifts } from '@/services/shiftService'
+import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 import { FEATURES } from '@/lib/featureFlags'
+
+// ─── Empty state — aucun contrat actif ───────────────────────────────────────
+
+function EmptyEmployeeDashboardState() {
+  return (
+    <Box
+      bg="bg.surface"
+      borderWidth="1.5px"
+      borderColor="border.default"
+      borderRadius="14px"
+      boxShadow="sm"
+      textAlign="center"
+      py={14}
+      px={8}
+    >
+      <Flex
+        align="center"
+        justify="center"
+        w="64px"
+        h="64px"
+        mx="auto"
+        mb={5}
+        bg="bg.muted"
+        borderRadius="16px"
+        color="text.muted"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" width="32" height="32" aria-hidden="true">
+          <rect x="3" y="4" width="18" height="18" rx="2" />
+          <path d="M16 2v4M8 2v4M3 10h18" />
+        </svg>
+      </Flex>
+
+      <Text fontWeight="700" fontSize="lg" color="text.default" mb={2}>
+        Aucun contrat actif pour le moment
+      </Text>
+      <Text fontSize="sm" color="text.muted" maxW="420px" mx="auto" mb={7} lineHeight="1.6">
+        Votre profil est prêt. Un employeur particulier pourra vous proposer des interventions
+        en vous ajoutant à son équipe. Pensez à compléter votre profil pour faciliter la mise en relation.
+      </Text>
+
+      <Flex gap={3} justify="center" flexWrap="wrap">
+        <AccessibleButton colorPalette="brand" asChild accessibleLabel="Compléter mon profil">
+          <RouterLink to="/profil">Compléter mon profil</RouterLink>
+        </AccessibleButton>
+        <AccessibleButton variant="outline" asChild accessibleLabel="Consulter l'aide">
+          <RouterLink to="/aide">Centre d'aide</RouterLink>
+        </AccessibleButton>
+      </Flex>
+    </Box>
+  )
+}
 
 interface EmployeeDashboardProps {
   profile: Profile
@@ -25,6 +79,17 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
   const [isLoadingShifts, setIsLoadingShifts] = useState(true)
   const [activeShift, setActiveShift] = useState<Shift | null>(null)
   const [todayShiftCount, setTodayShiftCount] = useState(0)
+  const [hasContracts, setHasContracts] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    supabase
+      .from('contracts')
+      .select('id', { count: 'exact', head: true })
+      .eq('employee_id', profile.id)
+      .eq('status', 'active')
+      .then(({ count }) => setHasContracts((count ?? 0) > 0))
+      .catch(() => setHasContracts(false))
+  }, [profile.id])
 
   useEffect(() => {
     async function loadUpcomingShifts() {
@@ -93,45 +158,57 @@ export function EmployeeDashboard({ profile }: EmployeeDashboardProps) {
         <OnboardingWidget profile={profile} userRole="employee" />
       </GridItem>
 
-      {/* 3. Stats — full width */}
-      <GridItem order={{ base: 8, lg: 0 }} gridColumn={{ base: '1', lg: '1 / -1' }} gridRow={{ lg: '3' }}>
-        <StatsWidget userRole="employee" profileId={profile.id} />
-      </GridItem>
-
-      {/* 4. Timeline — main col */}
-      <GridItem order={{ base: 2, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '4' }}>
-        <EmployeeShiftTimeline employeeId={profile.id} />
-      </GridItem>
-
-      {/* 4. Clock-in — aside col */}
-      {FEATURES.clockIn && (
-        <GridItem order={{ base: 4, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '4' }}>
-          <ClockInWidget
-            hasActiveShift={!!activeShift}
-            activeShiftLabel={activeShift ? `Intervention ${activeShift.startTime.slice(0, 5)} – ${activeShift.endTime.slice(0, 5)}` : undefined}
-          />
+      {/* Empty state — aucun contrat actif */}
+      {hasContracts === false && (
+        <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ base: '1', lg: '1 / -1' }} gridRow={{ lg: '3' }}>
+          <EmptyEmployeeDashboardState />
         </GridItem>
       )}
 
-      {/* 5. Heures du mois — main col */}
-      <GridItem order={{ base: 5, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '5' }}>
-        <EmployeeHoursProgress employeeId={profile.id} />
-      </GridItem>
+      {/* Widgets principaux — uniquement si au moins un contrat actif */}
+      {hasContracts && (
+        <>
+          {/* 3. Stats — full width */}
+          <GridItem order={{ base: 8, lg: 0 }} gridColumn={{ base: '1', lg: '1 / -1' }} gridRow={{ lg: '3' }}>
+            <StatsWidget userRole="employee" profileId={profile.id} />
+          </GridItem>
 
-      {/* 5. Messages — aside col (remonte d'une row si clock-in désactivé) */}
-      <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: FEATURES.clockIn ? '5' : '4' }}>
-        <RecentMessagesWidget userId={profile.id} />
-      </GridItem>
+          {/* 4. Timeline — main col */}
+          <GridItem order={{ base: 2, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '4' }}>
+            <EmployeeShiftTimeline employeeId={profile.id} />
+          </GridItem>
 
-      {/* 6. Congés & absences — main col */}
-      <GridItem order={{ base: 6, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '6' }}>
-        <EmployeeLeaveWidget employeeId={profile.id} />
-      </GridItem>
+          {/* 4. Clock-in — aside col */}
+          {FEATURES.clockIn && (
+            <GridItem order={{ base: 4, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: '4' }}>
+              <ClockInWidget
+                hasActiveShift={!!activeShift}
+                activeShiftLabel={activeShift ? `Intervention ${activeShift.startTime.slice(0, 5)} – ${activeShift.endTime.slice(0, 5)}` : undefined}
+              />
+            </GridItem>
+          )}
 
-      {/* 6. Mes documents — aside col (remonte d'une row si clock-in désactivé) */}
-      <GridItem order={{ base: 7, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: FEATURES.clockIn ? '6' : '5' }}>
-        <EmployeeDocumentsWidget employeeId={profile.id} />
-      </GridItem>
+          {/* 5. Heures du mois — main col */}
+          <GridItem order={{ base: 5, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '5' }}>
+            <EmployeeHoursProgress employeeId={profile.id} />
+          </GridItem>
+
+          {/* 5. Messages — aside col (remonte d'une row si clock-in désactivé) */}
+          <GridItem order={{ base: 3, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: FEATURES.clockIn ? '5' : '4' }}>
+            <RecentMessagesWidget userId={profile.id} />
+          </GridItem>
+
+          {/* 6. Congés & absences — main col */}
+          <GridItem order={{ base: 6, lg: 0 }} gridColumn={{ lg: '1' }} gridRow={{ lg: '6' }}>
+            <EmployeeLeaveWidget employeeId={profile.id} />
+          </GridItem>
+
+          {/* 6. Mes documents — aside col (remonte d'une row si clock-in désactivé) */}
+          <GridItem order={{ base: 7, lg: 0 }} gridColumn={{ lg: '2' }} gridRow={{ lg: FEATURES.clockIn ? '6' : '5' }}>
+            <EmployeeDocumentsWidget employeeId={profile.id} />
+          </GridItem>
+        </>
+      )}
     </Grid>
   )
 }


### PR DESCRIPTION
## Summary
Ajoute une variante d'onboarding sur le dashboard auxiliaire quand aucun contrat n'est encore actif. Aligne le comportement sur l'`EmptyDashboardState` existant côté employer pour cohérence visuelle et structurelle.

Avant : l'auxiliaire fraîchement inscrit voit un dashboard rempli de widgets vides (timeline vide, heures à 0, etc.) tant qu'aucun employeur ne lui a créé de contrat → expérience d'onboarding frustrante.

Après : tant que `hasContracts === false`, on affiche une carte d'empty state avec 2 CTAs ; les widgets principaux n'apparaissent qu'une fois au moins un contrat actif.

### Changements
- `EmployeeDashboard.tsx` : composant `EmptyEmployeeDashboardState` (style aligné sur la version employer) + détection `hasContracts` via query Supabase sur `contracts (employee_id, status='active')` + widgets principaux conditionnés (timeline, stats, heures, congés, documents)
- `WelcomeCard` + `OnboardingWidget` restent toujours visibles
- 2 CTAs : "Compléter mon profil" → `/profil`, "Centre d'aide" → `/aide`
- Tests : mock supabase + 4 tests empty state (rendu, CTAs, persistance Welcome/Onboarding, bascule quand contrats > 0)
- Checklist : Dashboard 9 → 10, total 99 → 100

## Test plan
- [x] Compte auxiliaire fraîchement créé (0 contrat) → empty state visible, widgets masqués
- [ ] CTAs "Compléter mon profil" et "Centre d'aide" naviguent vers les bonnes routes
- [ ] WelcomeCard + OnboardingWidget restent visibles dans les deux cas
- [x] Tests automatisés passent (2372 / 4 skipped)
- [x] `npm run lint` OK
- [x] `npm run typecheck` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)