### PR TITLE
test(rls): add pgTAP harness for Row Level Security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
         "jsdom": "^29.0.2",
+        "supabase": "^2.98.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.58.1",
         "vite": "^7.2.4",
@@ -3312,6 +3313,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -5920,6 +5934,16 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -6312,6 +6336,23 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6566,6 +6607,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -6573,6 +6624,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/color-convert": {
@@ -6744,6 +6805,16 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -7563,6 +7634,30 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -7739,6 +7834,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/framer-motion": {
@@ -8235,6 +8343,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/hyphen": {
       "version": "1.14.1",
@@ -9344,6 +9466,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
@@ -9391,6 +9526,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -9415,6 +9590,16 @@
       "license": "MIT",
       "dependencies": {
         "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/object-assign": {
@@ -9954,6 +10139,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10112,6 +10307,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/readdirp": {
@@ -11035,6 +11240,26 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
     },
+    "node_modules/supabase": {
+      "version": "2.98.2",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.98.2.tgz",
+      "integrity": "sha512-COSz57JyuUGbj75GSGM5mmyz/behBiYSiJ4A9qJVVC/vNp9bYS+9RCTXBtEt8kgqDDYWZsOmzk+mPbIBdr9bPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^9.0.0",
+        "node-fetch": "^3.3.2",
+        "tar": "7.5.13"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11072,6 +11297,33 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/temp-dir": {
       "version": "2.0.0",
@@ -11829,6 +12081,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -12408,6 +12670,19 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.0"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "test:db": "supabase test db"
   },
   "dependencies": {
     "@chakra-ui/react": "^3.34.0",
@@ -59,6 +60,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
     "jsdom": "^29.0.2",
+    "supabase": "^2.98.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.1",
     "vite": "^7.2.4",

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -7,7 +7,8 @@ supabase/
 ├── README.md                     ← ce fichier
 ├── migrations/
 │   └── 000_baseline_schema.sql   ← schéma de référence (source unique pour un reset)
-└── migrations_archive/           ← 64 migrations historiques (001 → 065), référence seule
+├── migrations_archive/           ← 64 migrations historiques (001 → 065), référence seule
+└── tests/                        ← tests RLS pgTAP (`npm run test:db`)
 ```
 
 ## Pourquoi un baseline
@@ -61,6 +62,50 @@ ssh unilien-test "docker exec supabase-db pg_dump -U postgres -d postgres \
 
 Puis : retirer les lignes `\restrict` / `\unrestrict`, rendre `CREATE SCHEMA
 public` idempotent (`IF NOT EXISTS`), conserver l'en-tête `CREATE EXTENSION`.
+
+## Tests RLS (pgTAP)
+
+Les policies Row Level Security sont testées avec [pgTAP](https://pgtap.org/),
+dans `supabase/tests/`. Objectif : verrouiller en régression les bugs RLS
+passés (fuites de données entre utilisateurs, RGPD art. 9).
+
+```bash
+npx supabase start    # le stack local doit tourner
+npm run test:db       # lance tous les supabase/tests/*_test.sql
+```
+
+### Écrire un test
+
+Un fichier de test est auto-suffisant : il crée ses fixtures, teste, puis
+`rollback` (aucune donnée ne persiste).
+
+```sql
+begin;
+select plan(N);            -- nombre d'assertions attendues
+
+-- fixtures : insert auth.users → profiles → employers/employees → ...
+
+-- helper local : exécute une requête sous l'identité d'un user (RLS appliquée)
+-- (bascule sur le rôle `authenticated` + claims JWT, puis restaure)
+
+select is( <valeur obtenue>, <attendu>, 'description' );
+-- ...
+
+select * from finish();
+rollback;
+```
+
+Points clés :
+
+- le rôle `postgres` (propriétaire des tables) **bypass la RLS** — il faut
+  exécuter les requêtes testées sous le rôle `authenticated`
+- `auth.uid()` lit les claims JWT : `set_config('request.jwt.claims', …)`
+- `plan()` / `finish()` doivent tourner sous `postgres` : ne basculer le rôle
+  qu'à l'intérieur du helper, et le restaurer (`reset role`) avant de rendre
+- nommer les fichiers `<sujet>_test.sql`
+
+Voir `conversations_rls_test.sql` comme modèle (régression de la migration 064 :
+fuite des conversations privées).
 
 ## Limites connues
 

--- a/supabase/tests/conversations_rls_test.sql
+++ b/supabase/tests/conversations_rls_test.sql
@@ -1,0 +1,148 @@
+-- =============================================================================
+-- Tests RLS — conversations & liaison_messages
+-- =============================================================================
+-- Régression de la fuite des conversations privées (RGPD art. 9).
+-- Avant la migration 064, un employé ajouté à l'équipe pouvait lire TOUTES les
+-- conversations privées historiques entre l'employeur et les autres employés.
+-- cf. supabase/migrations_archive/064_fix_private_conversations_rls.sql
+--
+-- Lancement : `npm run test:db` (nécessite `supabase start`).
+-- =============================================================================
+
+begin;
+select plan(8);
+
+-- ─── Fixtures ────────────────────────────────────────────────────────────────
+-- 1 employeur + 2 employés (A et B) de la même équipe.
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000000e1', 'employer@test.local'),
+  ('00000000-0000-0000-0000-0000000000a1', 'employee-a@test.local'),
+  ('00000000-0000-0000-0000-0000000000b2', 'employee-b@test.local');
+
+insert into public.profiles (id, role, first_name, last_name) values
+  ('00000000-0000-0000-0000-0000000000e1', 'employer', 'Emma',  'Ployeur'),
+  ('00000000-0000-0000-0000-0000000000a1', 'employee', 'Alice', 'Auxi'),
+  ('00000000-0000-0000-0000-0000000000b2', 'employee', 'Bob',   'Auxi');
+
+-- Lignes role-specific (référencées par les FK de `contracts`).
+insert into public.employers (profile_id, address) values
+  ('00000000-0000-0000-0000-0000000000e1', '{}'::jsonb);
+
+insert into public.employees (profile_id) values
+  ('00000000-0000-0000-0000-0000000000a1'),
+  ('00000000-0000-0000-0000-0000000000b2');
+
+-- Contrats actifs : A et B sont tous deux dans l'équipe de l'employeur.
+insert into public.contracts
+  (employer_id, employee_id, contract_type, start_date, weekly_hours, hourly_rate, status)
+values
+  ('00000000-0000-0000-0000-0000000000e1', '00000000-0000-0000-0000-0000000000a1',
+   'CDI', '2026-01-01', 35, 15, 'active'),
+  ('00000000-0000-0000-0000-0000000000e1', '00000000-0000-0000-0000-0000000000b2',
+   'CDI', '2026-01-01', 35, 15, 'active');
+
+-- Conversations : 1 privée (employeur ↔ A) + 1 d'équipe.
+insert into public.conversations (id, employer_id, type, participant_ids) values
+  ('00000000-0000-0000-0000-0000000000c1', '00000000-0000-0000-0000-0000000000e1', 'private',
+   array['00000000-0000-0000-0000-0000000000e1',
+         '00000000-0000-0000-0000-0000000000a1']::uuid[]),
+  ('00000000-0000-0000-0000-0000000000c2', '00000000-0000-0000-0000-0000000000e1', 'team',
+   array[]::uuid[]);
+
+-- Messages : 1 dans la conv privée, 1 dans la conv d'équipe (envoyés par l'employeur).
+insert into public.liaison_messages
+  (id, employer_id, sender_id, sender_role, content, conversation_id)
+values
+  ('00000000-0000-0000-0000-0000000000d1', '00000000-0000-0000-0000-0000000000e1',
+   '00000000-0000-0000-0000-0000000000e1', 'employer', 'message prive',
+   '00000000-0000-0000-0000-0000000000c1'),
+  ('00000000-0000-0000-0000-0000000000d2', '00000000-0000-0000-0000-0000000000e1',
+   '00000000-0000-0000-0000-0000000000e1', 'employer', 'message equipe',
+   '00000000-0000-0000-0000-0000000000c2');
+
+-- ─── Helper : exécute une requête de comptage sous l'identité d'un user ──────
+-- Bascule sur le rôle `authenticated` + pose les claims JWT (auth.uid()),
+-- exécute la requête (RLS appliquée), puis restaure le rôle.
+create function tests_count_as(p_uid uuid, p_query text) returns integer
+  language plpgsql as $$
+declare
+  v_count integer;
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_query into v_count;
+  reset role;
+  return v_count;
+end;
+$$;
+
+-- ─── conversations : policy SELECT ───────────────────────────────────────────
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000b2',
+    $$ select count(*) from public.conversations
+       where id = '00000000-0000-0000-0000-0000000000c1' $$),
+  0,
+  'employe B (equipe) ne voit PAS la conversation privee employeur<->A [regression mig 064]'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000a1',
+    $$ select count(*) from public.conversations
+       where id = '00000000-0000-0000-0000-0000000000c1' $$),
+  1,
+  'employe A (participant) voit la conversation privee'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000e1',
+    $$ select count(*) from public.conversations
+       where id = '00000000-0000-0000-0000-0000000000c1' $$),
+  1,
+  'employeur voit sa conversation privee'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000b2',
+    $$ select count(*) from public.conversations
+       where id = '00000000-0000-0000-0000-0000000000c2' $$),
+  1,
+  'employe B voit la conversation d''equipe (contrat actif)'
+);
+
+-- ─── liaison_messages : policy SELECT (cascade via la conversation) ─────────
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000b2',
+    $$ select count(*) from public.liaison_messages
+       where id = '00000000-0000-0000-0000-0000000000d1' $$),
+  0,
+  'employe B ne voit PAS le message de la conversation privee [cascade mig 064]'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000a1',
+    $$ select count(*) from public.liaison_messages
+       where id = '00000000-0000-0000-0000-0000000000d1' $$),
+  1,
+  'employe A voit le message de la conversation privee'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000b2',
+    $$ select count(*) from public.liaison_messages
+       where id = '00000000-0000-0000-0000-0000000000d2' $$),
+  1,
+  'employe B voit le message de la conversation d''equipe'
+);
+
+-- ─── Total : B ne voit qu'1 conversation sur 2 ──────────────────────────────
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000000b2',
+    $$ select count(*) from public.conversations $$),
+  1,
+  'employe B ne voit au total que la conversation d''equipe (pas la privee)'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Premier harness de tests RLS du projet, dans `supabase/tests/`. Verrouille en régression les bugs de Row Level Security — motivé par l'historique de fuites de données entre utilisateurs (migrations 061-064).

Rendu possible par le baseline de la PR #394 : `supabase db reset` fonctionne désormais, donc `supabase test db` aussi.

### Changements
- **`supabase/tests/conversations_rls_test.sql`** — 8 assertions pgTAP couvrant la fuite des conversations privées corrigée par la migration 064 (RGPD art. 9) :
  - un employé de l'équipe **ne voit pas** la conversation privée employeur↔autre-employé, ni ses messages
  - le participant et l'employeur **voient** bien la conversation privée
  - un employé **voit** les conversations d'équipe (contrat actif)
- **`package.json`** — script `test:db` (`supabase test db`) + `supabase` ajouté en `devDependencies`
- **`supabase/README.md`** — section « Tests RLS » : commande, pattern d'écriture, pièges (bypass RLS du rôle propriétaire, claims JWT pour `auth.uid()`, `plan()`/`finish()` à exécuter sous `postgres`)

### Pattern technique
Chaque fichier de test est auto-suffisant (`begin` → fixtures → assertions → `rollback`). Un helper local bascule sur le rôle `authenticated` + pose les claims JWT pour exécuter la requête testée sous RLS, puis restaure le rôle.

## Test plan
- [x] `npm run test:db` — 8/8 assertions ✅
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2330 passed / 4 skipped

## Suite possible
Étendre le harness aux autres tables RLS sensibles : `leave_balances` (INSERT employé, mig 063), `log_entries` (mark-as-read, mig 062), `liaison_messages` mark-as-read (mig 061).

## Note hors scope
`npm audit` remonte 3 vulnérabilités transitives préexistantes (`@babel/plugin-transform-modules-systemjs`, `fast-uri`, `postcss`) — non introduites par cette PR. Un `npm audit fix` dédié serait à prévoir.