### PR TITLE
feat(liaison): unread badge in sidebar + fix mark-as-read RLS bug

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -11,6 +11,7 @@ import {
   Link,
 } from '@chakra-ui/react'
 import { useAuth } from '@/hooks/useAuth'
+import { useLiaisonUnreadCount } from '@/hooks/useLiaisonUnreadCount'
 import { useNotifications } from '@/hooks/useNotifications'
 import { DevelopmentBanner, NavIcon } from '@/components/ui'
 import { NotificationBell, NotificationsPanel } from '@/components/notifications'
@@ -94,6 +95,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
   const { profile, userRole, signOut } = useAuth()
   const location = useLocation()
   const spotlight = useSpotlightSearch()
+  const liaisonUnreadCount = useLiaisonUnreadCount(profile?.id)
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [isNotificationsPanelOpen, setIsNotificationsPanelOpen] = useState(false)
   const [caregiverPermissions, setCaregiverPermissions] = useState<CaregiverPermissions | null>(null)
@@ -543,11 +545,16 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
                 <Stack gap={0}>
                   {visibleItems.map((item) => {
                     const isActive = location.pathname === item.href
+                    const showUnreadDot = item.href === '/messagerie' && liaisonUnreadCount > 0
                     return (
                       <Link
                         key={item.href}
                         asChild
-                        aria-label={item.ariaLabel}
+                        aria-label={
+                          showUnreadDot
+                            ? `${item.ariaLabel} (${liaisonUnreadCount} non lu${liaisonUnreadCount > 1 ? 's' : ''})`
+                            : item.ariaLabel
+                        }
                         aria-current={isActive ? 'page' : undefined}
                         css={{ marginInline: '5px', width: 'calc(100% - 10px)', display: 'block' }}
                       >
@@ -575,7 +582,23 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
                             }}
                             minH="40px"
                           >
-                            <NavIcon name={item.icon} />
+                            <Box position="relative" display="inline-flex">
+                              <NavIcon name={item.icon} />
+                              {showUnreadDot && (
+                                <Box
+                                  position="absolute"
+                                  top="-2px"
+                                  right="-3px"
+                                  w="8px"
+                                  h="8px"
+                                  borderRadius="full"
+                                  bg="red.500"
+                                  borderWidth="1.5px"
+                                  borderColor="bg.surface"
+                                  aria-hidden="true"
+                                />
+                              )}
+                            </Box>
                             <Text>{getNavLabel(item)}</Text>
                           </Flex>
                         </RouterLink>

--- a/src/components/liaison/LiaisonPage.tsx
+++ b/src/components/liaison/LiaisonPage.tsx
@@ -257,7 +257,7 @@ export function LiaisonPage() {
         const result = await getLiaisonMessages(selectedConv.id)
         setMessages(result.messages)
         setHasMore(result.hasMore)
-        await markAllMessagesAsRead(selectedConv.id, profile.id)
+        await markAllMessagesAsRead(selectedConv.id)
         // Mettre à jour le compteur non lu localement
         setConversations(prev =>
           prev.map(c => c.id === selectedConv.id ? { ...c, unreadCount: 0 } : c)

--- a/src/hooks/useLiaisonUnreadCount.ts
+++ b/src/hooks/useLiaisonUnreadCount.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase/client'
+import { getUnreadCountForUser } from '@/services/liaisonService'
+import { logger } from '@/lib/logger'
+
+/**
+ * Compteur global de messages non lus pour l'utilisateur courant
+ * (toutes conversations confondues). Fetch initial + subscription
+ * realtime aux INSERT / UPDATE sur liaison_messages — recompte à
+ * chaque event pour rester synchro avec le marquage côté serveur.
+ */
+export function useLiaisonUnreadCount(userId: string | undefined): number {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!userId) return
+
+    let cancelled = false
+
+    async function refresh() {
+      try {
+        const n = await getUnreadCountForUser(userId!)
+        if (!cancelled) setCount(n)
+      } catch (err) {
+        logger.error('useLiaisonUnreadCount refresh failed:', err)
+      }
+    }
+
+    refresh()
+
+    const channel = supabase
+      .channel(`liaison-unread-${userId}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'liaison_messages' },
+        () => refresh(),
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'liaison_messages' },
+        () => refresh(),
+      )
+      .subscribe()
+
+    return () => {
+      cancelled = true
+      supabase.removeChannel(channel)
+    }
+  }, [userId])
+
+  return count
+}

--- a/src/services/liaisonService.test.ts
+++ b/src/services/liaisonService.test.ts
@@ -21,12 +21,14 @@ import { sanitizeText } from '@/lib/sanitize'
 const mockFrom = vi.fn()
 const mockChannel = vi.fn()
 const mockRemoveChannel = vi.fn()
+const mockRpc = vi.fn()
 
 vi.mock('@/lib/supabase/client', () => ({
   supabase: {
     from: (...args: unknown[]) => mockFrom(...args),
     channel: (...args: unknown[]) => mockChannel(...args),
     removeChannel: (...args: unknown[]) => mockRemoveChannel(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
   },
 }))
 
@@ -519,30 +521,20 @@ describe('markMessageAsRead', () => {
 // ============================================
 
 describe('markAllMessagesAsRead', () => {
-  it('met a jour chaque message non lu dans la conversation', async () => {
-    const unreadMessages = [
-      { id: 'msg-001', read_by: ['other-user'] },
-      { id: 'msg-002', read_by: [] },
-    ]
-    mockSupabaseQuerySequence([
-      { data: unreadMessages, error: null },
-      { data: null, error: null },
-      { data: null, error: null },
-    ])
+  it('appelle la RPC mark_liaison_messages_read avec le conversationId', async () => {
+    mockRpc.mockResolvedValueOnce({ data: 2, error: null })
 
-    await markAllMessagesAsRead(CONV_ID, USER_ID)
+    await markAllMessagesAsRead(CONV_ID)
 
-    // 1 fetch + 2 updates = 3 appels a from()
-    expect(mockFrom).toHaveBeenCalledTimes(3)
+    expect(mockRpc).toHaveBeenCalledWith('mark_liaison_messages_read', {
+      p_conversation_id: CONV_ID,
+    })
   })
 
-  it('retourne sans erreur si le fetch echoue', async () => {
-    mockSupabaseQuery({
-      data: null,
-      error: { message: 'Fetch error' },
-    })
+  it('retourne sans erreur si la RPC échoue', async () => {
+    mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'RPC error' } })
 
-    await expect(markAllMessagesAsRead(CONV_ID, USER_ID)).resolves.toBeUndefined()
+    await expect(markAllMessagesAsRead(CONV_ID)).resolves.toBeUndefined()
   })
 })
 

--- a/src/services/liaisonService.ts
+++ b/src/services/liaisonService.ts
@@ -482,28 +482,16 @@ export async function markMessageAsRead(
 
 export async function markAllMessagesAsRead(
   conversationId: string,
-  userId: string
 ): Promise<void> {
-  // Get all unread messages in this conversation (inclut read_by NULL)
-  const { data: unreadMessages, error: fetchError } = await supabase
-    .from('liaison_messages')
-    .select('id, read_by')
-    .eq('conversation_id', conversationId)
-    .neq('sender_id', userId)
-    .or(`read_by.is.null,read_by.not.cs.{${userId}}`)
+  // RPC SECURITY DEFINER — contourne le RLS UPDATE qui restreint à sender_id.
+  // Cf. migration 061. Vérifie côté serveur que l'auth.uid() est bien
+  // participant de la conversation.
+  const { error } = await supabase.rpc('mark_liaison_messages_read', {
+    p_conversation_id: conversationId,
+  })
 
-  if (fetchError) {
-    logger.error('Erreur récupération messages non lus:', fetchError)
-    return
-  }
-
-  // Update each unread message
-  for (const msg of unreadMessages || []) {
-    const readBy = msg.read_by || []
-    await supabase
-      .from('liaison_messages')
-      .update({ read_by: [...readBy, userId] })
-      .eq('id', msg.id)
+  if (error) {
+    logger.error('Erreur marquage messages lus:', error)
   }
 }
 
@@ -546,6 +534,26 @@ export async function getTotalUnreadCount(
 
   if (error) {
     logger.error('Erreur comptage messages non lus total:', error)
+    return 0
+  }
+
+  return count || 0
+}
+
+/**
+ * Compte les messages non lus toutes conversations confondues pour l'utilisateur
+ * courant. La RLS SELECT sur liaison_messages filtre déjà aux messages des
+ * conversations dont l'utilisateur est membre.
+ */
+export async function getUnreadCountForUser(userId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('liaison_messages')
+    .select('*', { count: 'exact', head: true })
+    .neq('sender_id', userId)
+    .or(`read_by.is.null,read_by.not.cs.{${userId}}`)
+
+  if (error) {
+    logger.error('Erreur comptage messages non lus user:', error)
     return 0
   }
 

--- a/supabase/migrations/061_mark_liaison_messages_read_rpc.sql
+++ b/supabase/migrations/061_mark_liaison_messages_read_rpc.sql
@@ -1,0 +1,75 @@
+-- Migration 061 : RPC mark_liaison_messages_read
+--
+-- Bug initial : `markAllMessagesAsRead` côté client tentait un UPDATE direct
+-- sur liaison_messages pour ajouter l'auth.uid() dans le tableau read_by.
+-- La policy RLS UPDATE existante (migration 001) restreint l'UPDATE à
+-- `auth.uid() = sender_id` → seul l'auteur peut modifier son message.
+-- Conséquence : l'UPDATE était silencieusement bloqué (aucune ligne ne
+-- matche le filtre RLS), donc read_by ne contenait jamais le lecteur, et
+-- le compteur de non-lus revenait après un refresh.
+--
+-- Fix : RPC SECURITY DEFINER qui marque tous les messages non lus d'une
+-- conversation comme lus pour l'auth.uid() courant. Vérifie côté serveur
+-- que l'utilisateur est bien participant de la conversation (employer,
+-- participant_ids, ou via contracts/caregivers — mêmes règles d'accès
+-- que la policy SELECT sur conversations).
+
+CREATE OR REPLACE FUNCTION mark_liaison_messages_read(
+  p_conversation_id uuid
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_updated_count integer := 0;
+  v_has_access boolean;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Non authentifié' USING ERRCODE = '42501';
+  END IF;
+
+  -- Vérifie l'accès à la conversation : même logique que la policy SELECT
+  -- sur conversations (migration 035) — employer, participant, ou lié via
+  -- un contrat / un rôle d'aidant pour cet employeur.
+  SELECT EXISTS (
+    SELECT 1
+    FROM conversations c
+    WHERE c.id = p_conversation_id
+      AND (
+        c.employer_id = v_user_id
+        OR v_user_id = ANY(c.participant_ids)
+        OR EXISTS (
+          SELECT 1 FROM contracts
+          WHERE contracts.employer_id = c.employer_id
+            AND contracts.employee_id = v_user_id
+        )
+        OR EXISTS (
+          SELECT 1 FROM caregivers
+          WHERE caregivers.employer_id = c.employer_id
+            AND caregivers.profile_id = v_user_id
+        )
+      )
+  ) INTO v_has_access;
+
+  IF NOT v_has_access THEN
+    RAISE EXCEPTION 'Accès refusé à cette conversation' USING ERRCODE = '42501';
+  END IF;
+
+  -- Ajoute v_user_id dans read_by pour tous les messages non lus que
+  -- l'utilisateur n'a pas envoyés. array_append + NULL-safe.
+  UPDATE liaison_messages
+  SET read_by = COALESCE(read_by, ARRAY[]::uuid[]) || ARRAY[v_user_id]
+  WHERE conversation_id = p_conversation_id
+    AND sender_id <> v_user_id
+    AND (read_by IS NULL OR NOT (v_user_id = ANY(read_by)));
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  RETURN v_updated_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION mark_liaison_messages_read(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION mark_liaison_messages_read(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
Corrige le bug où le badge "non lu" revenait sur les conversations privées après un refresh (alors qu'on venait de les lire), et ajoute une pastille rouge à côté de "Messagerie" dans la sidebar globale pour signaler les non-lus à travers toute l'app.

### Bug fix — mark-as-read silencieux côté RLS
La policy UPDATE sur `liaison_messages` (migration 001) restreint à `auth.uid() = sender_id`. La boucle d'UPDATE côté client tentait d'ajouter l'userId dans `read_by` sur des messages reçus → bloqué silencieusement par le RLS, donc `read_by` ne contenait jamais le lecteur. Le state local passait à 0 visuellement puis revenait à la valeur DB au refresh.

**Fix** : migration `061_mark_liaison_messages_read_rpc.sql` + RPC `mark_liaison_messages_read(p_conversation_id)` SECURITY DEFINER qui vérifie côté serveur que l'auth.uid() est bien participant de la conversation (mêmes règles que la policy SELECT sur `conversations`), puis met à jour `read_by` en une seule requête (vs N requêtes côté client avant). `liaisonService.markAllMessagesAsRead` appelle la RPC.

### Feature — pastille sidebar
- `getUnreadCountForUser(userId)` : compte global toutes conversations confondues (la RLS SELECT sur `liaison_messages` filtre déjà aux convs accessibles, pas besoin de filtrer manuellement par employer/participant).
- Hook `useLiaisonUnreadCount(userId)` : fetch initial + subscription Realtime sur INSERT/UPDATE de `liaison_messages` → recompte à chaque event (nouveau message reçu OU `read_by` mis à jour). Recharge synchrone via la même fonction.
- `DashboardLayout` : pastille rouge 8px en haut-droite de l'icône "Messagerie" si non-lus > 0, avec bordure de la couleur de fond pour le contraste. `aria-label` enrichi avec le count pour les lecteurs d'écran.

### Changements
- `supabase/migrations/061_mark_liaison_messages_read_rpc.sql` (nouveau) — RPC SECURITY DEFINER
- `src/services/liaisonService.ts` — `markAllMessagesAsRead` → RPC, ajout de `getUnreadCountForUser`
- `src/hooks/useLiaisonUnreadCount.ts` (nouveau) — fetch + realtime
- `src/components/dashboard/DashboardLayout.tsx` — pastille rouge sur l'item Messagerie
- `src/components/liaison/LiaisonPage.tsx` — adaptation signature (1 arg au lieu de 2)
- `src/services/liaisonService.test.ts` — tests RPC

## ⚠️ Déploiement prod
La migration 061 doit être appliquée manuellement sur le VPS Supabase self-host avant que le fix soit effectif (pattern habituel — cf. PRs #345 / #348). À noter dans la check-list de déploiement.

## Test plan
- [x] `npm run lint` OK
- [x] `npm run typecheck` OK
- [x] `npm run test:run` : 2376 passed / 4 skipped (140 fichiers)
- [x] Manuel : ouvrir une conversation privée avec messages non lus → badge passe à 0 → refresh → reste à 0
- [x] Manuel : recevoir un message en étant sur une autre page → pastille rouge apparaît sur "Messagerie" dans la sidebar
- [x] Manuel : ouvrir la conv depuis la sidebar → pastille disparaît
- [x] Vérifier que la RPC refuse l'accès quand l'user n'est pas participant (réponse erreur 42501)

🤖 Generated with [Claude Code](https://claude.com/claude-code)