### PR TITLE
test(rls): cover employer_health_data and file_upload_audit

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -112,6 +112,8 @@ Points clés :
 | `liaison_messages_read_rls_test.sql` | RPC `mark_liaison_messages_read` (mig 061) |
 | `log_entries_read_rls_test.sql` | RPC `mark_log_entry_read` (mig 062) |
 | `leave_balances_rls_test.sql` | RPC `initialize_leave_balance` (mig 063) |
+| `employer_health_data_rls_test.sql` | isolation des données de santé (mig 058, RGPD art. 9) |
+| `file_upload_audit_rls_test.sql` | INSERT audit réservé à `service_role` (mig 065) |
 
 Chaque test RPC vérifie les trois faces du bug : l'écriture directe bloquée par
 la RLS, le RPC `SECURITY DEFINER` qui débloque le cas légitime, et le refus

--- a/supabase/tests/employer_health_data_rls_test.sql
+++ b/supabase/tests/employer_health_data_rls_test.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- Tests RLS — employer_health_data (migration 058)
+-- =============================================================================
+-- Données de santé chiffrées (handicap, besoins) — RGPD art. 9, catégorie
+-- "sensible". Les policies RLS restreignent INSERT/SELECT/UPDATE au seul
+-- propriétaire (`auth.uid() = profile_id`). Ce test verrouille la
+-- confidentialité en lecture : personne d'autre que l'employeur concerné —
+-- pas même un membre de son équipe — ne doit voir ses données de santé.
+-- cf. supabase/migrations_archive/058_pgsodium_health_data.sql
+-- =============================================================================
+
+begin;
+select plan(4);
+
+-- ─── Fixtures ────────────────────────────────────────────────────────────────
+-- 2 employeurs (E1, E2) + 1 employé (A) dans l'équipe de E1.
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000058e1', 'employer1-58@test.local'),
+  ('00000000-0000-0000-0000-0000000058e2', 'employer2-58@test.local'),
+  ('00000000-0000-0000-0000-0000000058a1', 'employee-58@test.local');
+
+insert into public.profiles (id, role, first_name, last_name) values
+  ('00000000-0000-0000-0000-0000000058e1', 'employer', 'Emma',  'Ployeur'),
+  ('00000000-0000-0000-0000-0000000058e2', 'employer', 'Enzo',  'Ployeur'),
+  ('00000000-0000-0000-0000-0000000058a1', 'employee', 'Alice', 'Auxi');
+
+insert into public.employers (profile_id, address) values
+  ('00000000-0000-0000-0000-0000000058e1', '{}'::jsonb),
+  ('00000000-0000-0000-0000-0000000058e2', '{}'::jsonb);
+insert into public.employees (profile_id) values
+  ('00000000-0000-0000-0000-0000000058a1');
+
+-- A a un contrat actif chez E1 (membre de l'équipe).
+insert into public.contracts
+  (employer_id, employee_id, contract_type, start_date, weekly_hours, hourly_rate, status)
+values
+  ('00000000-0000-0000-0000-0000000058e1', '00000000-0000-0000-0000-0000000058a1',
+   'CDI', '2026-01-01', 35, 15, 'active');
+
+-- Données de santé pour chaque employeur (colonnes chiffrées laissées NULL —
+-- non pertinent ici, le test porte sur la visibilité de la ligne).
+insert into public.employer_health_data (profile_id) values
+  ('00000000-0000-0000-0000-0000000058e1'),
+  ('00000000-0000-0000-0000-0000000058e2');
+
+-- ─── Helper : compte les lignes visibles sous l'identité d'un user ──────────
+create function tests_count_as(p_uid uuid, p_query text) returns integer
+  language plpgsql as $$
+declare
+  v_count integer;
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_query into v_count;
+  reset role;
+  return v_count;
+end;
+$$;
+
+-- ─── Tests ───────────────────────────────────────────────────────────────────
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000058e1',
+    $$ select count(*) from public.employer_health_data
+       where profile_id = '00000000-0000-0000-0000-0000000058e1' $$),
+  1,
+  'l''employeur voit ses propres donnees de sante'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000058e2',
+    $$ select count(*) from public.employer_health_data
+       where profile_id = '00000000-0000-0000-0000-0000000058e1' $$),
+  0,
+  'un autre employeur ne voit PAS les donnees de sante de E1'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000058a1',
+    $$ select count(*) from public.employer_health_data
+       where profile_id = '00000000-0000-0000-0000-0000000058e1' $$),
+  0,
+  'un employe de l''equipe ne voit PAS les donnees de sante de son employeur [RGPD art. 9]'
+);
+
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000058e1',
+    $$ select count(*) from public.employer_health_data $$),
+  1,
+  'l''employeur ne voit au total que sa propre ligne de donnees de sante'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/file_upload_audit_rls_test.sql
+++ b/supabase/tests/file_upload_audit_rls_test.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- Tests RLS — file_upload_audit (migration 065)
+-- =============================================================================
+-- Bug initial (mig 013) : la policy INSERT avait un WITH CHECK (true) qui
+-- laissait n'importe quel utilisateur `authenticated` insérer des lignes
+-- arbitraires dans le journal d'audit -> empoisonnement possible de la
+-- traçabilité RGPD.
+-- Fix (mig 065) : INSERT restreint au seul rôle `service_role`.
+-- La policy SELECT reste `auth.uid() = user_id` (chacun voit son audit).
+-- cf. supabase/migrations_archive/065_fix_file_upload_audit_insert_rls.sql
+-- =============================================================================
+
+begin;
+select plan(3);
+
+-- ─── Fixtures ────────────────────────────────────────────────────────────────
+-- user_id référence auth.users directement (pas de profil nécessaire).
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000065a1', 'user-a-65@test.local'),
+  ('00000000-0000-0000-0000-0000000065b2', 'user-b-65@test.local');
+
+-- Entrées d'audit existantes (insérées en tant que postgres, hors RLS).
+insert into public.file_upload_audit
+  (user_id, bucket_id, file_path, file_name, operation)
+values
+  ('00000000-0000-0000-0000-0000000065a1', 'justificatifs', 'a1/doc.pdf', 'doc.pdf', 'INSERT'),
+  ('00000000-0000-0000-0000-0000000065b2', 'justificatifs', 'b2/doc.pdf', 'doc.pdf', 'INSERT');
+
+-- ─── Helpers ─────────────────────────────────────────────────────────────────
+-- Exécute une instruction sous l'identité d'un user : NULL si OK, SQLSTATE sinon.
+create function tests_run_as(p_uid uuid, p_sql text) returns text
+  language plpgsql as $$
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_sql;
+  reset role;
+  return null;
+exception when others then
+  reset role;
+  return sqlstate;
+end;
+$$;
+
+-- Compte les lignes visibles sous l'identité d'un user.
+create function tests_count_as(p_uid uuid, p_query text) returns integer
+  language plpgsql as $$
+declare
+  v_count integer;
+begin
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', p_uid, 'role', 'authenticated')::text, true);
+  perform set_config('request.jwt.claim.sub', p_uid::text, true);
+  set local role authenticated;
+  execute p_query into v_count;
+  reset role;
+  return v_count;
+end;
+$$;
+
+-- ─── Tests ───────────────────────────────────────────────────────────────────
+-- 1. Régression mig 065 : un utilisateur authenticated ne peut PAS écrire
+--    dans le journal d'audit.
+select is(
+  tests_run_as('00000000-0000-0000-0000-0000000065a1',
+    $$ insert into public.file_upload_audit
+         (user_id, bucket_id, file_path, file_name, operation)
+       values ('00000000-0000-0000-0000-0000000065a1', 'justificatifs',
+               'a1/fake.pdf', 'fake.pdf', 'INSERT') $$),
+  '42501',
+  'un utilisateur authenticated ne peut pas inserer dans file_upload_audit'
+);
+
+-- 2. SELECT : chaque utilisateur voit sa propre entree d'audit.
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000065a1',
+    $$ select count(*) from public.file_upload_audit
+       where user_id = '00000000-0000-0000-0000-0000000065a1' $$),
+  1,
+  'un utilisateur voit sa propre entree d''audit'
+);
+
+-- 3. SELECT : un utilisateur ne voit PAS l'entree d'audit d'un autre.
+select is(
+  tests_count_as('00000000-0000-0000-0000-0000000065a1',
+    $$ select count(*) from public.file_upload_audit
+       where user_id = '00000000-0000-0000-0000-0000000065b2' $$),
+  0,
+  'un utilisateur ne voit pas l''entree d''audit d''un autre utilisateur'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Étend le harness de tests RLS (PRs #395, #397) à 2 tables sensibles supplémentaires. Toutes les tables RLS à risque connues (migrations 058, 061-065) sont désormais couvertes.

### Changements
2 nouveaux fichiers dans `supabase/tests/` :

| Fichier | Migration | Ce qui est verrouillé |
|---|---|---|
| `employer_health_data_rls_test.sql` | 058 | isolation en lecture des données de santé chiffrées |
| `file_upload_audit_rls_test.sql` | 065 | INSERT audit réservé à `service_role` |

**`employer_health_data`** (RGPD art. 9) — 4 assertions : l'employeur voit ses données de santé ; un **autre employeur** ne les voit pas ; un **employé de son équipe** (contrat actif) ne les voit pas non plus ; total visible limité à sa propre ligne.

**`file_upload_audit`** (mig 065) — 3 assertions : un utilisateur `authenticated` ne peut **pas** insérer dans le journal d'audit (régression — le `WITH CHECK (true)` d'origine le permettait, empoisonnement de la traçabilité) ; isolation SELECT (chacun ne voit que ses propres entrées).

`supabase/README.md` : tableau de couverture mis à jour.

### Bilan
Harness : **33 assertions** sur **6 fichiers**.

## Test plan
- [x] `npm run test:db` — 33/33 assertions ✅ (6 fichiers)
- [x] `npm run lint` — 0 erreur
- [x] `npm run test:run` — 2330 passed / 4 skipped