### PR TITLE
feat(voice): diagnostics panel + fix close button on popup

### DIFF
--- a/src/components/voice/VoiceDiagnosticsCard.tsx
+++ b/src/components/voice/VoiceDiagnosticsCard.tsx
@@ -1,0 +1,95 @@
+import { Box, Button, Card, HStack, Stack, Text, VStack } from '@chakra-ui/react'
+import { useAccessibilityStore } from '@/stores/authStore'
+import { useVoiceDiagnosticsStore } from '@/stores/voiceDiagnosticsStore'
+
+/**
+ * Carte "Diagnostic vocal" — visible uniquement quand le contrôle vocal
+ * est activé. Affiche les 10 dernières transcriptions Whisper qui n'ont
+ * pas matché une commande, pour aider à identifier les variantes
+ * phonétiques manquantes (ex : Whisper transcrit "tablo de bord" au
+ * lieu de "tableau de bord").
+ *
+ * Les données sont en RAM (non persistées) et vidées au reload — pas
+ * de fuite dans localStorage. Cible : utilisateurs à élocution
+ * atypique qui veulent comprendre pourquoi une commande échoue.
+ */
+export function VoiceDiagnosticsCard() {
+  const voiceEnabled = useAccessibilityStore((s) => s.settings.voiceControlEnabled)
+  const entries = useVoiceDiagnosticsStore((s) => s.entries)
+  const clear = useVoiceDiagnosticsStore((s) => s.clear)
+
+  if (!voiceEnabled) return null
+
+  return (
+    <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm">
+      <Card.Header px={4} py={3} borderBottomWidth="1px" borderColor="border.default">
+        <HStack justify="space-between" align="center">
+          <Box>
+            <Card.Title fontFamily="heading" fontSize="lg" fontWeight="700">
+              Diagnostic vocal
+            </Card.Title>
+            <Text fontSize="sm" color="text.muted" mt={1}>
+              {entries.length === 0
+                ? 'Aucune commande non reconnue pour le moment.'
+                : `${entries.length} commande${entries.length > 1 ? 's' : ''} non reconnue${entries.length > 1 ? 's' : ''} dans cette session.`}
+            </Text>
+          </Box>
+          {entries.length > 0 && (
+            <Button size="sm" variant="ghost" onClick={clear}>
+              Effacer
+            </Button>
+          )}
+        </HStack>
+      </Card.Header>
+
+      {entries.length > 0 && (
+        <Card.Body p={4}>
+          <Stack gap={3}>
+            {entries.map((entry) => (
+              <Box
+                key={entry.id}
+                p={3}
+                borderRadius="md"
+                borderWidth="1px"
+                borderColor="border.default"
+                bg="bg.subtle"
+              >
+                <HStack justify="space-between" align="baseline" mb={1}>
+                  <Text fontWeight="600" fontSize="sm">
+                    « {entry.primary} »
+                  </Text>
+                  <Text fontSize="xs" color="text.muted">
+                    {new Date(entry.timestamp).toLocaleTimeString('fr-FR', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      second: '2-digit',
+                    })}
+                  </Text>
+                </HStack>
+                {entry.alternatives.length > 1 && (
+                  <VStack align="stretch" gap={0} mt={1}>
+                    <Text fontSize="xs" color="text.muted">
+                      Autres possibilités entendues :
+                    </Text>
+                    <Text fontSize="xs" color="text.muted" fontStyle="italic">
+                      {entry.alternatives
+                        .slice(1)
+                        .map((alt) => `« ${alt} »`)
+                        .join(' · ')}
+                    </Text>
+                  </VStack>
+                )}
+              </Box>
+            ))}
+          </Stack>
+          <Text fontSize="xs" color="text.muted" mt={4}>
+            Ces données sont temporaires et ne quittent pas votre appareil. Elles servent à
+            comprendre pourquoi une commande échoue et à enrichir la reconnaissance vocale.
+          </Text>
+        </Card.Body>
+      )}
+    </Card.Root>
+  )
+}
+
+export default VoiceDiagnosticsCard

