### PR TITLE
fix(leave-balance): initialize via SECURITY DEFINER RPC

### DIFF
--- a/docs/SECURITY_CHECK_2026-05-13.md
+++ b/docs/SECURITY_CHECK_2026-05-13.md
@@ -68,7 +68,7 @@ Marquer comme lu un message envoyé par un autre user nécessite un UPDATE sur u
 3. Effectue l'UPDATE
 4. `REVOKE ALL FROM public` + `GRANT EXECUTE TO authenticated`
 
-À répliquer pour toute colonne type "seen_by / read_by" sur les autres tables. Audit cross-tables effectué le 2026-05-13 → seul `log_entries.read_by` présentait le même bug (cf. MEDIUM-3 + migration 062). `notifications` n'est pas concerné (chaque user ne touche que ses propres lignes).
+À répliquer pour toute colonne type "seen_by / read_by" sur les autres tables. Audit cross-tables effectué le 2026-05-13 → `log_entries.read_by` présentait le même bug (cf. MEDIUM-3 + migration 062). Variante remontée la même journée : `leave_balances` INSERT bloqué pour l'employé essayant d'initialiser son solde (policy `employer_manage_balances`) → erreur "Le solde de congés n'a pas encore été initialisé" côté UI → fix migration 063 `initialize_leave_balance` (RPC SECURITY DEFINER avec port serveur de `calculateAcquiredDays`). `notifications` n'est pas concerné (chaque user ne touche que ses propres lignes).
 
 ### 2.6 Migrations sécurité post-pentest
 
@@ -78,6 +78,7 @@ Marquer comme lu un message envoyé par un autre user nécessite un UPDATE sur u
 - **060** — trigger `auth.users` force `role='authenticated'` (fix bug GoTrue OAuth)
 - **061** — RPC `mark_liaison_messages_read`
 - **062** — RPC `mark_log_entry_read` (cf. MEDIUM-3, même pattern que 061)
