### PR TITLE
chore(cleanup): resolve 5 orphan TODO markers

### DIFF
--- a/src/components/dashboard/EmployerDashboard.test.tsx
+++ b/src/components/dashboard/EmployerDashboard.test.tsx
@@ -145,17 +145,6 @@ describe('EmployerDashboard', () => {
       })
     })
 
-    // TODO: réactiver quand les widgets seront remis
-    // it('affiche le TeamWidget avec le bon employerId', async () => {
-    //   renderWithProviders(<EmployerDashboard profile={profile} />)
-    //   await waitFor(() => {
-    //     expect(screen.getByTestId('team-widget')).toHaveAttribute(
-    //       'data-employer-id',
-    //       'employer-1'
-    //     )
-    //   })
-    // })
-
     it('affiche le ComplianceWidget avec le bon employerId', async () => {
       renderWithProviders(<EmployerDashboard profile={profile} />)
       await waitFor(() => {
@@ -165,28 +154,7 @@ describe('EmployerDashboard', () => {
         )
       })
     })
-
-    // TODO: réactiver quand les widgets seront remis
-    // it('affiche le RecentLogsWidget avec le bon employerId', async () => {
-    //   renderWithProviders(<EmployerDashboard profile={profile} />)
-    //   await waitFor(() => {
-    //     expect(screen.getByTestId('recent-logs-widget')).toHaveAttribute(
-    //       'data-employer-id',
-    //       'employer-1'
-    //     )
-    //   })
-    // })
   })
-
-  // TODO: réactiver quand UpcomingShiftsWidget sera remis
-  // describe('Chargement des shifts', () => {
-  //   it('passe loading=true pendant le chargement', () => { ... })
-  //   it('passe loading=false après chargement', async () => { ... })
-  //   it('filtre les shifts non-planifiés et passe seulement les planned', async () => { ... })
-  //   it('limite les shifts à 5 au maximum', async () => { ... })
-  //   it('passe un tableau vide si le service échoue', async () => { ... })
-  //   it('appelle getShifts avec le bon profileId et rôle employer', async () => { ... })
-  // })
 
   describe('Monitoring conformité', () => {
     it('active useComplianceMonitor avec le bon employerId', () => {

--- a/src/components/dashboard/widgets/ClockInWidget.tsx
+++ b/src/components/dashboard/widgets/ClockInWidget.tsx
@@ -132,7 +132,8 @@ export function ClockInWidget({ hasActiveShift = false, activeShiftLabel, varian
           transition="background 0.15s"
           _hover={{ bg: 'rgba(255,255,255,.15)' }}
           onClick={() => {
-            // TODO: implémenter la fin d'intervention
+            // Fin d'intervention : déférée au pointage QR (V2).
+            // Spec : docs/QR_CLOCKIN_IMPLEMENTATION.md — clock-in désactivé en v1.
           }}
         >
           {endLabel}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -133,10 +133,9 @@ export const logger = {
     const sanitizedArgs = formatArgs(args)
     console.error(`[ERROR] ${redactString(message)}`, ...sanitizedArgs)
 
-    // En production, on pourrait envoyer à Sentry/LogRocket
+    // Point d'extension monitoring : brancher un service (Sentry/LogRocket) ici si besoin
     if (IS_PROD && args[0] instanceof Error) {
-      // TODO: Sentry.captureException(args[0])
-      void args[0] // Prêt pour intégration Sentry
+      void args[0]
     }
   },
 


### PR DESCRIPTION
## Summary
Nettoyage des 5 marqueurs TODO orphelins identifiés dans l'audit technique du 2026-05-14. Plus aucun `TODO`/`FIXME` dans `src/` ni `supabase/functions/`.

### Changements
- **`EmployerDashboard.test.tsx`** : suppression de 3 blocs de tests commentés (`TeamWidget`, `RecentLogsWidget`, `UpcomingShiftsWidget`) — ces widgets ne font plus partie du dashboard employeur depuis son redesign et ne reviendront pas
- **`ClockInWidget.tsx`** : commentaire « implémenter la fin d'intervention » reformulé — la fin d'intervention relève du pointage QR (V2), le clock-in est désactivé en v1. Renvoi vers `docs/QR_CLOCKIN_IMPLEMENTATION.md`
- **`logger.ts`** : TODO Sentry reformulé en point d'extension monitoring clair (aucun Sentry prévu ; le hook `void args[0]` est conservé)

## Notes
Les composants `TeamWidget` / `RecentLogsWidget` / `UpcomingShiftsWidget` sont désormais du code mort (référencés uniquement par leurs tests et le barrel `widgets/index.ts`). Suppression non incluse ici pour garder la PR scopée — à traiter dans un `chore/` dédié.

## Test plan
- [x] `npm run lint` — 0 erreur
- [x] `npm run typecheck` — OK
- [x] `npm run test:run` — 2375 passed / 4 skipped
- [x] `grep -rn "TODO\|FIXME" src/ supabase/functions/` — 0 résultat