### PR TITLE
docs(session): add audit & cleanup session report 2026-05-14

### DIFF
--- a/docs/AUDIT_SESSION_2026-05-14.md
+++ b/docs/AUDIT_SESSION_2026-05-14.md
@@ -1,0 +1,187 @@
+# Session audit & cleanup — 14 mai 2026
+
+Synthèse de la session de cleanup post-audit lancée via `/wd:analyze` (depth=deep, scope=tout le projet). 4 agents Explore en parallèle (qualité, sécurité, performance, architecture) → rapport consolidé → **5 PRs livrées**.
+
+---
+
+## 1. Audit initial — résumé
+
+**Score global** :
+
+| Domaine | Score | État |
+|---|---|---|
+| Sécurité / RGPD | 9/10 | 🟢 Excellent — 0 critical, posture art. 9 conforme |
+| Architecture | 8/10 | 🟢 Solide — séparation claire, type safety bonne |
+| Qualité code | 7/10 | 🟡 Bon — quelques fichiers obèses, dette modérée |
+| Performance | 6/10 | 🟠 Levier majeur — bundle WASM x4 à fixer |
+
+**Périmètre** : 456 fichiers TS/TSX, 64 migrations Supabase, 30 services, 13+ hooks.
+
+**Top 5 priorités identifiées** :
+
+| Priorité | Action | Effort | Statut |
+|---|---|---|---|
+| P0 | Filtrer ONNX WASM en build | 30 min | ✅ PR #385 |
+| P1 | Refactor SettingsPage.tsx (2210 L) | 3-5 h | ✅ PR #386 |
+| P2 | Tester retrait `'unsafe-eval'` du CSP | 1 h | ✅ PR #387 (skip + doc) |
+| P3 | Centraliser duplications `statusMaps` | 1-2 h | ✅ PR #388 |
+| P4 | Optimiser `.select('*', { count })` × 6 | 1 h | ✅ PR #389 |
+
+---
+
+## 2. PRs livrées
+
+### PR #385 — Bundle ONNX WASM (P0)
+
+**Branche** : `chore/onnx-wasm-reduce-variants`
+**Commit** : `49436ef`
+
+`vite-plugin-static-copy` copiait les 4 variantes WASM ONNX (`asyncify` 23 Mo + `jsep` 25 Mo + `jspi` 14 Mo + base 13 Mo = 75 Mo) alors qu'à runtime, le browser n'en charge qu'une. Filtrage explicite : on garde `asyncify` (universel CPU SIMD threaded) + base, on drop `jsep` (WebGPU) et `jspi` (Chrome 123+).
+
+**Impact** : `dist/` **122 Mo → 81 Mo** (-41 Mo, -34%).
+
+**Pourquoi conservatif** : si on supprime `'asyncify'`, Whisper plante. Avec asyncify + base, le runtime ONNX a toujours un fallback CPU universel — un peu moins rapide sur Chrome WebGPU, imperceptible à l'usage (nav vocale lazy-loadée).
+
+---
+
+### PR #386 — Split SettingsPage (P1)
+
+**Branche** : `refactor/settings-page-split-panels`
+**Commit** : `f2266d7`
+
+`SettingsPage.tsx` était devenu un super-composant de **2210 lignes** avec 14 panneaux et helpers tous colocalisés. Découpage en `src/components/settings/` (structure plate, cards inline dans leur parent).
+
+**Impact** : `src/pages/SettingsPage.tsx` **2210 → 87 lignes** (-96%). Plus gros panel = `SecuritePanel.tsx` (390 L).
+
+**Structure cible** :
+
+```
+src/components/settings/
+├── index.ts                   (barrel)
+├── navigationConfig.tsx        (types + NAV_SECTIONS + panelFromHash)
+├── SettingsNavigation.tsx      (sidebar + flèches scroll mobile)
+├── SettingsShared.tsx          (PanelHeader, ToggleRow)
+├── ProfilPanel.tsx             (263 L)
+├── SecuritePanel.tsx           (390 L — TwoFactorCard + DangerZone inline)
+├── AbonnementPanel.tsx         (191 L — UsageBar inline)
+├── NotificationsPanel.tsx      (152 L)
+├── InterventionsPanel.tsx      (151 L)
+├── ConventionPanel.tsx         (108 L)
+├── PchPanel.tsx                (81 L)
+├── ApparencePanel.tsx          (246 L — palettes inline)
+├── AccessibilitePanel.tsx      (107 L)
+└── DonneesPanel.tsx            (231 L — HealthConsentCard + PrivacySettingsCard inline)
+```
+
+**Bonus fix** : `SecuritePanel` utilisait `supabase.auth.getUser/signInWithPassword/updateUser` **sans importer `supabase`**. Le fichier compilait par chance (résolution implicite). Désormais explicitement importé depuis `@/lib/supabase/client`.
+
+---
+
+### PR #387 — Documentation CSP `unsafe-eval` (P2)
+
+**Branche** : `docs/csp-unsafe-eval-rationale`
+**Commit** : `5c3eec0`
+
+L'audit avait suggéré de tester le retrait de `'unsafe-eval'` du CSP en s'appuyant sur `'wasm-unsafe-eval'`. **Faux positif** : vérification dans le bundle prod a révélé un `new Function(...)` dans `vendor-whisper-*.js` (pattern `methodCaller` Emscripten). `'wasm-unsafe-eval'` ne couvre QUE `WebAssembly.compile/instantiate`, pas `new Function()`. Si on retire `'unsafe-eval'`, Whisper plante à la 1ère utilisation.
+
+**Action** : commentaire de 6 lignes inline dans le `Caddyfile` au-dessus du header CSP pour qu'aucun futur audit (humain ou IA) ne re-propose ce changement sans contexte. Memory entry locale aussi ajoutée (`csp-unsafe-eval-required.md`).
+
+---
+
+### PR #388 — Centralisation labels caregiver (P3)
+
+**Branche** : `refactor/centralize-status-maps`
+**Commit** : `50b2f04`
+
+L'audit pointait `DOT_COLORS` / `STATUS_LABELS` des timelines (`CaregiverShiftTimeline`, `EmployeeShiftTimeline`) comme dupliqués — **faux positif** : palettes différentes voulues (caregiver = `warm`, employee = `accent`). Skipped.
+
+**Vraie duplication trouvée en cherchant** : labels statut juridique aidant + statut contrat aidant redéfinis localement dans 4 composants — avec en bonus une **divergence visuelle** entre `CaregiverCard` (« PCH actif ») et `EditCaregiverModal` (« PCH — Maintient une activité pro »). Centralisation dans `statusMaps.ts` avec harmonisation sur la version IDCC 3239 (canonique).
+
+**Ajouts dans `src/lib/constants/statusMaps.ts`** :
+- `CAREGIVER_LEGAL_STATUS_LABELS` (Record, 5 entries)
+- `CAREGIVER_LEGAL_STATUS_OPTIONS` (Array dérivée pour les selects)
+- `CAREGIVER_CONTRACT_STATUS_LABELS` (Record, 3 entries — wording IDCC 3239)
+
+**Régression visuelle volontaire** : les badges de `CaregiverCard` montrent désormais le wording long (« PCH — Maintient une activité pro ») au lieu de la version courte (« PCH actif »).
+
+---
+
+### PR #389 — Supabase counts (P4) — _en review_
+
+**Branche** : `perf/optimize-supabase-counts`
+**Commit** : `49913e0`
+
+L'audit pointait 7 appels `.select('*', { count: 'exact', head: true })` comme inefficaces. Vrai gain trouvé : `hasActiveContract` faisait un `COUNT(*)` sur toute la table `contracts` filtrée, juste pour dériver un boolean. Bascule en `.limit(1).maybeSingle()` qui s'arrête à la première ligne trouvée.
+
+Les 6 autres callers restent légitimement des counts (badges non lus, dashboard stats), mais migrent de `select('*')` à `select('id')` pour s'aligner sur la convention déjà en place ailleurs (`EmployerDashboard`, `EmployeeDashboard`, `OnboardingWidget`, `nudgeService`).
+
+**Pas adressé** : N+1 dans `liaisonService.listConversations` (1 count par conversation dans une boucle). Refactor distinct, mieux traité avec une RPC ou aggregate query.
+
+---
+
+## 3. Découvertes en chemin
+
+### Faux positifs de l'audit
+
+| Finding audit | Réalité |
+|---|---|
+| `'unsafe-eval'` retirable via `'wasm-unsafe-eval'` | ❌ `new Function()` Emscripten dans `vendor-whisper-*.js` non couvert. Cf. PR #387. |
+| `DOT_COLORS` / `STATUS_LABELS` timelines dupliqués | ❌ Palettes différentes voulues (`warm` vs `accent`). |
+| `CaregiverShiftTimeline.tsx` au path `src/components/planning/` | ❌ Vrai path : `src/components/dashboard/widgets/`. |
+| `legalStatusLabels` / `caregiverStatusLabels` "existaient déjà dans statusMaps" | ❌ Étaient dupliqués localement, pas dans `statusMaps`. |
+
+→ Leçon : les agents Explore voient des excerpts, pas l'arbo complète. Toujours vérifier avant d'agir sur leurs recommandations exactes.
+
+### Bugs latents trouvés en passant
+
+1. **`SettingsPage.tsx` — import `supabase` manquant** (PR #386 bonus). Le fichier utilisait `supabase.auth.*` sans l'importer. Compilation passait par chance via résolution implicite. Fixé en extraction `SecuritePanel`.
+
+2. **`CaregiverCard` vs `EditCaregiverModal` — divergence labels** (PR #388). Mêmes statuts contrat (`active`/`full_time`/`voluntary`) avec libellés différents selon le composant. Harmonisé sur version IDCC 3239.
+
+---
+
+## 4. Métriques avant/après
+
+| Métrique | Avant session | Après session | Delta |
+|---|---|---|---|
+| `dist/` taille totale | 122 Mo | 81 Mo | **-41 Mo (-34%)** |
+| Bundle WASM ONNX | 75 Mo (4 variants) | 36 Mo (2 variants) | -39 Mo |
+| `src/pages/SettingsPage.tsx` | 2210 L | 87 L | **-96%** |
+| Tests passing | 2330 | 2375 | +45 (nouveaux tests + cleanup) |
+| Fichiers `>500 L` (non-test) | 23 | 22 | -1 (SettingsPage sortie du top) |
+| Duplications statusMaps caregiver | 4 sites | 1 source | -3 sites |
+
+---
+
+## 5. Reste à faire
+
+Ces points figuraient dans le rapport audit mais hors scope de la session (effort > 2h ou nécessitent décision produit) :
+
+- **N+1 dans `liaisonService.listConversations`** — 1 count Supabase par conversation dans une boucle. Mieux traité avec une RPC ou aggregate query.
+- **Sentry / GlitchTip self-hosted** — instrumentation erreurs front prod actuellement absente (`logger.ts:138` TODO).
+- **Tests RLS pgTAP** — pas de suite de tests dédiée pour les policies. Validation actuellement manuelle / via pentest externe.
+- **Magic numbers IDCC** — `calculatePay.ts:77,101,106` (4, 21, 6, 1/4) à extraire en constantes nommées.
+- **Refactor SettingsPage panels lourds** — ex `AbonnementPanel` (191 L) pourrait extraire `UsageBar` ailleurs si réutilisé. Pas urgent.
+
+À évaluer aussi (non identifiés par l'audit mais ressortis de la session) :
+- **Rotation clé `medical_data_key` pgsodium** — procédure à documenter pour conformité long terme.
+- **Performance budget CI** — alerte si bundle > 2 MB (`vite-plugin-thresholds` ou similaire).
+
+---
+
+## 6. Process de la session
+
+**Méthode** : `/wd:analyze` avec 4 agents Explore en parallèle, puis itération PR par PR avec validation utilisateur entre chaque.
+
+**Workflow git appliqué** (cf. `.claude/rules/git-workflow.md`) :
+1. `git checkout main && git pull` avant chaque branche
+2. Une PR = une branche dédiée, préfixe correct (`chore/`, `refactor/`, `docs/`, `perf/`)
+3. `npm run lint` + `npm run typecheck` + `npm run test:run` + `npm run build` avant chaque push
+4. Demande d'autorisation avant chaque `git push`
+5. PR créée via `gh pr create` avec body français + test plan
+6. Cleanup branche locale après merge
+
+**Points d'attention pour futures sessions** :
+- Toujours vérifier les paths fournis par l'audit (faux positifs courants)
+- Vérifier la diff dans le bundle prod avant de toucher à la CSP
+- Les tests Vitest mettent ~140 s en local — bon temps pour caler une revue manuelle


### PR DESCRIPTION
## Summary

Synthèse de la session d'audit et cleanup du 14 mai 2026, lancée via `/wd:analyze` (4 agents Explore en parallèle, scope = tout le projet).

Le doc capture :
- Le rapport d'audit initial (scores par domaine, top 5 priorités)
- Le détail des 5 PRs livrées (#385, #386, #387, #388, #389) — branche, commit, impact, rationale
- Les **faux positifs de l'audit** détectés en chemin (`'unsafe-eval'` retirable, `DOT_COLORS` dupliqués, paths erronés)
- Les **bugs latents trouvés en passant** (import `supabase` manquant dans `SettingsPage`, divergence labels caregiver)
- Les métriques avant/après (`dist/` -41 Mo, `SettingsPage.tsx` -96%, +45 tests)
- Le backlog restant (N+1 listConversations, Sentry, tests RLS pgTAP, magic numbers IDCC)
- Notes de process git pour les futures sessions

### Pourquoi ce doc

- Trace les **décisions** prises pendant la session (ex: pourquoi `'unsafe-eval'` reste, pourquoi version IDCC 3239 retenue pour les libellés)
- Évite que les **faux positifs de l'audit** soient re-proposés dans 3 mois
- Sert de **base de référence** pour le prochain `/wd:analyze` (delta vs cette baseline)
- Aligné avec la convention de naming du projet (cf. `FEEDBACK_REUNION_2026-04-16.md`, `SECURITY_CHECK_2026-03-26.md`)

### Changements

- `docs/AUDIT_SESSION_2026-05-14.md` (187 lignes, nouveau)

## Test plan

- [x] Document seul, aucun impact runtime
- [x] Vérifier que les liens internes (PRs #385-#389) sont corrects
- [ ] Optionnel : lien depuis `docs/DEVELOPMENT_ROADMAP.md` ou `CLAUDE.md` si pertinent

🤖 Generated with [Claude Code](https://claude.com/claude-code)