### PR TITLE
chore(build): keep only asyncify+base ONNX WASM variants (-41 Mo)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,8 +15,15 @@ export default defineConfig({
         { src: 'node_modules/@ricky0123/vad-web/dist/vad.worklet.bundle.min.js', dest: './', rename: { stripBase: true } },
         { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_v5.onnx', dest: './', rename: { stripBase: true } },
         { src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_legacy.onnx', dest: './', rename: { stripBase: true } },
-        { src: 'node_modules/onnxruntime-web/dist/*.wasm', dest: './', rename: { stripBase: true } },
-        { src: 'node_modules/onnxruntime-web/dist/*.mjs', dest: './', rename: { stripBase: true } },
+        // onnxruntime-web — variants WASM utilisés par Whisper en runtime.
+        // On garde uniquement asyncify (universel CPU SIMD threaded) et la variante base.
+        // jsep (WebGPU) et jspi (Chrome 123+) sont des optimisations dont on se passe
+        // pour réduire le bundle de ~39 Mo. Le runtime fallback sur asyncify si absent.
+        { src: 'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.wasm', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.wasm', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.asyncify.mjs', dest: './', rename: { stripBase: true } },
+        { src: 'node_modules/onnxruntime-web/dist/ort.*.mjs', dest: './', rename: { stripBase: true } },
       ],
     }),
     VitePWA({


### PR DESCRIPTION
## Summary

Réduction du bundle de production en filtrant les variantes ONNX WASM copiées par `vite-plugin-static-copy`. Le glob `*.wasm` copiait les 4 variantes (asyncify + jsep + jspi + base) totalisant ~75 Mo, alors que Whisper n'a besoin que d'asyncify (fallback CPU SIMD threaded universel) et de la variante base.

`dist/` passe de **122 Mo à 81 Mo** (-41 Mo, -34%).

### Changements

- `vite.config.ts` : remplace les globs `*.wasm` et `*.mjs` par 4 entries explicites :
  - `ort-wasm-simd-threaded.wasm` + `.mjs` (CPU SIMD threaded, base)
  - `ort-wasm-simd-threaded.asyncify.wasm` + `.mjs` (universel)
  - `ort.*.mjs` glob conservé pour les bundles ONNX runtime (loaders, tailles négligeables)
- Drop : `ort-wasm-simd-threaded.jsep.{wasm,mjs}` (-25 Mo, accélération WebGPU optionnelle)
- Drop : `ort-wasm-simd-threaded.jspi.{wasm,mjs}` (-14 Mo, JS Promise Integration Chrome 123+)

### Pourquoi c'est sûr

Le runtime onnxruntime-web auto-sélectionne la variante selon les capacités du navigateur. Si `jsep` ou `jspi` sont absents, il bascule automatiquement sur `asyncify` (toujours présent). La nav vocale Whisper continue de fonctionner sur tous les browsers — un peu moins rapide sur Chrome WebGPU, imperceptible à l'usage (lazy-loadée + transcription de courtes commandes).

## Test plan

- [x] `npm run build` OK (31s, pas d'erreur)
- [x] `npm run lint` : 0 errors (2 warnings préexistants non liés)
- [x] `npm run test:run` : 2376 passed / 4 skipped (clock-in v1)
- [x] Vérification `dist/` : seuls asyncify (23M) + base wasm (13M) présents
- [ ] Test manuel nav vocale en preview (Ctrl+Maj+V) sur Chrome + Firefox après déploiement
- [ ] Vérifier qu'il n'y a pas de 404 sur `/ort-wasm-simd-threaded.{jsep,jspi}.wasm` dans la console réseau

🤖 Generated with [Claude Code](https://claude.com/claude-code)