--- a/src/components/voice/VoiceNavButton.tsx
+++ b/src/components/voice/VoiceNavButton.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/hooks/useAuth'
 
 export function VoiceNavButton() {
   const { profile } = useAuth()
-  const { enabled, status, engine, transcript, matched, error, modelProgress, speechDetected, toggle } = useVoiceNavigation()
+  const { enabled, status, engine, transcript, matched, error, modelProgress, speechDetected, toggle, stop } = useVoiceNavigation()
   const [showHelp, setShowHelp] = useState(false)
 
   // Raccourci clavier : Ctrl/Cmd + Shift + V
@@ -46,7 +46,7 @@ export function VoiceNavButton() {
 
   return (
     <Box position="fixed" bottom={{ base: '20px', md: '24px' }} right={{ base: '20px', md: '24px' }} zIndex={400}>
-      {(showHelp || transcript || error || isListening || isLoading) && (
+      {(showHelp || isListening || isLoading) && (
         <Box
           position="absolute"
           bottom="72px"
@@ -66,7 +66,13 @@ export function VoiceNavButton() {
               aria-label="Fermer l'aide vocale"
               size="2xs"
               variant="ghost"
-              onClick={() => setShowHelp(false)}
+              onClick={() => {
+                // Si l'utilisateur ferme pendant l'écoute, on arrête aussi
+                // le micro — sinon la modale disparaît mais le moteur
+                // continue de tourner sans feedback visuel.
+                if (isListening || isLoading) stop()
+                setShowHelp(false)
+              }}
             >
               <NavIcon name="close" size={14} />
             </IconButton>

--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAccessibilityStore } from '@/stores/authStore'
+import { useVoiceDiagnosticsStore } from '@/stores/voiceDiagnosticsStore'
 import { useAuth } from '@/hooks/useAuth'
 import { matchCommand, type VoiceCommand } from '@/lib/voice/voiceCommands'
 import { formatVoiceError } from '@/lib/voice/errors'
@@ -77,6 +78,13 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
         navigate(cmd.path)
       } else if (primary) {
         setError(`Commande non reconnue : "${primary}"`)
+        // Log dans le panneau diagnostic (Paramètres > Assistance) pour permettre
+        // à l'utilisateur d'identifier ce que Whisper a réellement entendu et
+        // d'ajuster les variantes phonétiques si besoin.
+        useVoiceDiagnosticsStore.getState().pushEntry({
+          primary,
+          alternatives: candidates,
+        })
       }
     },
     [navigate, profile?.role],

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -44,6 +44,7 @@ import { useInterventionSettings } from '@/hooks/useInterventionSettings'
 import { ShoppingListTemplatesSection } from '@/components/profile/ShoppingListTemplatesSection'
 import { useConventionSettings } from '@/hooks/useConventionSettings'
 import { usePrivacySettings } from '@/hooks/usePrivacySettings'
+import { VoiceDiagnosticsCard } from '@/components/voice/VoiceDiagnosticsCard'
 import { useMfa } from '@/hooks/useMfa'
 import { MfaEnrollment } from '@/components/auth/MfaEnrollment'
 import { DEFAULT_TASKS } from '@/lib/constants/taskDefaults'
@@ -1979,6 +1980,8 @@ function AccessibilitePanel() {
           </VStack>
         </Card.Body>
       </Card.Root>
+
+      <VoiceDiagnosticsCard />
 
       <HStack gap={2} align="center">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} width={14} height={14} aria-hidden="true" style={{ flexShrink: 0 }}><rect x="3" y="3" width="18" height="18" rx="2" /><path d="M3 9h18M9 21V9" /></svg>

--- a/src/stores/voiceDiagnosticsStore.ts
+++ b/src/stores/voiceDiagnosticsStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand'
+
+/**
+ * Diagnostic vocal — store éphémère (RAM only, pas persisté).
+ *
+ * Garde les 10 dernières transcriptions Whisper qui n'ont pas matché
+ * une commande, pour permettre à l'utilisateur (ou à un proche dev) de
+ * voir ce que le moteur de reconnaissance a réellement entendu quand
+ * une commande échoue. Utile pour ajuster les variantes phonétiques
+ * dans `src/lib/voice/voiceCommands.ts` quand un utilisateur cible
+ * (ex: Marie) reporte que "ça ne reconnaît rien".
+ *
+ * Pas de persistance : les données sont vidées au reload, le panneau
+ * Paramètres affiche uniquement la session courante. Évite toute fuite
+ * via localStorage.
+ */
+
+export interface VoiceDiagnosticEntry {
+  id: string
+  timestamp: number
+  primary: string
+  alternatives: string[]
+}
+
+interface VoiceDiagnosticsState {
+  entries: VoiceDiagnosticEntry[]
+  pushEntry: (entry: Omit<VoiceDiagnosticEntry, 'id' | 'timestamp'>) => void
+  clear: () => void
+}
+
+const MAX_ENTRIES = 10
+
+export const useVoiceDiagnosticsStore = create<VoiceDiagnosticsState>((set) => ({
+  entries: [],
+  pushEntry: ({ primary, alternatives }) =>
+    set((state) => ({
+      entries: [
+        {
+          id:
+            typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+              ? crypto.randomUUID()
+              : `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+          timestamp: Date.now(),
+          primary,
+          alternatives,
+        },
+        ...state.entries,
+      ].slice(0, MAX_ENTRIES),
+    })),
+  clear: () => set({ entries: [] }),
+}))


### PR DESCRIPTION
## Summary

PR 1/2 du chantier nav vocale "régression Marie depuis le 11/05" : commande non reconnue tantôt OK, tantôt KO chez Marie depuis les PRs #374 / #375 (qui étaient elles-mêmes des fixes de bugs prod). Plutôt que de revert à l'aveugle, on **observe** d'abord ce que Whisper transcrit réellement quand Marie parle, puis on ajustera (PR 2) — soit en enrichissant les variantes phonétiques dans `voiceCommands.ts`, soit en élargissant la tolérance fuzzy.

### 1. Panneau "Diagnostic vocal"

- Nouveau store `voiceDiagnosticsStore` (Zustand, RAM only, max 10 entrées).
- `useVoiceNavigation` push une entry à chaque échec de match (`cmd === null && primary !== ''`) avec la transcription principale + les alternatives.
- Nouvelle carte `VoiceDiagnosticsCard` affichée sous "Assistance" dans Paramètres > Accessibilité, **uniquement quand le contrôle vocal est activé**. Liste les 10 dernières transcriptions ratées, avec horodatage, et bouton "Effacer".
- Pas de persistance : tout est vidé au reload. Pas de fuite localStorage.

**UX cible** : Marie utilise normalement. À la prochaine session, on (toi ou elle) ouvre Paramètres > Accessibilité, on voit ce que Whisper a entendu sur les commandes ratées (ex: "tablo de bord", "plening"), on en déduit les variantes à ajouter en PR 2.

### 2. Fix bouton fermeture (×)

Bug rapporté : cliquer la croix du popup nav vocale après un échec ne ferme rien. Cause : la condition d'affichage du popup était `showHelp || transcript || error || isListening || isLoading` — après un échec, `transcript` et `error` restent renseignés, donc `setShowHelp(false)` ne masque pas le popup.

Fix :
- Condition simplifiée à `showHelp || isListening || isLoading` (on ne reste plus ouvert juste à cause d'un transcript / error résiduels).
- La croix appelle aussi `stop()` si le micro est encore actif, pour éviter une situation où la modale est fermée mais Whisper continue de tourner sans feedback.

### Changements

- `src/stores/voiceDiagnosticsStore.ts` (nouveau, 50 lignes)
- `src/components/voice/VoiceDiagnosticsCard.tsx` (nouveau, ~90 lignes)
- `src/components/voice/VoiceNavButton.tsx` — fix croix + condition d'affichage
- `src/hooks/useVoiceNavigation.ts` — push diagnostic on no-match
- `src/pages/SettingsPage.tsx` — intégration de la carte sous "Assistance"

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — OK
- [x] `npm run test:run` — 2376 passed (5 tests VoiceNavButton continuent à passer après le changement de condition)
- [ ] **Test manuel fermeture** : activer la nav vocale → ouvrir le popup (clic mic ou Ctrl+Maj+V) → dire une commande inexistante → toast "Commande non reconnue : '...'" affiché → cliquer la × → popup se ferme proprement ✅
- [ ] **Test manuel diagnostic** : faire 2-3 tentatives qui échouent → ouvrir Paramètres > Accessibilité → la carte "Diagnostic vocal" liste les 2-3 transcriptions ratées avec horodatage. Bouton "Effacer" vide la liste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)