### PR TITLE
perf(supabase): boolean check in hasActiveContract + select('id') alignment

### DIFF
--- a/src/services/contractService.test.ts
+++ b/src/services/contractService.test.ts
@@ -277,7 +277,7 @@ describe('contractService', () => {
   })
 
   describe('getActiveContractsCount', () => {
-    // Chaine: .select('*', { count, head }).eq('employer_id').eq('status')
+    // Chaine: .select('id', { count, head }).eq('employer_id').eq('status')
     // 2 appels .eq() : le 1er doit retourner le chainage, le 2e doit resoudre
 
     it('devrait retourner le nombre de contrats actifs', async () => {
@@ -763,18 +763,19 @@ describe('contractService', () => {
   })
 
   describe('hasActiveContract', () => {
-    // Chaine: .select('*', { count, head }).eq('employer_id').eq('employee_id').eq('status')
-    // 3 appels .eq() : les 2 premiers retournent le chainage, le 3e resolve
+    // Chaine: .select('id').eq('employer_id').eq('employee_id').eq('status').limit(1).maybeSingle()
+    // 3 appels .eq() puis .limit() qui retourne { maybeSingle }.
 
     function setupHasActiveContractMock(resolvedValue: Record<string, unknown>) {
+      const mockLimit = vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue(resolvedValue) })
       mockEq
         .mockReturnValueOnce({ eq: mockEq, single: mockSingle, maybeSingle: mockMaybeSingle, order: mockOrder })
         .mockReturnValueOnce({ eq: mockEq, single: mockSingle, maybeSingle: mockMaybeSingle, order: mockOrder })
-        .mockResolvedValueOnce(resolvedValue)
+        .mockReturnValueOnce({ limit: mockLimit })
     }
 
     it('devrait retourner true quand un contrat actif existe', async () => {
-      setupHasActiveContractMock({ count: 1, error: null })
+      setupHasActiveContractMock({ data: { id: 'contract-1' }, error: null })
 
       const result = await hasActiveContract('employer-456', 'employee-789')
 
@@ -782,15 +783,7 @@ describe('contractService', () => {
     })
 
     it('devrait retourner false quand aucun contrat actif', async () => {
-      setupHasActiveContractMock({ count: 0, error: null })
-
-      const result = await hasActiveContract('employer-456', 'employee-789')
-
-      expect(result).toBe(false)
-    })
-
-    it('devrait retourner false quand count est null', async () => {
-      setupHasActiveContractMock({ count: null, error: null })
+      setupHasActiveContractMock({ data: null, error: null })
 
       const result = await hasActiveContract('employer-456', 'employee-789')
 
@@ -798,7 +791,7 @@ describe('contractService', () => {
     })
 
     it('devrait retourner false en cas d\'erreur', async () => {
-      setupHasActiveContractMock({ count: null, error: { message: 'Database error' } })
+      setupHasActiveContractMock({ data: null, error: { message: 'Database error' } })
 
       const result = await hasActiveContract('employer-456', 'employee-789')
 

--- a/src/services/contractService.ts
+++ b/src/services/contractService.ts
@@ -168,7 +168,7 @@ export async function getContractsForEmployee(
 export async function getActiveContractsCount(employerId: string): Promise<number> {
   const { count, error } = await supabase
     .from('contracts')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .eq('employer_id', employerId)
     .eq('status', 'active')
 
@@ -518,19 +518,23 @@ export async function hasActiveContract(
   employerId: string,
   employeeId: string
 ): Promise<boolean> {
-  const { count, error } = await supabase
+  // Boolean check : on s'arrête à la première ligne trouvée plutôt que de
+  // faire un COUNT(*) qui scanne toute la table.
+  const { data, error } = await supabase
     .from('contracts')
-    .select('*', { count: 'exact', head: true })
+    .select('id')
     .eq('employer_id', employerId)
     .eq('employee_id', employeeId)
     .eq('status', 'active')
+    .limit(1)
+    .maybeSingle()
 
   if (error) {
     logger.error('Erreur vérification contrat:', error)
     return false
   }
 
-  return (count || 0) > 0
+  return data !== null
 }
 
 export async function getActiveCaregiverContract(

--- a/src/services/liaisonService.ts
+++ b/src/services/liaisonService.ts
@@ -85,7 +85,7 @@ export async function getConversations(
     // Nombre de messages non lus (inclut read_by NULL = jamais lu)
     const { count: unreadCount } = await supabase
       .from('liaison_messages')
-      .select('*', { count: 'exact', head: true })
+      .select('id', { count: 'exact', head: true })
       .eq('conversation_id', conv.id)
       .neq('sender_id', userId)
       .or(`read_by.is.null,read_by.not.cs.{${userId}}`)
@@ -505,7 +505,7 @@ export async function getLiaisonUnreadCount(
 ): Promise<number> {
   const { count, error } = await supabase
     .from('liaison_messages')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .eq('conversation_id', conversationId)
     .neq('sender_id', userId)
     .or(`read_by.is.null,read_by.not.cs.{${userId}}`)
@@ -527,7 +527,7 @@ export async function getTotalUnreadCount(
 ): Promise<number> {
   const { count, error } = await supabase
     .from('liaison_messages')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .eq('employer_id', employerId)
     .neq('sender_id', userId)
     .or(`read_by.is.null,read_by.not.cs.{${userId}}`)
@@ -548,7 +548,7 @@ export async function getTotalUnreadCount(
 export async function getUnreadCountForUser(userId: string): Promise<number> {
   const { count, error } = await supabase
     .from('liaison_messages')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .neq('sender_id', userId)
     .or(`read_by.is.null,read_by.not.cs.{${userId}}`)
 

--- a/src/services/logbookService.ts
+++ b/src/services/logbookService.ts
@@ -304,7 +304,7 @@ export async function getUnreadCount(
 ): Promise<number> {
   const { count, error } = await supabase
     .from('log_entries')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .eq('employer_id', employerId)
     .not('read_by', 'cs', `{${userId}}`)
 

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -68,7 +68,7 @@ export async function getNotifications(
 export async function getUnreadNotificationCount(userId: string): Promise<number> {
   const { count, error } = await supabase
     .from('notifications')
-    .select('*', { count: 'exact', head: true })
+    .select('id', { count: 'exact', head: true })
     .eq('user_id', userId)
     .eq('is_read', false)
     .eq('is_dismissed', false)


### PR DESCRIPTION
## Summary

L'audit pointait 7 appels `.select('*', { count: 'exact', head: true })` comme inefficaces. Vrai gain trouvé : `hasActiveContract` faisait un `COUNT(*)` sur toute la table `contracts` filtrée, juste pour dériver un boolean. Bascule en `.limit(1).maybeSingle()` qui s'arrête à la première ligne trouvée.

Les 6 autres callers restent légitimement des counts (badges non lus, dashboard stats), mais migrent de `select('*')` à `select('id')` pour s'aligner sur la convention déjà en place ailleurs (`EmployerDashboard`, `EmployeeDashboard`, `OnboardingWidget`, `nudgeService` font tous `select('id')`).

### Changements

**Vrai gain perf** :
- `contractService.ts:hasActiveContract` : `COUNT(*)` filtré → `.select('id').limit(1).maybeSingle()`. Postgres s'arrête à la 1ère ligne au lieu de scanner toutes les lignes filtrées par RLS.

**Alignement convention** (`select('*')` → `select('id')`) :
- `contractService.ts:getActiveContractsCount`
- `notificationService.ts:getUnreadNotificationCount`
- `logbookService.ts:getUnreadCount`
- `liaisonService.ts` : 4 helpers (`listConversations` boucle, `getLiaisonUnreadCount`, `getTotalUnreadCount`, `getUnreadCountForUser`)

**Tests** :
- `contractService.test.ts:hasActiveContract` : 3 tests adaptés à la nouvelle chaîne (`.select.eq.eq.eq.limit.maybeSingle`). Le cas "count est null" devient redondant avec "aucun contrat actif" (data null = false). Les couvertures restent.

### Pas adressé

Le N+1 dans `liaisonService.listConversations` (1 count par conversation dans une boucle) reste à faire — c'est un refactor distinct, mieux traité avec une RPC ou aggregate query, hors scope d'un cleanup à 1h.

## Test plan

- [x] `npm run lint` : 0 errors
- [x] `npm run typecheck` : OK
- [x] `npm run test:run` : **2375 passed / 4 skipped** (vs 2376 avant : -1 test obsolète "count est null", remplacé fonctionnellement par "aucun contrat trouvé")
- [ ] Test manuel : valider qu'un assignment d'employé déjà sous contrat actif est toujours bloqué (le check `hasActiveContract` est utilisé dans le flow d'invitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)