### PR TITLE
test(rls): extend pgTAP harness to RPC-fixed tables

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -104,8 +104,18 @@ Points clés :
   qu'à l'intérieur du helper, et le restaurer (`reset role`) avant de rendre
 - nommer les fichiers `<sujet>_test.sql`
 
-Voir `conversations_rls_test.sql` comme modèle (régression de la migration 064 :
-fuite des conversations privées).
+### Couverture actuelle
+
+| Fichier | Régression couverte |
+|---|---|
+| `conversations_rls_test.sql` | fuite des conversations privées (mig 064, RGPD art. 9) |
+| `liaison_messages_read_rls_test.sql` | RPC `mark_liaison_messages_read` (mig 061) |
+| `log_entries_read_rls_test.sql` | RPC `mark_log_entry_read` (mig 062) |
+| `leave_balances_rls_test.sql` | RPC `initialize_leave_balance` (mig 063) |
+
+Chaque test RPC vérifie les trois faces du bug : l'écriture directe bloquée par
+la RLS, le RPC `SECURITY DEFINER` qui débloque le cas légitime, et le refus
+(`42501`) pour un utilisateur non autorisé.
 
 ## Limites connues
 

--- a/supabase/tests/leave_balances_rls_test.sql
+++ b/supabase/tests/leave_balances_rls_test.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- Tests RLS — initialize_leave_balance (migration 063)
+-- =============================================================================
+-- Bug initial : un employé posant une demande de congé alors que son solde
+-- n'était pas encore initialisé déclenchait un INSERT direct sur leave_balances,
+-- bloqué par la policy RLS `employer_manage_balances` (réservée à
+-- `employer_id = auth.uid()`). Résultat : "solde non initialisé".
+-- Fix : RPC SECURITY DEFINER `initialize_leave_balance`, qui autorise
+-- l'employeur OU l'employé du contrat, avec calcul serveur des jours acquis.
+-- cf. supabase/migrations_archive/063_initialize_leave_balance_rpc.sql
+-- =============================================================================
+
+begin;
+select plan(6);
+
+-- ─── Fixtures ────────────────────────────────────────────────────────────────
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000063e1', 'employer63@test.local'),
+  ('00000000-0000-0000-0000-0000000063a1', 'employee63@test.local'),
+  ('00000000-0000-0000-0000-0000000063f9', 'stranger63@test.local');
+
+insert into public.profiles (id, role, first_name, last_name) values
+  ('00000000-0000-0000-0000-0000000063e1', 'employer', 'Emma',  'Ployeur'),
+  ('00000000-0000-0000-0000-0000000063a1', 'employee', 'Alice', 'Auxi'),
+  ('00000000-0000-0000-0000-0000000063f9', 'employee', 'Sam',   'Etranger');
+
+insert into public.employers (profile_id, address) values
+  ('00000000-0000-0000-0000-0000000063e1', '{}'::jsonb);
+insert into public.employees (profile_id) values
+  ('00000000-0000-0000-0000-0000000063a1'),
+  ('00000000-0000-0000-0000-0000000063f9');
+
+-- Contrat d'A chez l'employeur (id fixe pour pouvoir l'adresser au RPC).
+insert into public.contracts
+  (id, employer_id, employee_id, contract_type, start_date, weekly_hours, hourly_rate, status)
+values
+  ('00000000-0000-0000-0000-0000000063c1', '00000000-0000-0000-0000-0000000063e1',
+   '00000000-0000-0000-0000-0000000063a1', 'CDI', '2026-01-01', 35, 15, 'active');
+
+-- ─── Helper : exécute une instruction sous l'identité d'un user ─────────────
+-- Renvoie NULL si l'instruction passe, le SQLSTATE si elle lève une exception.
+create function tests_run_as(p_uid uuid, p_sql text) returns text
+  language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_sql;
+  reset role;
+  return null;
+exception when others then
+  reset role;
+  return sqlstate;
+end;
+$$;
+
+-- ─── Tests ───────────────────────────────────────────────────────────────────
+-- 1. Le bug : un INSERT direct par l'employé est bloqué par la RLS WITH CHECK.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000063a1',
+    $$ insert into public.leave_balances
+         (contract_id, employee_id, employer_id, leave_year)
+       values ('00000000-0000-0000-0000-0000000063c1',
+               '00000000-0000-0000-0000-0000000063a1',
+               '00000000-0000-0000-0000-0000000063e1', '2026-2027') $$),
+  '42501',
+  'INSERT direct sur leave_balances par l''employe : bloque par la RLS'
+);
+
+-- 2. Le fix : l'employé du contrat peut initialiser son solde via le RPC.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000063a1',
+    $$ select public.initialize_leave_balance(
+         '00000000-0000-0000-0000-0000000063c1', '2026-2027') $$),
+  null,
+  'initialize_leave_balance : autorise pour l''employe du contrat'
+);
+select ok(
+  exists (
+    select 1 from public.leave_balances
+    where contract_id = '00000000-0000-0000-0000-0000000063c1'
+      and leave_year = '2026-2027'
+  ),
+  'le RPC a bien cree la ligne de solde de conges'
+);
+
+-- 3. Idempotent : un second appel ne crée pas de doublon.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000063a1',
+    $$ select public.initialize_leave_balance(
+         '00000000-0000-0000-0000-0000000063c1', '2026-2027') $$),
+  null,
+  'initialize_leave_balance : second appel sans erreur'
+);
+select is(
+  (select count(*)::integer from public.leave_balances
+   where contract_id = '00000000-0000-0000-0000-0000000063c1'),
+  1,
+  'idempotent : une seule ligne de solde malgre deux appels'
+);
+
+-- 4. Controle d'acces : un user etranger au contrat est refuse.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000063f9',
+    $$ select public.initialize_leave_balance(
+         '00000000-0000-0000-0000-0000000063c1', '2026-2027') $$),
+  '42501',
+  'initialize_leave_balance : refuse pour un user etranger au contrat'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/liaison_messages_read_rls_test.sql
+++ b/supabase/tests/liaison_messages_read_rls_test.sql
@@ -1,0 +1,110 @@
+-- =============================================================================
+-- Tests RLS — mark_liaison_messages_read (migration 061)
+-- =============================================================================
+-- Bug initial : un UPDATE direct sur liaison_messages pour marquer un message
+-- comme lu était silencieusement bloqué par la policy RLS UPDATE
+-- (`auth.uid() = sender_id` — seul l'auteur peut modifier). Le compteur de
+-- non-lus revenait après refresh.
+-- Fix : RPC SECURITY DEFINER `mark_liaison_messages_read`.
+-- cf. supabase/migrations_archive/061_mark_liaison_messages_read_rpc.sql
+-- =============================================================================
+
+begin;
+select plan(5);
+
+-- ─── Fixtures ────────────────────────────────────────────────────────────────
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000061e1', 'employer61@test.local'),
+  ('00000000-0000-0000-0000-0000000061b2', 'employee61@test.local'),
+  ('00000000-0000-0000-0000-0000000061f9', 'stranger61@test.local');
+
+insert into public.profiles (id, role, first_name, last_name) values
+  ('00000000-0000-0000-0000-0000000061e1', 'employer', 'Emma', 'Ployeur'),
+  ('00000000-0000-0000-0000-0000000061b2', 'employee', 'Bob',  'Auxi'),
+  ('00000000-0000-0000-0000-0000000061f9', 'employee', 'Sam',  'Etranger');
+
+insert into public.employers (profile_id, address) values
+  ('00000000-0000-0000-0000-0000000061e1', '{}'::jsonb);
+insert into public.employees (profile_id) values
+  ('00000000-0000-0000-0000-0000000061b2'),
+  ('00000000-0000-0000-0000-0000000061f9');
+
+-- B a un contrat actif chez l'employeur ; Sam n'a aucun lien.
+insert into public.contracts
+  (employer_id, employee_id, contract_type, start_date, weekly_hours, hourly_rate, status)
+values
+  ('00000000-0000-0000-0000-0000000061e1', '00000000-0000-0000-0000-0000000061b2',
+   'CDI', '2026-01-01', 35, 15, 'active');
+
+-- Conversation d'équipe + 1 message envoyé par l'employeur.
+insert into public.conversations (id, employer_id, type, participant_ids) values
+  ('00000000-0000-0000-0000-0000000061c2', '00000000-0000-0000-0000-0000000061e1',
+   'team', array[]::uuid[]);
+insert into public.liaison_messages
+  (id, employer_id, sender_id, sender_role, content, conversation_id)
+values
+  ('00000000-0000-0000-0000-0000000061d1', '00000000-0000-0000-0000-0000000061e1',
+   '00000000-0000-0000-0000-0000000061e1', 'employer', 'message equipe',
+   '00000000-0000-0000-0000-0000000061c2');
+
+-- ─── Helper : exécute une instruction sous l'identité d'un user ─────────────
+-- Renvoie NULL si l'instruction passe, le SQLSTATE si elle lève une exception.
+create function tests_run_as(p_uid uuid, p_sql text) returns text
+  language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_sql;
+  reset role;
+  return null;
+exception when others then
+  reset role;
+  return sqlstate;
+end;
+$$;
+
+-- ─── Tests ───────────────────────────────────────────────────────────────────
+-- 1. Le bug : un UPDATE direct par B (non-auteur) ne modifie aucune ligne.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000061b2',
+    $$ update public.liaison_messages
+         set read_by = coalesce(read_by, array[]::uuid[])
+                       || '00000000-0000-0000-0000-0000000061b2'::uuid
+       where id = '00000000-0000-0000-0000-0000000061d1' $$),
+  null,
+  'UPDATE direct par un non-auteur : pas d''erreur mais filtre RLS (0 ligne)'
+);
+select ok(
+  not ('00000000-0000-0000-0000-0000000061b2'::uuid = any(
+    coalesce((select read_by from public.liaison_messages
+              where id = '00000000-0000-0000-0000-0000000061d1'), array[]::uuid[])
+  )),
+  'read_by reste vide apres l''UPDATE direct bloque par la RLS'
+);
+
+-- 2. Le fix : B (contrat actif) appelle le RPC -> message marque lu.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000061b2',
+    $$ select public.mark_liaison_messages_read('00000000-0000-0000-0000-0000000061c2') $$),
+  null,
+  'mark_liaison_messages_read : autorise pour un employe de l''equipe'
+);
+select ok(
+  (select read_by from public.liaison_messages
+   where id = '00000000-0000-0000-0000-0000000061d1')
+  @> array['00000000-0000-0000-0000-0000000061b2'::uuid],
+  'le RPC a bien ajoute B dans read_by'
+);
+
+-- 3. Controle d'acces : un user sans lien avec l'employeur est refuse.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000061f9',
+    $$ select public.mark_liaison_messages_read('00000000-0000-0000-0000-0000000061c2') $$),
+  '42501',
+  'mark_liaison_messages_read : refuse pour un user etranger a la conversation'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/log_entries_read_rls_test.sql
+++ b/supabase/tests/log_entries_read_rls_test.sql
@@ -1,0 +1,120 @@
+-- =============================================================================
+-- Tests RLS — mark_log_entry_read (migration 062)
+-- =============================================================================
+-- Bug initial : un UPDATE direct sur log_entries pour marquer une entrée comme
+-- lue était silencieusement bloqué par les policies RLS UPDATE (réservées à
+-- author_id / employer_id / tuteur). Un employé non-auteur qui pouvait LIRE
+-- l'entrée voyait son UPDATE filtré (0 ligne) -> compteur de non-lus persistant.
+-- Fix : RPC SECURITY DEFINER `mark_log_entry_read`.
+-- cf. supabase/migrations_archive/062_mark_log_entry_read_rpc.sql
+-- =============================================================================
+
+begin;
+select plan(7);
+
+-- ─── Fixtures ────────────────────────────────────────────────────────────────
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000062e1', 'employer62@test.local'),
+  ('00000000-0000-0000-0000-0000000062a1', 'employee62@test.local'),
+  ('00000000-0000-0000-0000-0000000062f9', 'stranger62@test.local');
+
+insert into public.profiles (id, role, first_name, last_name) values
+  ('00000000-0000-0000-0000-0000000062e1', 'employer', 'Emma',  'Ployeur'),
+  ('00000000-0000-0000-0000-0000000062a1', 'employee', 'Alice', 'Auxi'),
+  ('00000000-0000-0000-0000-0000000062f9', 'employee', 'Sam',   'Etranger');
+
+insert into public.employers (profile_id, address) values
+  ('00000000-0000-0000-0000-0000000062e1', '{}'::jsonb);
+insert into public.employees (profile_id) values
+  ('00000000-0000-0000-0000-0000000062a1'),
+  ('00000000-0000-0000-0000-0000000062f9');
+
+-- A a un contrat actif chez l'employeur ; Sam n'a aucun lien.
+insert into public.contracts
+  (employer_id, employee_id, contract_type, start_date, weekly_hours, hourly_rate, status)
+values
+  ('00000000-0000-0000-0000-0000000062e1', '00000000-0000-0000-0000-0000000062a1',
+   'CDI', '2026-01-01', 35, 15, 'active');
+
+-- Entrée de cahier de liaison rédigée par l'employeur.
+insert into public.log_entries
+  (id, employer_id, author_id, author_role, type, content)
+values
+  ('00000000-0000-0000-0000-0000000062c1', '00000000-0000-0000-0000-0000000062e1',
+   '00000000-0000-0000-0000-0000000062e1', 'employer', 'info', 'note du jour');
+
+-- ─── Helper : exécute une instruction sous l'identité d'un user ─────────────
+-- Renvoie NULL si l'instruction passe, le SQLSTATE si elle lève une exception.
+create function tests_run_as(p_uid uuid, p_sql text) returns text
+  language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_sql;
+  reset role;
+  return null;
+exception when others then
+  reset role;
+  return sqlstate;
+end;
+$$;
+
+-- ─── Tests ───────────────────────────────────────────────────────────────────
+-- 1. Le bug : un UPDATE direct par A (employé non-auteur) ne modifie rien.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000062a1',
+    $$ update public.log_entries
+         set read_by = coalesce(read_by, array[]::uuid[])
+                       || '00000000-0000-0000-0000-0000000062a1'::uuid
+       where id = '00000000-0000-0000-0000-0000000062c1' $$),
+  null,
+  'UPDATE direct par un employe non-auteur : pas d''erreur mais filtre RLS'
+);
+select ok(
+  coalesce(array_length(
+    (select read_by from public.log_entries
+     where id = '00000000-0000-0000-0000-0000000062c1'), 1), 0) = 0,
+  'read_by reste vide apres l''UPDATE direct bloque par la RLS'
+);
+
+-- 2. Le fix : A (contrat actif) appelle le RPC -> entree marquee lue.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000062a1',
+    $$ select public.mark_log_entry_read('00000000-0000-0000-0000-0000000062c1') $$),
+  null,
+  'mark_log_entry_read : autorise pour un employe au contrat actif'
+);
+select ok(
+  (select read_by from public.log_entries
+   where id = '00000000-0000-0000-0000-0000000062c1')
+  @> array['00000000-0000-0000-0000-0000000062a1'::uuid],
+  'le RPC a bien ajoute A dans read_by'
+);
+
+-- 3. Idempotent : un second appel ne duplique pas A dans read_by.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000062a1',
+    $$ select public.mark_log_entry_read('00000000-0000-0000-0000-0000000062c1') $$),
+  null,
+  'mark_log_entry_read : second appel sans erreur'
+);
+select is(
+  array_length(
+    (select read_by from public.log_entries
+     where id = '00000000-0000-0000-0000-0000000062c1'), 1),
+  1,
+  'idempotent : A n''apparait qu''une fois dans read_by'
+);
+
+-- 4. Controle d'acces : un user sans lien avec l'employeur est refuse.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000062f9',
+    $$ select public.mark_log_entry_read('00000000-0000-0000-0000-0000000062c1') $$),
+  '42501',
+  'mark_log_entry_read : refuse pour un user etranger'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Étend le harness de tests RLS (PR #395) aux 3 autres tables touchées par des bugs RLS — celles dont l'écriture directe était silencieusement bloquée et corrigée via un RPC `SECURITY DEFINER` (migrations 061-063).

### Changements
3 nouveaux fichiers dans `supabase/tests/` :

| Fichier | Migration | RPC testé |
|---|---|---|
| `liaison_messages_read_rls_test.sql` | 061 | `mark_liaison_messages_read` |
| `log_entries_read_rls_test.sql` | 062 | `mark_log_entry_read` |
| `leave_balances_rls_test.sql` | 063 | `initialize_leave_balance` |

Chaque test vérifie **les 3 faces du bug** :
1. l'écriture directe (`UPDATE`/`INSERT`) est bien bloquée par la RLS
2. le RPC `SECURITY DEFINER` débloque le cas légitime (employé concerné)
3. un utilisateur non autorisé est refusé (`42501`)

Les tests d'idempotence des RPC `mark_log_entry_read` et `initialize_leave_balance` sont également couverts.

`supabase/README.md` : tableau de couverture ajouté à la section Tests RLS.

### Bilan
Harness : **26 assertions** sur **4 fichiers** (migrations 061-064 couvertes).

## Test plan
- [x] `npm run test:db` — 26/26 assertions ✅ (4 fichiers)
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2330 passed / 4 skipped

## Suite possible
Étendre aux autres surfaces RLS sensibles : `employer_health_data` (RGPD art. 9, chiffré), `file_upload_audit` (mig 065), policies SELECT des plannings.