### PR TITLE
refactor(caregiver): centralize legal + contract status labels

### DIFF
--- a/src/components/profile/sections/CaregiverSection.tsx
+++ b/src/components/profile/sections/CaregiverSection.tsx
@@ -49,13 +49,9 @@ const relationshipOptions: { value: CaregiverRelationship; label: string }[] = [
   { value: 'other', label: 'Autre' },
 ]
 
-const legalStatusOptions: { value: CaregiverLegalStatus; label: string }[] = [
-  { value: 'none', label: 'Aucun statut particulier' },
-  { value: 'tutor', label: 'Tuteur' },
-  { value: 'curator', label: 'Curateur' },
-  { value: 'safeguard_justice', label: 'Sauvegarde de justice' },
-  { value: 'family_caregiver', label: 'Aidant familial reconnu' },
-]
+import { CAREGIVER_LEGAL_STATUS_OPTIONS } from '@/lib/constants/statusMaps'
+
+const legalStatusOptions = CAREGIVER_LEGAL_STATUS_OPTIONS
 
 export function CaregiverSection({ profileId }: CaregiverSectionProps) {
   const [isLoading, setIsLoading] = useState(false)

--- a/src/components/team/AddCaregiverModal.tsx
+++ b/src/components/team/AddCaregiverModal.tsx
@@ -19,6 +19,7 @@ import {
 import { logger } from '@/lib/logger'
 import { toaster } from '@/lib/toaster'
 import type { CaregiverPermissions, CaregiverLegalStatus } from '@/types'
+import { CAREGIVER_LEGAL_STATUS_OPTIONS } from '@/lib/constants/statusMaps'
 
 // ============================================
 // PROPS
@@ -54,14 +55,7 @@ const ALL_PERMISSIONS: CaregiverPermissions = {
   canExportData: true,
 }
 
-// Options de statut juridique
-const legalStatusOptions: { value: CaregiverLegalStatus | 'none'; label: string }[] = [
-  { value: 'none', label: 'Aucun statut particulier' },
-  { value: 'tutor', label: 'Tuteur' },
-  { value: 'curator', label: 'Curateur' },
-  { value: 'safeguard_justice', label: 'Sauvegarde de justice' },
-  { value: 'family_caregiver', label: 'Aidant familial reconnu' },
-]
+const legalStatusOptions = CAREGIVER_LEGAL_STATUS_OPTIONS
 
 // ============================================
 // COMPONENT

--- a/src/components/team/CaregiverCard.tsx
+++ b/src/components/team/CaregiverCard.tsx
@@ -8,12 +8,7 @@ import {
 import { AccessibleButton } from '@/components/ui'
 import type { CaregiverWithProfile } from '@/services/caregiverService'
 import type { Contract } from '@/types'
-
-const caregiverStatusLabels: Record<string, string> = {
-  active: 'PCH actif',
-  full_time: 'PCH temps plein',
-  voluntary: 'Bénévole',
-}
+import { CAREGIVER_CONTRACT_STATUS_LABELS } from '@/lib/constants/statusMaps'
 
 interface CaregiverCardProps {
   caregiver: CaregiverWithProfile
@@ -47,7 +42,7 @@ export function CaregiverCard({ caregiver, contract, onEdit, onRemove }: Caregiv
   ].filter(Boolean).length
 
   const statusLabel = contract
-    ? caregiverStatusLabels[contract.caregiverStatus || ''] || 'Contrat actif'
+    ? CAREGIVER_CONTRACT_STATUS_LABELS[contract.caregiverStatus || ''] || 'Contrat actif'
     : undefined
 
   return (

--- a/src/components/team/EditCaregiverModal.tsx
+++ b/src/components/team/EditCaregiverModal.tsx
@@ -16,24 +16,12 @@ import { AccessibleButton, AccessibleInput, AccessibleSelect, GhostButton } from
 import { updateCaregiver, type CaregiverWithProfile } from '@/services/caregiverService'
 import { getActiveCaregiverContract, terminateContract, updateContract } from '@/services/contractService'
 import { PCH_RATES } from '@/types'
-import type { Contract, CaregiverPermissions, CaregiverLegalStatus, CaregiverContractStatus } from '@/types'
+import type { Contract, CaregiverPermissions, CaregiverContractStatus } from '@/types'
 import { toaster } from '@/lib/toaster'
-
-// Labels pour les statuts juridiques
-const legalStatusLabels: Record<CaregiverLegalStatus, string> = {
-  none: 'Aucun statut particulier',
-  tutor: 'Tuteur',
-  curator: 'Curateur',
-  safeguard_justice: 'Sauvegarde de justice',
-  family_caregiver: 'Aidant familial reconnu',
-}
-
-// Labels statut contrat aidant
-const caregiverStatusLabels: Record<string, string> = {
-  active: 'PCH — Maintient une activité pro',
-  full_time: 'PCH — A cessé son activité pro',
-  voluntary: 'Bénévole',
-}
+import {
+  CAREGIVER_LEGAL_STATUS_LABELS,
+  CAREGIVER_CONTRACT_STATUS_LABELS,
+} from '@/lib/constants/statusMaps'
 
 // ============================================
 // PROPS
@@ -266,7 +254,7 @@ export function EditCaregiverModal({
                       </Tag.Root>
                       {legalStatus && legalStatus !== 'none' && (
                         <Tag.Root colorPalette="blue" size="sm">
-                          <Tag.Label>{legalStatusLabels[legalStatus]}</Tag.Label>
+                          <Tag.Label>{CAREGIVER_LEGAL_STATUS_LABELS[legalStatus]}</Tag.Label>
                         </Tag.Root>
                       )}
                     </Flex>
@@ -414,7 +402,7 @@ export function EditCaregiverModal({
                             <>
                               <InfoRow
                                 label="Statut"
-                                value={caregiverStatusLabels[caregiverContract.caregiverStatus || ''] || 'Aidant'}
+                                value={CAREGIVER_CONTRACT_STATUS_LABELS[caregiverContract.caregiverStatus || ''] || 'Aidant'}
                               />
                               <InfoRow
                                 label="Heures hebdomadaires"

--- a/src/lib/constants/statusMaps.ts
+++ b/src/lib/constants/statusMaps.ts
@@ -1,4 +1,4 @@
-import type { Shift, Absence } from '@/types'
+import type { Shift, Absence, CaregiverLegalStatus, CaregiverContractStatus } from '@/types'
 
 // ─── Shift ───────────────────────────────────────────────────────────────────
 
@@ -66,4 +66,25 @@ export const ABSENCE_TYPE_COLORS: Record<Absence['absenceType'], string> = {
   training: 'purple',
   unavailable: 'gray',
   emergency: 'orange',
+}
+
+// ─── Caregiver ───────────────────────────────────────────────────────────────
+
+export const CAREGIVER_LEGAL_STATUS_LABELS: Record<CaregiverLegalStatus, string> = {
+  none: 'Aucun statut particulier',
+  tutor: 'Tuteur',
+  curator: 'Curateur',
+  safeguard_justice: 'Sauvegarde de justice',
+  family_caregiver: 'Aidant familial reconnu',
+}
+
+export const CAREGIVER_LEGAL_STATUS_OPTIONS: { value: CaregiverLegalStatus; label: string }[] =
+  (Object.entries(CAREGIVER_LEGAL_STATUS_LABELS) as [CaregiverLegalStatus, string][])
+    .map(([value, label]) => ({ value, label }))
+
+// Libellés conformes au vocabulaire IDCC 3239 (cf. Article 2 — situations PCH)
+export const CAREGIVER_CONTRACT_STATUS_LABELS: Record<CaregiverContractStatus, string> = {
+  active: 'PCH — Maintient une activité pro',
+  full_time: 'PCH — A cessé son activité pro',
+  voluntary: 'Bénévole',
 }


### PR DESCRIPTION
## Summary

Les libellés de statut juridique aidant et de statut contrat aidant étaient redéfinis localement dans 4 composants — avec en bonus une **divergence visuelle** entre `CaregiverCard` (« PCH actif » / « PCH temps plein ») et `EditCaregiverModal` (« PCH — Maintient une activité pro » / « PCH — A cessé son activité pro »). Centralisation dans `statusMaps.ts` avec harmonisation sur la version IDCC 3239 (canonique).

### Changements

- `src/lib/constants/statusMaps.ts` :
  - `CAREGIVER_LEGAL_STATUS_LABELS` (Record) — 5 entries (none, tutor, curator, safeguard_justice, family_caregiver)
  - `CAREGIVER_LEGAL_STATUS_OPTIONS` (Array dérivée, format `{value, label}` pour les selects)
  - `CAREGIVER_CONTRACT_STATUS_LABELS` (Record) — 3 entries, wording IDCC 3239
- 4 composants migrés (suppression des constantes locales, import depuis `statusMaps`) :
  - `EditCaregiverModal.tsx`
  - `AddCaregiverModal.tsx`
  - `CaregiverSection.tsx`
  - `CaregiverCard.tsx`

### Régression visuelle volontaire (CaregiverCard)

Les badges affichaient :
- avant : « PCH actif » / « PCH temps plein » / « Bénévole »
- après : « PCH — Maintient une activité pro » / « PCH — A cessé son activité pro » / « Bénévole »

Plus long mais consistent avec le reste de l'app et conforme au vocabulaire IDCC 3239 (Article 2 — situations PCH).

### Note sur l'audit qui a déclenché la PR

L'audit avait aussi pointé `DOT_COLORS` / `STATUS_LABELS` dans les 2 timelines (`CaregiverShiftTimeline`, `EmployeeShiftTimeline`) comme dupliqués — vérification : faux positif, les palettes sont volontairement différentes (caregiver = `warm`, employee = `accent`). Skipped.

## Test plan

- [x] `npm run lint` : 0 errors (2 warnings préexistants)
- [x] `npm run typecheck` : OK
- [x] `npm run test:run` : **2376 passed / 4 skipped** — aucune régression
- [ ] Test manuel : ouvrir une carte aidant (TeamPage employer) — vérifier les nouveaux libellés badges
- [ ] Test manuel : ouvrir le modal Edit aidant — légende et select inchangés

🤖 Generated with [Claude Code](https://claude.com/claude-code)