### PR TITLE
docs(csp): document why 'unsafe-eval' must stay in Caddyfile

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -10,6 +10,12 @@ unilien.app, www.unilien.app {
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "camera=(), microphone=(self), geolocation=()"
+        # CSP — 'unsafe-eval' est requis par onnxruntime-web (nav vocale Whisper) :
+        # le code Emscripten génère ses wrappers de méthodes natives via `new Function()`,
+        # qui n'est PAS couvert par 'wasm-unsafe-eval' (lui ne couvre que la compilation
+        # WebAssembly, pas la création dynamique de fonctions JS). Vérifié sur build prod
+        # 14/05/2026 (vendor-whisper-*.js : 1× `new Function()`). Tant que la nav vocale
+        # est shippée, on doit garder 'unsafe-eval'. Cf. PR #288 (ajout initial).
         Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob: https://plausible.unilien.app; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.unilien.app wss://api.unilien.app https://plausible.unilien.app https://huggingface.co https://*.huggingface.co https://*.hf.co; img-src 'self' data: blob: https://api.unilien.app; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     }
 


### PR DESCRIPTION
## Summary

L'audit sécurité de la session avait suggéré de tester le retrait de `'unsafe-eval'` du CSP en s'appuyant sur `'wasm-unsafe-eval'`. Vérification dans le bundle prod : **impossible**, ça casserait Whisper.

`vendor-whisper-*.js` contient un `new Function(Object.keys(ie),he)(...)` (pattern `methodCaller` Emscripten généré par onnxruntime-web pour wrapper les méthodes natives WASM). `'wasm-unsafe-eval'` ne couvre QUE `WebAssembly.compile/instantiate`, pas `new Function()`.

Cette PR ajoute juste un commentaire inline dans le Caddyfile à côté du header CSP pour qu'aucun futur audit (humain ou IA) ne re-propose ce changement sans contexte.

### Changements

- `infra/caddy/Caddyfile` : commentaire de 6 lignes au-dessus du `Content-Security-Policy` expliquant pourquoi `'unsafe-eval'` est requis et la verification concrète sur le bundle prod.

### Aucun changement runtime

Pas de modification du header CSP lui-même, juste de la documentation. Pas besoin de redéployer le Caddyfile sur le VPS.

## Test plan

- [x] Vérification sur build prod : `vendor-whisper-*.js` contient bien 1× `new Function()` (pattern `T=new Function(Object.keys(ie),he)(...Object.values(ie))`)
- [x] Lecture upstream : la spec CSP3 confirme que `'wasm-unsafe-eval'` ne couvre que la compilation WebAssembly, pas l'évaluation JS dynamique
- [N/A] Pas de runtime impact, pas de redéploiement infra

## Suite

Pour pouvoir un jour retirer `'unsafe-eval'`, il faudrait :
- soit attendre une version d'`onnxruntime-web` qui n'utilise plus `new Function()` (peu probable côté upstream)
- soit mettre en place une CSP différente par route via Caddy (eval seulement sur les pages chargeant Whisper)
- soit désactiver complètement la nav vocale

🤖 Generated with [Claude Code](https://claude.com/claude-code)