### PR TITLE
fix(email): kind-based Edge send-email + server-side recipient resolution

### DIFF
--- a/docs/SECURITY_CHECK_2026-05-13.md
+++ b/docs/SECURITY_CHECK_2026-05-13.md
@@ -3,7 +3,7 @@
 > Snapshot de la posture sécurité après migrations 041 → 061, navigation vocale, pgsodium santé, OAuth onboarding, suivi RLS UPDATE.
 > Successeur de [SECURITY_CHECK_2026-03-26.md](./SECURITY_CHECK_2026-03-26.md).
 
-**TL;DR** : posture solide (0 vulnérabilités npm, RLS étendue, chiffrement applicatif des données santé, logger centralisé avec redaction). **1 finding HIGH** sur l'Edge Function `send-email` (relais d'emails ouvert aux authenticated users), 3 findings MEDIUM (dont MEDIUM-3 `log_entries` couvert par migration 062), 3 LOW.
+**TL;DR** : posture solide (0 vulnérabilités npm, RLS étendue, chiffrement applicatif des données santé, logger centralisé avec redaction). HIGH-1 `send-email` (relais d'emails ouvert) **corrigé** (refonte kind-based + lookup serveur), MEDIUM-3 `log_entries` **corrigé** (migration 062). Reste : 2 findings MEDIUM, 3 LOW.
 
 ---
 
@@ -112,27 +112,23 @@ form-action 'self'
 
 ## 3. Findings
 
-### 🔴 HIGH-1 — `send-email` = relais d'emails ouvert
+### ✅ HIGH-1 — `send-email` = relais d'emails ouvert (CORRIGÉ)
 
 **Fichier** : [supabase/functions/send-email/index.ts](../supabase/functions/send-email/index.ts)
 
-L'Edge Function vérifie le JWT et applique un rate limit (10 emails/min/user) mais **n'impose aucune contrainte sur `payload.to` ni sur `payload.html`**. Un utilisateur authentifié peut envoyer jusqu'à **600 emails/heure** vers n'importe quelle adresse, avec n'importe quel HTML, depuis l'expéditeur officiel `notifications@unilien.app`.
+**État** : ✅ corrigé par PR `fix/edge-send-email-recipient-validation` (option 1 stricte du plan d'origine).
 
-**Impact** :
-- Phishing depuis un domaine vérifié Resend (réputation domaine brûlée + listes anti-spam)
-- Risque RGPD (envois non sollicités)
-- Risque facture Resend (abus)
+**Bug initial** : l'Edge Function vérifiait le JWT et appliquait un rate limit (10 emails/min/user) mais **n'imposait aucune contrainte sur `payload.to` ni sur `payload.html`**. Un utilisateur authentifié pouvait envoyer jusqu'à **600 emails/heure** vers n'importe quelle adresse, avec n'importe quel HTML, depuis l'expéditeur officiel `notifications@unilien.app` (phishing, RGPD, facture Resend).
 
-**Vecteur** : signup gratuit → automatisation du POST `/functions/v1/send-email` avec un payload custom.
-
-**Fix recommandé** :
-
-Valider côté serveur que `payload.to` correspond à un destinataire légitime du caller. Options :
-
-1. **Stricte** : exposer des RPC métier (`send_shift_reminder(p_shift_id)`, `send_new_message_notification(p_message_id)`) qui résolvent l'email destinataire côté DB en vérifiant les relations. L'Edge Function `send-email` devient privée (callable uniquement par service_role).
-2. **Souple** : dans `send-email`, lookup côté serveur que `payload.to` existe dans `profiles` et est lié au caller via `contracts` / `caregivers` / `conversations`. Reject sinon.
-
-Recommandation : option 1 (stricte). Surface d'attaque réduite à 0, et les payloads HTML sont contrôlés par le code de l'app.
+**Fix appliqué** :
+- Le client ne passe plus `{ to, subject, html }` libres. Le payload accepté est `{ kind, ...ids }` :
+  - `{ kind: 'shift_reminder', shiftId, recipientId }`
+  - `{ kind: 'new_message_notification', messageId, recipientId }`
+- L'Edge résout côté `service_role` :
+  - `shift_reminder` : SELECT shift + contrat, vérifie que `recipientId == auth.uid()` ET que `recipientId == contract.employee_id`. Sinon 403.
+  - `new_message_notification` : SELECT message + conversation, vérifie que `auth.uid() == message.sender_id` ET que `recipientId ∈ participant_ids` ET `recipientId != sender_id`. Sinon 403.
+- Templates HTML déplacés Deno-side (`supabase/functions/_shared/emailTemplates.ts`), toute donnée externe passe par `escapeHtml()` avant interpolation.
+- Surface "to/html arbitraires" → fermée. L'expéditeur `notifications@unilien.app` ne peut plus servir qu'à 2 cas d'usage métier.
 
 ### 🟡 MEDIUM-1 — `file_upload_audit` INSERT policy laxiste
 
@@ -214,7 +210,7 @@ Si absent, ajouter explicitement dans le bloc `header` du Caddyfile.
 
 | # | Branche | Priorité | Effort |
 |---|---|---|---|
-| 1 | `fix/edge-send-email-recipient-validation` | HIGH | ~1 jour |
+| 1 | ~~`fix/edge-send-email-recipient-validation`~~ ✅ refonte kind-based | HIGH | fait |
 | 2 | `fix/file-upload-audit-rls` | MEDIUM | ~30 min |
 | 3 | ~~`fix/logbook-mark-read-rpc`~~ ✅ migration 062 | MEDIUM | fait |
 | 4 | `chore/csp-remove-unsafe-eval` | LOW (test preview) | ~1h |

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -2,42 +2,18 @@ import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 
 // ============================================
-// TYPES
+// EMAIL SERVICE — Edge Function `send-email`
 // ============================================
+//
+// Cf. SECURITY_CHECK_2026-05-13 HIGH-1.
+// Le client ne passe plus de `to` / `html` libres : on n'envoie que des
+// kinds métier + IDs. La résolution destinataire + génération HTML
+// se font côté Edge (service_role), templates dans
+// `supabase/functions/_shared/emailTemplates.ts`.
 
-export interface EmailOptions {
-  to: string
-  subject: string
-  html: string
-  text?: string
-}
-
-export interface ShiftReminderData {
-  recipientName: string
-  employerName: string
-  date: string        // ex: "Lundi 14 avril 2026"
-  startTime: string   // ex: "09:00"
-  endTime?: string    // ex: "17:00"
-  address?: string
-}
-
-export interface NewMessageData {
-  recipientName: string
-  senderName: string
-  preview: string     // premiers caractères du message
-  conversationUrl: string
-}
-
-// ============================================
-// CORE
-// ============================================
-
-/**
- * Envoie un email via l'Edge Function send-email
- */
-export async function sendEmail(options: EmailOptions): Promise<void> {
+async function invokeSendEmail(payload: Record<string, unknown>): Promise<void> {
   const { data, error } = await supabase.functions.invoke('send-email', {
-    body: options,
+    body: payload,
   })
 
   if (error) {
@@ -48,146 +24,26 @@ export async function sendEmail(options: EmailOptions): Promise<void> {
   logger.info('[Email] Envoyé, ID:', data?.id)
 }
 
-// ============================================
-// TEMPLATES
-// ============================================
-
 /**
- * Rappel d'intervention J-1
+ * Rappel d'intervention J-1. Le destinataire DOIT être l'auth.uid()
+ * courant (rule serveur).
  */
-export async function sendShiftReminder(to: string, data: ShiftReminderData): Promise<void> {
-  await sendEmail({
-    to,
-    subject: `Rappel : intervention demain ${data.date}`,
-    html: shiftReminderTemplate(data),
-    text: `Bonjour ${data.recipientName}, rappel de votre intervention demain ${data.date} de ${data.startTime} à ${data.endTime} chez ${data.employerName}.`,
+export async function sendShiftReminder(shiftId: string, recipientId: string): Promise<void> {
+  await invokeSendEmail({
+    kind: 'shift_reminder',
+    shiftId,
+    recipientId,
   })
 }
 
 /**
- * Notification nouveau message
+ * Notification nouveau message. Le caller DOIT être le sender du message
+ * (rule serveur) et `recipientId` un participant de la conversation.
  */
-export async function sendNewMessageNotification(to: string, data: NewMessageData): Promise<void> {
-  await sendEmail({
-    to,
-    subject: `Nouveau message de ${data.senderName}`,
-    html: newMessageTemplate(data),
-    text: `Bonjour ${data.recipientName}, vous avez reçu un message de ${data.senderName} : "${data.preview}"`,
+export async function sendNewMessageNotification(messageId: string, recipientId: string): Promise<void> {
+  await invokeSendEmail({
+    kind: 'new_message_notification',
+    messageId,
+    recipientId,
   })
-}
-
-// ============================================
-// HTML TEMPLATES
-// ============================================
-
-function emailLayout(title: string, content: string): string {
-  return `<!DOCTYPE html>
-<html lang="fr">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>${title}</title>
-</head>
-<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
-  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
-    <tr>
-      <td align="center">
-        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
-          <tr>
-            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
-                <tr>
-                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
-                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
-                  </td>
-                </tr>
-              </table>
-              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:40px 32px 24px 32px;">
-              ${content}
-            </td>
-          </tr>
-          <tr>
-            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
-              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
-              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>`
-}
-
-function shiftReminderTemplate(data: ShiftReminderData): string {
-  return emailLayout('Rappel d\'intervention', `
-    <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Rappel d'intervention</h2>
-    <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Bonjour ${data.recipientName}, votre prochaine intervention est prévue pour demain.</p>
-
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#EDF1F5;border-radius:8px;margin-bottom:24px;">
-      <tr>
-        <td style="padding:20px 24px;">
-          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-            <tr>
-              <td style="padding:6px 0;">
-                <span style="font-size:13px;color:#6D93AD;display:block;">Date</span>
-                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.date}</span>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:6px 0;">
-                <span style="font-size:13px;color:#6D93AD;display:block;">Horaires</span>
-                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.startTime}${data.endTime ? ` – ${data.endTime}` : ''}</span>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding:6px 0;">
-                <span style="font-size:13px;color:#6D93AD;display:block;">Employeur</span>
-                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.employerName}</span>
-              </td>
-            </tr>
-            ${data.address ? `
-            <tr>
-              <td style="padding:6px 0;">
-                <span style="font-size:13px;color:#6D93AD;display:block;">Adresse</span>
-                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${data.address}</span>
-              </td>
-            </tr>` : ''}
-          </table>
-        </td>
-      </tr>
-    </table>
-
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-      <tr>
-        <td align="center" style="padding:8px 0 0 0;">
-          <a href="https://unilien.app/planning" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Voir le planning</a>
-        </td>
-      </tr>
-    </table>
-  `)
-}
-
-function newMessageTemplate(data: NewMessageData): string {
-  return emailLayout('Nouveau message', `
-    <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Nouveau message</h2>
-    <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Bonjour ${data.recipientName}, <strong style="color:#1F2C3B;">${data.senderName}</strong> vous a envoyé un message.</p>
-
-    <div style="background-color:#EDF1F5;border-left:3px solid #3D5166;border-radius:4px;padding:16px 20px;margin:0 0 24px 0;">
-      <p style="margin:0;font-size:15px;color:#4E6478;font-style:italic;">&ldquo;${data.preview}…&rdquo;</p>
-    </div>
-
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-      <tr>
-        <td align="center" style="padding:8px 0 0 0;">
-          <a href="${data.conversationUrl}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Répondre</a>
-        </td>
-      </tr>
-    </table>
-  `)
 }

--- a/src/services/liaisonService.ts
+++ b/src/services/liaisonService.ts
@@ -394,7 +394,7 @@ export async function createLiaisonMessage(
       const senderName = await getProfileName(senderId)
       await Promise.all(
         recipients.map((recipientId: string) =>
-          createMessageNotification(recipientId, senderName, content.trim())
+          createMessageNotification(recipientId, senderName, content.trim(), data.id)
         )
       )
     }

--- a/src/services/notificationCreators.ts
+++ b/src/services/notificationCreators.ts
@@ -1,4 +1,3 @@
-import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
 import { formatHoursCompact } from '@/lib/formatHours'
 import type { Notification, NotificationType, NotificationPriority } from '@/types'
@@ -10,19 +9,6 @@ import {
   getPlanningUrlWithDate,
 } from './notificationService.core'
 import { sendShiftReminder, sendNewMessageNotification } from './emailService'
-
-// ============================================
-// EMAIL HELPER
-// ============================================
-
-async function getUserEmail(userId: string): Promise<string | null> {
-  const { data } = await supabase
-    .from('profiles')
-    .select('email')
-    .eq('id', userId)
-    .single()
-  return data?.email ?? null
-}
 
 // ============================================
 // COMPLIANCE NOTIFICATION HELPERS
@@ -154,20 +140,11 @@ export async function createShiftReminderNotification(
     },
   })
 
-  // Email si activé dans les préférences
+  // Email si activé dans les préférences (résolution destinataire côté Edge)
   try {
-    const [prefs, email, recipientName] = await Promise.all([
-      getNotificationPreferences(userId),
-      getUserEmail(userId),
-      getProfileName(userId),
-    ])
-    if (prefs.emailEnabled && prefs.shiftReminders && email) {
-      await sendShiftReminder(email, {
-        recipientName,
-        employerName,
-        date: formattedDate,
-        startTime,
-      })
+    const prefs = await getNotificationPreferences(userId)
+    if (prefs.emailEnabled && prefs.shiftReminders) {
+      await sendShiftReminder(shiftId, userId)
     }
   } catch (err) {
     logger.error('[Email] Erreur rappel shift:', err)
@@ -179,7 +156,8 @@ export async function createShiftReminderNotification(
 export async function createMessageNotification(
   userId: string,
   senderName: string,
-  messagePreview: string
+  messagePreview: string,
+  messageId: string
 ): Promise<Notification | null> {
   const notification = await createNotification({
     userId,
@@ -191,20 +169,11 @@ export async function createMessageNotification(
     data: { senderName, messagePreview },
   })
 
-  // Email si activé dans les préférences
+  // Email si activé dans les préférences (résolution destinataire côté Edge)
   try {
-    const [prefs, email, recipientName] = await Promise.all([
-      getNotificationPreferences(userId),
-      getUserEmail(userId),
-      getProfileName(userId),
-    ])
-    if (prefs.emailEnabled && prefs.messageNotifications && email) {
-      await sendNewMessageNotification(email, {
-        recipientName,
-        senderName,
-        preview: messagePreview.substring(0, 120),
-        conversationUrl: 'https://unilien.app/messagerie',
-      })
+    const prefs = await getNotificationPreferences(userId)
+    if (prefs.emailEnabled && prefs.messageNotifications) {
+      await sendNewMessageNotification(messageId, userId)
     }
   } catch (err) {
     logger.error('[Email] Erreur notif message:', err)

--- a/src/services/notificationService.test.ts
+++ b/src/services/notificationService.test.ts
@@ -855,7 +855,7 @@ describe('createMessageNotification', () => {
   })
 
   it('crée une notification de message avec actionUrl /messagerie', async () => {
-    await createMessageNotification(USER_ID, 'Jean Martin', 'Bonjour, comment allez-vous ?')
+    await createMessageNotification(USER_ID, 'Jean Martin', 'Bonjour, comment allez-vous ?', 'msg-001')
 
     expect(mockRpc).toHaveBeenCalledWith('create_notification', expect.objectContaining({
       p_type: 'message_received',
@@ -866,7 +866,7 @@ describe('createMessageNotification', () => {
 
   it('tronque le message preview à 100 caractères', async () => {
     const longMessage = 'A'.repeat(150)
-    await createMessageNotification(USER_ID, 'Jean', longMessage)
+    await createMessageNotification(USER_ID, 'Jean', longMessage, 'msg-001')
 
     const call = mockRpc.mock.calls[0]
     const message = call[1].p_message as string

--- a/supabase/functions/_shared/emailTemplates.ts
+++ b/supabase/functions/_shared/emailTemplates.ts
@@ -1,0 +1,173 @@
+// ============================================
+// EMAIL TEMPLATES — Deno side
+// ============================================
+//
+// Les templates sont générés côté Edge Function pour que le client ne
+// puisse jamais injecter de HTML arbitraire dans le pipeline Resend.
+// Toute donnée externe (noms, contenus de message, dates) DOIT passer
+// par escapeHtml() avant interpolation.
+
+export interface ShiftReminderData {
+  recipientName: string
+  employerName: string
+  date: string
+  startTime: string
+  endTime?: string
+  address?: string
+}
+
+export interface NewMessageData {
+  recipientName: string
+  senderName: string
+  preview: string
+  conversationUrl: string
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function emailLayout(title: string, content: string): string {
+  return `<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${escapeHtml(title)}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F7F9FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;color:#1F2C3B;line-height:1.5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#F7F9FA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="560" style="max-width:560px;background-color:#FFFFFF;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(31,44,59,0.06);">
+          <tr>
+            <td style="background-color:#3D5166;padding:28px 32px;text-align:center;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0 auto 14px auto;">
+                <tr>
+                  <td style="background-color:#FFFFFF;border-radius:16px;padding:10px;">
+                    <img src="https://unilien.app/pwa-192x192.png" alt="Unilien" width="48" height="48" style="display:block;border:0;">
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0;color:#FFFFFF;font-size:22px;font-weight:700;letter-spacing:-0.02em;">Unilien</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 32px 24px 32px;">
+              ${content}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#EDF1F5;border-top:1px solid #C2D2E0;text-align:center;">
+              <p style="margin:0;font-size:12px;color:#6D93AD;">Unilien — Gestion de soins pour personnes handicapées</p>
+              <p style="margin:4px 0 0 0;font-size:12px;color:#6D93AD;"><a href="https://unilien.app" style="color:#3D5166;text-decoration:none;">unilien.app</a></p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}
+
+export function shiftReminderTemplate(data: ShiftReminderData): { subject: string; html: string; text: string } {
+  const safeRecipient = escapeHtml(data.recipientName)
+  const safeEmployer = escapeHtml(data.employerName)
+  const safeDate = escapeHtml(data.date)
+  const safeStart = escapeHtml(data.startTime)
+  const safeEnd = data.endTime ? escapeHtml(data.endTime) : ''
+  const safeAddress = data.address ? escapeHtml(data.address) : ''
+
+  const html = emailLayout(
+    "Rappel d'intervention",
+    `
+    <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Rappel d'intervention</h2>
+    <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Bonjour ${safeRecipient}, votre prochaine intervention est prévue pour demain.</p>
+
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color:#EDF1F5;border-radius:8px;margin-bottom:24px;">
+      <tr>
+        <td style="padding:20px 24px;">
+          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Date</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${safeDate}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Horaires</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${safeStart}${safeEnd ? ` – ${safeEnd}` : ''}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Employeur</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${safeEmployer}</span>
+              </td>
+            </tr>
+            ${safeAddress ? `
+            <tr>
+              <td style="padding:6px 0;">
+                <span style="font-size:13px;color:#6D93AD;display:block;">Adresse</span>
+                <span style="font-size:15px;color:#1F2C3B;font-weight:600;">${safeAddress}</span>
+              </td>
+            </tr>` : ''}
+          </table>
+        </td>
+      </tr>
+    </table>
+
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td align="center" style="padding:8px 0 0 0;">
+          <a href="https://unilien.app/planning" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Voir le planning</a>
+        </td>
+      </tr>
+    </table>
+  `
+  )
+
+  return {
+    subject: `Rappel : intervention demain ${data.date}`,
+    html,
+    text: `Bonjour ${data.recipientName}, rappel de votre intervention demain ${data.date} de ${data.startTime}${data.endTime ? ` à ${data.endTime}` : ''} chez ${data.employerName}.`,
+  }
+}
+
+export function newMessageTemplate(data: NewMessageData): { subject: string; html: string; text: string } {
+  const safeRecipient = escapeHtml(data.recipientName)
+  const safeSender = escapeHtml(data.senderName)
+  const safePreview = escapeHtml(data.preview)
+  // L'URL n'est pas escapée comme du HTML : on n'autorise que des URL https://unilien.app/* (validation côté Edge).
+  const safeUrl = escapeHtml(data.conversationUrl)
+
+  const html = emailLayout('Nouveau message', `
+    <h2 style="margin:0 0 16px 0;font-size:22px;font-weight:600;color:#1F2C3B;">Nouveau message</h2>
+    <p style="margin:0 0 24px 0;font-size:16px;color:#4E6478;">Bonjour ${safeRecipient}, <strong style="color:#1F2C3B;">${safeSender}</strong> vous a envoyé un message.</p>
+
+    <div style="background-color:#EDF1F5;border-left:3px solid #3D5166;border-radius:4px;padding:16px 20px;margin:0 0 24px 0;">
+      <p style="margin:0;font-size:15px;color:#4E6478;font-style:italic;">&ldquo;${safePreview}…&rdquo;</p>
+    </div>
+
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td align="center" style="padding:8px 0 0 0;">
+          <a href="${safeUrl}" style="display:inline-block;background-color:#3D5166;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:16px;font-weight:600;">Répondre</a>
+        </td>
+      </tr>
+    </table>
+  `)
+
+  return {
+    subject: `Nouveau message de ${data.senderName}`,
+    html,
+    text: `Bonjour ${data.recipientName}, vous avez reçu un message de ${data.senderName} : "${data.preview}"`,
+  }
+}

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,16 +1,26 @@
 // ============================================
 // SUPABASE EDGE FUNCTION: send-email
 // ============================================
+//
+// Sécurité (cf. SECURITY_CHECK_2026-05-13 HIGH-1) :
+// Le client ne peut PLUS spécifier `to` ni `html` directement. Il envoie
+// uniquement un `kind` (shift_reminder | new_message_notification) + des
+// IDs métier. La fonction résout côté serveur (service_role) le
+// destinataire et génère le HTML via les templates dans
+// `_shared/emailTemplates.ts`. Surface d'attaque "relais d'emails" =
+// fermée.
+
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
 import { createRateLimiter } from '../_shared/rateLimit.ts'
+import {
+  shiftReminderTemplate,
+  newMessageTemplate,
+} from '../_shared/emailTemplates.ts'
 
-interface EmailPayload {
-  to: string
-  subject: string
-  html: string
-  text?: string
-}
+type EmailRequest =
+  | { kind: 'shift_reminder'; shiftId: string; recipientId: string }
+  | { kind: 'new_message_notification'; messageId: string; recipientId: string }
 
 const ALLOWED_ORIGINS = [
   'https://unilien.app',
@@ -24,7 +34,30 @@ function getCorsOrigin(req: Request): string {
   return ALLOWED_ORIGINS[0]
 }
 
-const rateLimiter = createRateLimiter(10) // max 10 emails/min
+const rateLimiter = createRateLimiter(10) // max 10 emails/min/user
+
+function fail(message: string, status: number, headers: Record<string, string>) {
+  return new Response(JSON.stringify({ error: message }), { status, headers })
+}
+
+function formatFrenchDate(dateStr: string): string {
+  // dateStr au format ISO (YYYY-MM-DD)
+  try {
+    const d = new Date(dateStr + 'T00:00:00Z')
+    return new Intl.DateTimeFormat('fr-FR', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      timeZone: 'UTC',
+    }).format(d)
+  } catch {
+    return dateStr
+  }
+}
+
+function fullName(first: string | null, last: string | null): string {
+  return [first, last].filter(Boolean).join(' ').trim() || 'Utilisateur'
+}
 
 serve(async (req) => {
   const corsOrigin = getCorsOrigin(req)
@@ -52,47 +85,159 @@ serve(async (req) => {
     const resendApiKey = Deno.env.get('RESEND_API_KEY')
 
     if (!resendApiKey) {
-      return new Response(JSON.stringify({ error: 'RESEND_API_KEY not configured' }), {
-        status: 500,
-        headers: corsHeaders,
-      })
+      return fail('RESEND_API_KEY not configured', 500, corsHeaders)
     }
 
-    // Vérification JWT
+    // 1. Auth — JWT
     const authHeader = req.headers.get('authorization') || ''
     const token = authHeader.replace('Bearer ', '')
-    if (!token) {
-      return new Response(JSON.stringify({ error: 'Unauthorized - no token' }), {
-        status: 401,
-        headers: corsHeaders,
-      })
-    }
+    if (!token) return fail('Unauthorized - no token', 401, corsHeaders)
 
-    const authClient = createClient(supabaseUrl, supabaseServiceKey, {
+    const admin = createClient(supabaseUrl, supabaseServiceKey, {
       auth: { persistSession: false },
     })
-    const { data: { user }, error: authError } = await authClient.auth.getUser(token)
-    if (authError || !user) {
-      return new Response(JSON.stringify({ error: 'Unauthorized - invalid token' }), {
-        status: 401,
-        headers: corsHeaders,
-      })
-    }
+    const { data: { user }, error: authError } = await admin.auth.getUser(token)
+    if (authError || !user) return fail('Unauthorized - invalid token', 401, corsHeaders)
 
-    // Rate limiting
+    // 2. Rate limit (per-user, in-memory — cf. MEDIUM-2)
     if (rateLimiter.isLimited(user.id)) {
       return rateLimiter.tooManyRequestsResponse(corsHeaders)
     }
 
-    const payload: EmailPayload = await req.json()
-
-    if (!payload.to || !payload.subject || !payload.html) {
-      return new Response(JSON.stringify({ error: 'to, subject and html are required' }), {
-        status: 400,
-        headers: corsHeaders,
-      })
+    // 3. Parse + valide le payload
+    let body: EmailRequest
+    try {
+      body = await req.json()
+    } catch {
+      return fail('Invalid JSON', 400, corsHeaders)
     }
 
+    if (!body || typeof body !== 'object' || !('kind' in body)) {
+      return fail('Missing kind', 400, corsHeaders)
+    }
+
+    // 4. Résolution côté serveur selon le kind
+    let to: string
+    let subject: string
+    let html: string
+    let text: string
+
+    if (body.kind === 'shift_reminder') {
+      if (!body.shiftId || !body.recipientId) {
+        return fail('Missing shiftId or recipientId', 400, corsHeaders)
+      }
+
+      // Seul le destinataire peut déclencher son propre rappel.
+      // (Empêche un user d'envoyer des emails à un autre user au nom du système.)
+      if (body.recipientId !== user.id) {
+        return fail('Forbidden: recipient must be the caller', 403, corsHeaders)
+      }
+
+      const { data: shift, error: shiftErr } = await admin
+        .from('shifts')
+        .select(`
+          date,
+          start_time,
+          end_time,
+          contract:contracts!contract_id(
+            employer_id,
+            employee_id,
+            employer:profiles!employer_id(first_name, last_name)
+          )
+        `)
+        .eq('id', body.shiftId)
+        .single()
+
+      if (shiftErr || !shift) {
+        return fail('Shift not found', 404, corsHeaders)
+      }
+
+      const contract = Array.isArray(shift.contract) ? shift.contract[0] : shift.contract
+      if (!contract || contract.employee_id !== user.id) {
+        return fail('Forbidden: not your shift', 403, corsHeaders)
+      }
+
+      const { data: recipient, error: rcpErr } = await admin
+        .from('profiles')
+        .select('email, first_name, last_name')
+        .eq('id', body.recipientId)
+        .single()
+      if (rcpErr || !recipient?.email) {
+        return fail('Recipient email not found', 404, corsHeaders)
+      }
+
+      const employer = Array.isArray(contract.employer) ? contract.employer[0] : contract.employer
+      const rendered = shiftReminderTemplate({
+        recipientName: fullName(recipient.first_name, recipient.last_name),
+        employerName: fullName(employer?.first_name ?? null, employer?.last_name ?? null),
+        date: formatFrenchDate(shift.date),
+        startTime: shift.start_time,
+        endTime: shift.end_time || undefined,
+      })
+
+      to = recipient.email
+      subject = rendered.subject
+      html = rendered.html
+      text = rendered.text
+    } else if (body.kind === 'new_message_notification') {
+      if (!body.messageId || !body.recipientId) {
+        return fail('Missing messageId or recipientId', 400, corsHeaders)
+      }
+
+      const { data: message, error: msgErr } = await admin
+        .from('liaison_messages')
+        .select(`
+          content,
+          sender_id,
+          conversation:conversations!conversation_id(participant_ids),
+          sender:profiles!sender_id(first_name, last_name)
+        `)
+        .eq('id', body.messageId)
+        .single()
+
+      if (msgErr || !message) {
+        return fail('Message not found', 404, corsHeaders)
+      }
+
+      // Seul l'expéditeur peut déclencher la notification de SON message.
+      if (message.sender_id !== user.id) {
+        return fail('Forbidden: not message sender', 403, corsHeaders)
+      }
+
+      const conversation = Array.isArray(message.conversation) ? message.conversation[0] : message.conversation
+      const participants: string[] = conversation?.participant_ids ?? []
+      if (!participants.includes(body.recipientId) || body.recipientId === message.sender_id) {
+        return fail('Forbidden: recipient not in conversation', 403, corsHeaders)
+      }
+
+      const { data: recipient, error: rcpErr } = await admin
+        .from('profiles')
+        .select('email, first_name, last_name')
+        .eq('id', body.recipientId)
+        .single()
+      if (rcpErr || !recipient?.email) {
+        return fail('Recipient email not found', 404, corsHeaders)
+      }
+
+      const sender = Array.isArray(message.sender) ? message.sender[0] : message.sender
+      const fullContent = (message.content as string) || ''
+      const preview = fullContent.length > 120 ? fullContent.slice(0, 120) : fullContent
+      const rendered = newMessageTemplate({
+        recipientName: fullName(recipient.first_name, recipient.last_name),
+        senderName: fullName(sender?.first_name ?? null, sender?.last_name ?? null),
+        preview,
+        conversationUrl: 'https://unilien.app/messagerie',
+      })
+
+      to = recipient.email
+      subject = rendered.subject
+      html = rendered.html
+      text = rendered.text
+    } else {
+      return fail('Unknown kind', 400, corsHeaders)
+    }
+
+    // 5. Envoi Resend
     const res = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
@@ -101,15 +246,14 @@ serve(async (req) => {
       },
       body: JSON.stringify({
         from: 'Unilien <notifications@unilien.app>',
-        to: payload.to,
-        subject: payload.subject,
-        html: payload.html,
-        ...(payload.text ? { text: payload.text } : {}),
+        to,
+        subject,
+        html,
+        text,
       }),
     })
 
     const data = await res.json()
-
     if (!res.ok) {
       return new Response(JSON.stringify({ error: data }), {
         status: res.status,
@@ -122,9 +266,6 @@ serve(async (req) => {
       headers: corsHeaders,
     })
   } catch {
-    return new Response(JSON.stringify({ error: 'Internal error' }), {
-      status: 500,
-      headers: corsHeaders,
-    })
+    return fail('Internal error', 500, corsHeaders)
   }
 })


### PR DESCRIPTION
## Summary

Corrige **HIGH-1** du rapport `SECURITY_CHECK_2026-05-13` : l'Edge Function `send-email` était un relais d'emails ouvert pour tout user authentifié, qui pouvait envoyer 600 mails/h vers n'importe quelle adresse avec n'importe quel HTML depuis `notifications@unilien.app` (phishing, RGPD, facture Resend).

### Approche choisie (option 1 stricte du rapport)

Le client ne passe plus `{ to, subject, html }` libres. Le payload est réduit à un kind métier + IDs :

- `{ kind: 'shift_reminder', shiftId, recipientId }`
- `{ kind: 'new_message_notification', messageId, recipientId }`

L'Edge Function **résout côté `service_role`** :
- **shift_reminder** : SELECT shift + contrat, vérifie `recipientId == auth.uid()` ET `recipientId == contract.employee_id`. Sinon 403.
- **new_message_notification** : SELECT message + conversation, vérifie `auth.uid() == message.sender_id` ET `recipientId ∈ participant_ids` ET `recipientId != sender_id`. Sinon 403.

Templates HTML déplacés côté Deno (`supabase/functions/_shared/emailTemplates.ts`), toute donnée externe passe par `escapeHtml()` avant interpolation.

Surface "to/html arbitraires" → **fermée**. L'expéditeur `notifications@unilien.app` ne peut servir qu'à 2 cas d'usage métier connus.

### Changements

- **`supabase/functions/send-email/index.ts`** : refonte complète kind-based, lookup service_role, génération HTML serveur
- **`supabase/functions/_shared/emailTemplates.ts`** (nouveau) : templates Deno-side avec `escapeHtml()`
- **`src/services/emailService.ts`** : 194 → 45 lignes, plus de `sendEmail()` exposé, signatures `(shiftId, recipientId)` / `(messageId, recipientId)`
- **`src/services/notificationCreators.ts`** : suppression `getUserEmail` local, blocks email simplifiés
- **`src/services/notificationService.test.ts`** : 2 tests `createMessageNotification` mis à jour avec le nouveau param `messageId`
- **`src/services/liaisonService.ts`** : passe `data.id` à `createMessageNotification`
- **`docs/SECURITY_CHECK_2026-05-13.md`** : HIGH-1 marqué corrigé + plan §4 à jour

## Test plan

- [x] `npm run lint` — 0 errors (2 warnings préexistants)
- [x] `npm run test:run` — 2376 passed / 4 skipped / 0 fail
- [x] `npm run typecheck` — OK
- [ ] Déploiement Edge Functions sur VPS (workflow `deploy.yml` actuel : rsync `supabase/functions/` + restart container `functions`)
- [ ] **Test manuel shift_reminder** : ouvrir le dashboard d'un employé qui a un shift dans les 24h → vérifier que l'email part (logs container `functions`)
- [ ] **Test manuel new_message** : envoyer un message liaison à un autre user → vérifier que l'email part
- [ ] **Test négatif** : tenter de POST `/functions/v1/send-email` avec un payload `{ to: 'attaquant@gmail.com', html: '...' }` → 400 "Missing kind"
- [ ] **Test négatif kind** : POST avec `{ kind: 'shift_reminder', shiftId: '<id>', recipientId: '<autre user>' }` → 403 "recipient must be the caller"

⚠️ **Pas de tests automatisés sur Deno côté Edge** (pas de pipeline Deno actuellement). Toute la validation se fait via le test plan manuel ci-dessus post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)