+- **063** — RPC `initialize_leave_balance` + helper `count_working_days` (variante INSERT-bloqué du pattern RLS 061/062, fix bug "solde de congés pas initialisé" pour l'employé)
 
 ### 2.7 Edge Functions
 

--- a/src/services/absenceService.ts
+++ b/src/services/absenceService.ts
@@ -160,13 +160,7 @@ export async function createAbsence(
       let balance = await getLeaveBalance(contract.id, leaveYear)
 
       if (!balance) {
-        balance = await initializeLeaveBalance(
-          contract.id,
-          employeeId,
-          contract.employer_id,
-          leaveYear,
-          { startDate: new Date(contract.start_date), weeklyHours: contract.weekly_hours }
-        )
+        balance = await initializeLeaveBalance(contract.id, leaveYear)
       }
 
       if (balance) {

--- a/src/services/leaveBalanceService.test.ts
+++ b/src/services/leaveBalanceService.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 const mockFrom = vi.fn()
+const mockRpc = vi.fn()
 
 vi.mock('@/lib/supabase/client', () => ({
   supabase: {
     from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
   },
 }))
 
@@ -268,64 +270,43 @@ describe('leaveBalanceService', () => {
   // ============================================
 
   describe('initializeLeaveBalance', () => {
-    const contract = { startDate: new Date('2025-01-15'), weeklyHours: 35 }
-
-    it('appelle calculateAcquiredDays et upsert puis retourne le solde', async () => {
+    it('appelle la RPC initialize_leave_balance et retourne le solde mappé', async () => {
       const dbRow = makeLeaveBalanceDbRow({ acquired_days: 25, taken_days: 0, adjustment_days: 0 })
-      const chain = mockSupabaseQuery({ data: dbRow, error: null })
+      mockRpc.mockResolvedValueOnce({ data: dbRow, error: null })
 
       const { initializeLeaveBalance } = await import('@/services/leaveBalanceService')
-      const { calculateAcquiredDays, getLeaveYearStartDate } = await import('@/lib/absence')
-      const result = await initializeLeaveBalance('c-001', 'emp-001', 'er-001', '2025', contract)
+      const result = await initializeLeaveBalance('c-001', '2025')
 
-      expect(getLeaveYearStartDate).toHaveBeenCalledWith('2025')
-      expect(calculateAcquiredDays).toHaveBeenCalledWith(
-        contract,
-        new Date('2025-06-01'),
-        expect.any(Date)
-      )
-      expect(chain.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          contract_id: 'c-001',
-          employee_id: 'emp-001',
-          employer_id: 'er-001',
-          leave_year: '2025',
-          acquired_days: 25,
-          taken_days: 0,
-          adjustment_days: 0,
-        }),
-        { onConflict: 'contract_id,leave_year' }
-      )
+      expect(mockRpc).toHaveBeenCalledWith('initialize_leave_balance', {
+        p_contract_id: 'c-001',
+        p_leave_year: '2025',
+      })
       expect(result).not.toBeNull()
       expect(result!.acquiredDays).toBe(25)
       expect(result!.takenDays).toBe(0)
     })
 
-    it('retourne null et log erreur si erreur upsert', async () => {
-      mockSupabaseQuery({ data: null, error: { message: 'Upsert failed' } })
+    it('retourne null et log erreur si la RPC échoue', async () => {
+      mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'access denied' } })
 
       const { initializeLeaveBalance } = await import('@/services/leaveBalanceService')
       const { logger } = await import('@/lib/logger')
-      const result = await initializeLeaveBalance('c-001', 'emp-001', 'er-001', '2025', contract)
+      const result = await initializeLeaveBalance('c-001', '2025')
 
       expect(result).toBeNull()
       expect(logger.error).toHaveBeenCalledWith(
         'Erreur initialisation solde congés:',
-        expect.objectContaining({ message: 'Upsert failed' })
+        expect.objectContaining({ message: 'access denied' })
       )
     })
 
-    it('appelle single() apres upsert + select', async () => {
-      const chain = mockSupabaseQuery({
-        data: makeLeaveBalanceDbRow(),
-        error: null,
-      })
+    it('retourne null si la RPC répond data=null sans erreur', async () => {
+      mockRpc.mockResolvedValueOnce({ data: null, error: null })
 
       const { initializeLeaveBalance } = await import('@/services/leaveBalanceService')
-      await initializeLeaveBalance('c-001', 'emp-001', 'er-001', '2025', contract)
+      const result = await initializeLeaveBalance('c-001', '2025')
 
-      expect(chain.select).toHaveBeenCalled()
-      expect(chain.single).toHaveBeenCalled()
+      expect(result).toBeNull()
     })
   })
 

--- a/src/services/leaveBalanceService.ts
+++ b/src/services/leaveBalanceService.ts
@@ -2,11 +2,7 @@ import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 import type { LeaveBalance } from '@/types'
 import type { LeaveBalanceDbRow } from '@/types/database'
-import {
-  calculateAcquiredDays,
-  calculateRemainingDays,
-  getLeaveYearStartDate,
-} from '@/lib/absence'
+import { calculateRemainingDays } from '@/lib/absence'
 
 // ============================================
 // GET LEAVE BALANCE
@@ -79,36 +75,28 @@ export async function getLeaveBalancesForEmployer(
 // INITIALIZE LEAVE BALANCE
 // ============================================
 
+/**
+ * Initialise le solde de congés via la RPC SECURITY DEFINER
+ * (migration 063). La RPC autorise l'employer OU l'employee du contrat
+ * à créer le solde, sans ouvrir la policy RLS INSERT réservée à
+ * l'employer. acquired_days est calculé côté serveur depuis
+ * `p_contract_id`.
+ */
 export async function initializeLeaveBalance(
   contractId: string,
-  employeeId: string,
-  employerId: string,
-  leaveYear: string,
-  contract: { startDate: Date; weeklyHours: number }
+  leaveYear: string
 ): Promise<LeaveBalance | null> {
-  const leaveYearStart = getLeaveYearStartDate(leaveYear)
-  const acquired = calculateAcquiredDays(contract, leaveYearStart, new Date())
+  const { data, error } = await supabase.rpc('initialize_leave_balance', {
+    p_contract_id: contractId,
+    p_leave_year: leaveYear,
+  })
 
-  const { data, error } = await supabase
-    .from('leave_balances')
-    .upsert({
-      contract_id: contractId,
-      employee_id: employeeId,
-      employer_id: employerId,
-      leave_year: leaveYear,
-      acquired_days: acquired,
-      taken_days: 0,
-      adjustment_days: 0,
-    }, { onConflict: 'contract_id,leave_year' })
-    .select()
-    .single()
-
-  if (error) {
+  if (error || !data) {
     logger.error('Erreur initialisation solde congés:', error)
     return null
   }
 
-  return mapLeaveBalanceFromDb(data)
+  return mapLeaveBalanceFromDb(data as LeaveBalanceDbRow)
 }
 
 // ============================================

--- a/supabase/migrations/063_initialize_leave_balance_rpc.sql
+++ b/supabase/migrations/063_initialize_leave_balance_rpc.sql
@@ -1,0 +1,110 @@
+-- Migration 063 : RPC initialize_leave_balance
+--
+-- Bug initial : un employé qui pose une demande de congé payé alors que
+-- son leave_balance n'a pas encore été initialisé voyait l'erreur
+-- "Le solde de congés n'a pas encore été initialisé." La cause : la
+-- policy RLS `employer_manage_balances` (migration 025) restreint
+-- INSERT/UPDATE/DELETE sur leave_balances à `employer_id = auth.uid()`.
+-- Quand l'employé déclenchait le fallback `initializeLeaveBalance` côté
+-- client (absenceService:160), l'INSERT était bloqué par RLS et
+-- `initializeLeaveBalance` retournait null.
+--
+-- Fix : RPC SECURITY DEFINER qui autorise l'init du solde par l'employer
+-- OU l'employee du contrat, sans ouvrir la policy RLS. Le calcul
+-- d'`acquired_days` est porté côté serveur pour ne pas faire confiance
+-- au client (port de `calculateAcquiredDays` dans
+-- src/lib/absence/balanceCalculator.ts).
+--
+-- Même pattern que migrations 061 (liaison_messages) et 062 (log_entries).
+
+CREATE OR REPLACE FUNCTION public.count_working_days(p_start date, p_end date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COUNT(*)::integer
+  FROM generate_series(p_start, p_end, '1 day'::interval) AS d
+  WHERE EXTRACT(ISODOW FROM d) BETWEEN 1 AND 6;
+$$;
+
+CREATE OR REPLACE FUNCTION public.initialize_leave_balance(
+  p_contract_id uuid,
+  p_leave_year text
+)
+RETURNS public.leave_balances
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_employer_id uuid;
+  v_employee_id uuid;
+  v_contract_start date;
+  v_leave_year_start date;
+  v_effective_start date;
+  v_working_days integer;
+  v_acquired integer;
+  v_balance public.leave_balances;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Non authentifié' USING ERRCODE = '42501';
+  END IF;
+
+  -- Format attendu : "YYYY-YYYY" (cf. getLeaveYear côté TS).
+  IF p_leave_year !~ '^\d{4}-\d{4}$' THEN
+    RAISE EXCEPTION 'Format leave_year invalide' USING ERRCODE = '22023';
+  END IF;
+  v_leave_year_start := make_date(split_part(p_leave_year, '-', 1)::int, 6, 1);
+
+  SELECT employer_id, employee_id, start_date
+    INTO v_employer_id, v_employee_id, v_contract_start
+  FROM public.contracts
+  WHERE id = p_contract_id;
+
+  IF v_employer_id IS NULL THEN
+    RAISE EXCEPTION 'Contrat introuvable' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_user_id <> v_employer_id AND v_user_id <> v_employee_id THEN
+    RAISE EXCEPTION 'Accès refusé' USING ERRCODE = '42501';
+  END IF;
+
+  -- Port fidèle de calculateAcquiredDays(TS) :
+  --   effectiveStart = max(contract.startDate, leaveYearStart)
+  --   workingDays    = jours ouvrables (lun-sam) effectiveStart → now
+  --   months         = floor(workingDays / 24)
+  --   acquired       = min(ceil(months * 2.5), 30)
+  v_effective_start := GREATEST(v_contract_start, v_leave_year_start);
+
+  IF v_effective_start > CURRENT_DATE THEN
+    v_acquired := 0;
+  ELSE
+    v_working_days := public.count_working_days(v_effective_start, CURRENT_DATE);
+    -- Division entière intentionnelle : (workingDays / 24) tronque
+    v_acquired := LEAST(CEIL((v_working_days / 24) * 2.5)::integer, 30);
+  END IF;
+
+  -- Idempotent : si une balance existe déjà, on ne touche pas et on la renvoie.
+  INSERT INTO public.leave_balances (
+    contract_id, employee_id, employer_id, leave_year,
+    acquired_days, taken_days, adjustment_days
+  ) VALUES (
+    p_contract_id, v_employee_id, v_employer_id, p_leave_year,
+    v_acquired, 0, 0
+  )
+  ON CONFLICT (contract_id, leave_year) DO NOTHING;
+
+  SELECT * INTO v_balance
+  FROM public.leave_balances
+  WHERE contract_id = p_contract_id AND leave_year = p_leave_year;
+
+  RETURN v_balance;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.count_working_days(date, date) FROM public;
+GRANT EXECUTE ON FUNCTION public.count_working_days(date, date) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.initialize_leave_balance(uuid, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.initialize_leave_balance(uuid, text) TO authenticated;


### PR DESCRIPTION
## Summary

Corrige le bug **"Le solde de congés n'a pas encore été initialisé. Veuillez réessayer ou contacter votre employeur si le problème persiste."** qui apparaissait quand un employé tentait de poser une demande de congé payé alors qu'aucun `leave_balance` n'existait encore en DB pour son contrat.

### Cause racine

La policy RLS `employer_manage_balances` (migration 025) restreint INSERT/UPDATE/DELETE sur `leave_balances` à `employer_id = auth.uid()`. Quand l'employé déclenchait le fallback `initializeLeaveBalance` côté client (`absenceService.ts:160`), l'INSERT était bloqué par RLS → `initializeLeaveBalance` retournait `null` → `validateBalance` recevait `null` → message d'erreur affiché à l'UI.

Scénario typique : un employer crée un contrat **sans reprise historique de congés** (pas d'appel à `initializeLeaveBalanceWithOverride`) → aucun `leave_balance` en DB → l'employé essaie de poser un congé payé → boom.

Même pattern que les bugs corrigés par les PRs #378 (liaison_messages) et #379 (log_entries). Cf. mémoire pattern `feedback-rls-update-silent-pattern.md`.

### Changements

- **`supabase/migrations/063_initialize_leave_balance_rpc.sql`** : RPC `initialize_leave_balance(p_contract_id, p_leave_year)` SECURITY DEFINER. Vérifie `auth.uid() ∈ {employer_id, employee_id}` du contrat. Calcule `acquired_days` côté serveur (port fidèle de `calculateAcquiredDays` TS + helper `count_working_days`). INSERT idempotent via `ON CONFLICT DO NOTHING`. `REVOKE FROM public` + `GRANT EXECUTE TO authenticated`.
- **`src/services/leaveBalanceService.ts`** : `initializeLeaveBalance(contractId, leaveYear)` passe par `.rpc('initialize_leave_balance', ...)`. Signature simplifiée (3 params devenus inutiles supprimés : la RPC résout tout depuis `p_contract_id`).
- **`src/services/absenceService.ts`** : caller mis à jour vers la nouvelle signature.
- **`src/services/leaveBalanceService.test.ts`** : 3 tests `initializeLeaveBalance` réécrits autour de `mockRpc`.
- **`docs/SECURITY_CHECK_2026-05-13.md`** : §2.5 et §2.6 mentionnent la migration 063 comme variante du pattern.

## Test plan

- [x] `npm run lint` — 0 errors (2 warnings préexistants)
- [x] `npm run test:run` — 2376 passed / 4 skipped / 0 fail
- [x] `npm run typecheck` — OK
- [x] Appliquer migration 063 en prod (Studio SQL editor ou pipeline self-host)
- [x] **Reproduction du bug** : employé avec contrat actif sans `leave_balance` initialisé → demander un congé payé → l'erreur ne doit plus apparaître, balance créée avec `acquired_days` correct (vérifier en DB)
- [x] **Cas employer** : l'employer crée une absence "vacation" sur un employé sans balance → init OK
- [x] **Cas accès refusé** : un user tiers (ni employer ni employee du contrat) qui appellerait la RPC doit recevoir une erreur 42501

### Suivi sécurité

Avec cette PR, le rapport `SECURITY_CHECK_2026-05-13` voit 3 cas du pattern RLS restrictif fixés (061, 062, 063). HIGH-1 send-email + MEDIUM-1/2 + 3 LOW restent au plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)