### PR TITLE
feat(voice): acoustic command classifier with diagnostics panel

### DIFF
--- a/src/components/voice/VoiceDiagnosticsCard.tsx
+++ b/src/components/voice/VoiceDiagnosticsCard.tsx
@@ -4,10 +4,12 @@ import { useVoiceDiagnosticsStore } from '@/stores/voiceDiagnosticsStore'
 
 /**
  * Carte "Diagnostic vocal" — visible uniquement quand le contrôle vocal
- * est activé. Affiche les 10 dernières transcriptions Whisper qui n'ont
- * pas matché une commande, pour aider à identifier les variantes
- * phonétiques manquantes (ex : Whisper transcrit "tablo de bord" au
- * lieu de "tableau de bord").
+ * est activé. Affiche :
+ *  - les 10 dernières transcriptions Whisper qui n'ont pas matché une
+ *    commande (variantes phonétiques manquantes) ;
+ *  - les 5 derniers classements du classifier acoustique : pour chaque
+ *    commande candidate, sa log-probabilité moyenne (forced-decoding
+ *    Whisper). Permet de calibrer le scoring sans la console devtools.
  *
  * Les données sont en RAM (non persistées) et vidées au reload — pas
  * de fuite dans localStorage. Cible : utilisateurs à élocution
@@ -16,9 +18,19 @@ import { useVoiceDiagnosticsStore } from '@/stores/voiceDiagnosticsStore'
 export function VoiceDiagnosticsCard() {
   const voiceEnabled = useAccessibilityStore((s) => s.settings.voiceControlEnabled)
   const entries = useVoiceDiagnosticsStore((s) => s.entries)
+  const classifications = useVoiceDiagnosticsStore((s) => s.classifications)
   const clear = useVoiceDiagnosticsStore((s) => s.clear)
 
   if (!voiceEnabled) return null
+
+  const hasData = entries.length > 0 || classifications.length > 0
+
+  const formatTime = (ts: number) =>
+    new Date(ts).toLocaleTimeString('fr-FR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
 
   return (
     <Card.Root borderRadius="md" borderWidth="1px" borderColor="border.default" boxShadow="sm">
@@ -34,7 +46,7 @@ export function VoiceDiagnosticsCard() {
                 : `${entries.length} commande${entries.length > 1 ? 's' : ''} non reconnue${entries.length > 1 ? 's' : ''} dans cette session.`}
             </Text>
           </Box>
-          {entries.length > 0 && (
+          {hasData && (
             <Button size="sm" variant="ghost" onClick={clear}>
               Effacer
             </Button>
@@ -42,46 +54,58 @@ export function VoiceDiagnosticsCard() {
         </HStack>
       </Card.Header>
 
-      {entries.length > 0 && (
+      {hasData && (
         <Card.Body p={4}>
-          <Stack gap={3}>
-            {entries.map((entry) => (
-              <Box
-                key={entry.id}
-                p={3}
-                borderRadius="md"
-                borderWidth="1px"
-                borderColor="border.default"
-                bg="bg.subtle"
-              >
-                <HStack justify="space-between" align="baseline" mb={1}>
-                  <Text fontWeight="600" fontSize="sm">
-                    « {entry.primary} »
-                  </Text>
-                  <Text fontSize="xs" color="text.muted">
-                    {new Date(entry.timestamp).toLocaleTimeString('fr-FR', {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                      second: '2-digit',
-                    })}
-                  </Text>
-                </HStack>
-                {entry.alternatives.length > 1 && (
-                  <VStack align="stretch" gap={0} mt={1}>
-                    <Text fontSize="xs" color="text.muted">
-                      Autres possibilités entendues :
-                    </Text>
-                    <Text fontSize="xs" color="text.muted" fontStyle="italic">
-                      {entry.alternatives
-                        .slice(1)
-                        .map((alt) => `« ${alt} »`)
-                        .join(' · ')}
-                    </Text>
-                  </VStack>
-                )}
-              </Box>
-            ))}
+          <Stack gap={6}>
+            {entries.length > 0 && (
+              <Stack gap={3}>
+                {entries.map((entry) => (
+                  <Box
+                    key={entry.id}
+                    p={3}
+                    borderRadius="md"
+                    borderWidth="1px"
+                    borderColor="border.default"
+                    bg="bg.subtle"
+                  >
+                    <HStack justify="space-between" align="baseline" mb={1}>
+                      <Text fontWeight="600" fontSize="sm">
+                        « {entry.primary} »
+                      </Text>
+                      <Text fontSize="xs" color="text.muted">
+                        {formatTime(entry.timestamp)}
+                      </Text>
+                    </HStack>
+                    {entry.alternatives.length > 1 && (
+                      <VStack align="stretch" gap={0} mt={1}>
+                        <Text fontSize="xs" color="text.muted">
+                          Autres possibilités entendues :
+                        </Text>
+                        <Text fontSize="xs" color="text.muted" fontStyle="italic">
+                          {entry.alternatives
+                            .slice(1)
+                            .map((alt) => `« ${alt} »`)
+                            .join(' · ')}
+                        </Text>
+                      </VStack>
+                    )}
+                  </Box>
+                ))}
+              </Stack>
+            )}
+
+            {classifications.length > 0 && (
+              <Stack gap={3}>
+                <Text fontWeight="700" fontSize="sm" fontFamily="heading">
+                  Classement du classifier acoustique
+                </Text>
+                {classifications.map((entry) => (
+                  <ClassificationBlock key={entry.id} entry={entry} formatTime={formatTime} />
+                ))}
+              </Stack>
+            )}
           </Stack>
+
           <Text fontSize="xs" color="text.muted" mt={4}>
             Ces données sont temporaires et ne quittent pas votre appareil. Elles servent à
             comprendre pourquoi une commande échoue et à enrichir la reconnaissance vocale.
@@ -89,6 +113,67 @@ export function VoiceDiagnosticsCard() {
         </Card.Body>
       )}
     </Card.Root>
+  )
+}
+
+function ClassificationBlock({
+  entry,
+  formatTime,
+}: {
+  entry: { id: string; timestamp: number; scores: { phrase: string; avgLogProb: number }[] }
+  formatTime: (ts: number) => string
+}) {
+  // Scores triés meilleur d'abord ; on borne l'échelle de la barre entre le
+  // meilleur et le pire score de cet essai pour rendre l'écart lisible.
+  const best = entry.scores[0]?.avgLogProb ?? 0
+  const worst = entry.scores[entry.scores.length - 1]?.avgLogProb ?? -1
+  const span = best - worst || 1
+
+  return (
+    <Box
+      p={3}
+      borderRadius="md"
+      borderWidth="1px"
+      borderColor="border.default"
+      bg="bg.subtle"
+    >
+      <HStack justify="space-between" align="baseline" mb={2}>
+        <Text fontWeight="600" fontSize="sm">
+          Gagnant : « {entry.scores[0]?.phrase} »
+        </Text>
+        <Text fontSize="xs" color="text.muted">
+          {formatTime(entry.timestamp)}
+        </Text>
+      </HStack>
+      <VStack align="stretch" gap={1}>
+        {entry.scores.map((score, i) => {
+          const ratio = (score.avgLogProb - worst) / span
+          return (
+            <HStack key={score.phrase} gap={2} align="center">
+              <Text
+                fontSize="xs"
+                fontWeight={i === 0 ? '700' : '500'}
+                color={i === 0 ? 'brand.fg' : 'text.default'}
+                minW="110px"
+              >
+                {score.phrase}
+              </Text>
+              <Box flex="1" h="6px" borderRadius="full" bg="bg.muted" overflow="hidden">
+                <Box
+                  h="full"
+                  borderRadius="full"
+                  bg={i === 0 ? 'brand.solid' : 'border.emphasized'}
+                  width={`${Math.max(2, ratio * 100)}%`}
+                />
+              </Box>
+              <Text fontSize="xs" color="text.muted" minW="48px" textAlign="right">
+                {score.avgLogProb.toFixed(2)}
+              </Text>
+            </HStack>
+          )
+        })}
+      </VStack>
+    </Box>
   )
 }
 

--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAccessibilityStore } from '@/stores/authStore'
 import { useVoiceDiagnosticsStore } from '@/stores/voiceDiagnosticsStore'
 import { useAuth } from '@/hooks/useAuth'
-import { matchCommand, type VoiceCommand } from '@/lib/voice/voiceCommands'
+import { matchCommand, getCommandCandidates, type VoiceCommand } from '@/lib/voice/voiceCommands'
 import { formatVoiceError } from '@/lib/voice/errors'
 import { logger } from '@/lib/logger'
 
@@ -53,7 +53,12 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
   const speechEndAtRef = useRef<number | null>(null)
 
   const handleResult = useCallback(
-    (heard: string | string[]) => {
+    async (
+      heard: string | string[],
+      // Secours acoustique (chemin Whisper uniquement) : invoqué quand aucune
+      // alternative texte ne matche. Re-score l'audio contre les commandes.
+      rescue?: () => Promise<VoiceCommand | null>,
+    ) => {
       // Latence perçue : depuis la fin de parole jusqu'à l'affichage du
       // résultat. Utile pour comparer engine natif vs Whisper en prod.
       if (speechEndAtRef.current !== null) {
@@ -68,19 +73,26 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       setTranscript(primary)
 
       // Tente toutes les alternatives ; la 1ère qui matche gagne.
-      let cmd = null
+      let cmd: VoiceCommand | null = null
       for (const alt of candidates) {
         cmd = matchCommand(alt, profile?.role ?? null)
         if (cmd) break
       }
+
+      // Échec du matching texte → secours par scoring acoustique (Whisper).
+      // La transcription a beau être fausse ("Plague"), l'audio est re-scoré
+      // contre chaque commande et la mieux notée l'emporte.
+      if (!cmd && rescue) {
+        cmd = await rescue()
+      }
+
       setMatched(cmd)
       if (cmd) {
         navigate(cmd.path)
       } else if (primary) {
         setError(`Commande non reconnue : "${primary}"`)
         // Log dans le panneau diagnostic (Paramètres > Assistance) pour permettre
-        // à l'utilisateur d'identifier ce que Whisper a réellement entendu et
-        // d'ajuster les variantes phonétiques si besoin.
+        // à l'utilisateur d'identifier ce que Whisper a réellement entendu.
         useVoiceDiagnosticsStore.getState().pushEntry({
           primary,
           alternatives: candidates,
@@ -110,7 +122,8 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       if (!result) return
       const alternatives = Array.from({ length: result.length }, (_, i) => result[i]?.transcript ?? '')
         .filter(Boolean)
-      handleResult(alternatives)
+      // Moteur natif : pas d'audio brut → pas de secours acoustique.
+      void handleResult(alternatives)
     }
     recognition.onspeechstart = () => setSpeechDetected(true)
     recognition.onspeechend = () => {
@@ -211,14 +224,23 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       setStatus('transcribing')
       const { transcribe } = await import('@/lib/voice/whisperEngine')
       const heard = await transcribe(audio)
-      handleResult(heard)
+      await handleResult(heard, async () => {
+        // Secours : transcription + matchCommand ont échoué. On re-score
+        // l'audio contre chaque commande par forced-decoding Whisper.
+        const { recognizeCommand } = await import('@/lib/voice/whisperClassifier')
+        const { command } = await recognizeCommand(
+          audio,
+          getCommandCandidates(profile?.role ?? null),
+        )
+        return command
+      })
       setStatus('idle')
     } catch (err) {
       logger.error('Whisper voice flow error', err)
       setError(formatVoiceError(err))
       setStatus('error')
     }
-  }, [handleResult])
+  }, [handleResult, profile?.role])
 
   // Garde la dernière référence à startWhisper pour la bascule depuis onerror native.
   useEffect(() => {

--- a/src/hooks/useVoiceNavigation.ts
+++ b/src/hooks/useVoiceNavigation.ts
@@ -84,6 +84,11 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
       // contre chaque commande et la mieux notée l'emporte.
       if (!cmd && rescue) {
         cmd = await rescue()
+      } else if (import.meta.env.DEV && rescue) {
+        // [DEBUG TEMP — à retirer après calibration] Lance quand même le
+        // classifier alors qu'une commande a déjà matché, pour capturer son
+        // classement à chaque essai pendant la phase de calibration du scoring.
+        await rescue()
       }
 
       setMatched(cmd)
@@ -228,10 +233,13 @@ export function useVoiceNavigation(): UseVoiceNavigationReturn {
         // Secours : transcription + matchCommand ont échoué. On re-score
         // l'audio contre chaque commande par forced-decoding Whisper.
         const { recognizeCommand } = await import('@/lib/voice/whisperClassifier')
-        const { command } = await recognizeCommand(
+        const { command, scores } = await recognizeCommand(
           audio,
           getCommandCandidates(profile?.role ?? null),
         )
+        // Remonte le classement dans le panneau diagnostic (Paramètres >
+        // Assistance) pour calibrer le scoring sans la console devtools.
+        useVoiceDiagnosticsStore.getState().pushClassification(scores)
         return command
       })
       setStatus('idle')

--- a/src/lib/voice/voiceCommands.test.ts
+++ b/src/lib/voice/voiceCommands.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { matchCommand, normalize, listAvailableCommands, VOICE_COMMANDS } from './voiceCommands'
+import {
+  matchCommand,
+  normalize,
+  listAvailableCommands,
+  getCommandCandidates,
+  VOICE_COMMANDS,
+} from './voiceCommands'
 
 describe('voiceCommands.normalize', () => {
   it('lowercases, removes diacritics and punctuation', () => {
@@ -181,5 +187,28 @@ describe('voiceCommands.listAvailableCommands', () => {
   it('returns only unrestricted commands for null role', () => {
     const list = listAvailableCommands(null)
     expect(list.every((c) => !c.roles)).toBe(true)
+  })
+})
+
+describe('voiceCommands.getCommandCandidates', () => {
+  it('excludes submenu (#) and action (?) commands', () => {
+    const candidates = getCommandCandidates('employer')
+    expect(
+      candidates.every(
+        (c) => !c.command.path.includes('#') && !c.command.path.includes('?'),
+      ),
+    ).toBe(true)
+  })
+
+  it('uses the first phrase of each command as the canonical one', () => {
+    const planning = getCommandCandidates('employer').find(
+      (c) => c.command.path === '/planning',
+    )
+    expect(planning?.phrase).toBe('planning')
+  })
+
+  it('respects role gating (employee does not get /equipe)', () => {
+    const candidates = getCommandCandidates('employee')
+    expect(candidates.find((c) => c.command.path === '/equipe')).toBeUndefined()
   })
 })

--- a/src/lib/voice/voiceCommands.ts
+++ b/src/lib/voice/voiceCommands.ts
@@ -130,3 +130,24 @@ export function matchCommand(
 export function listAvailableCommands(role?: UserRole | null): VoiceCommand[] {
   return VOICE_COMMANDS.filter((c) => !c.roles || (role && c.roles.includes(role)))
 }
+
+export interface CommandCandidate {
+  /** Phrase canonique (1re de la liste) — celle scorée par le classifier Whisper. */
+  phrase: string
+  command: VoiceCommand
+}
+
+// Candidats pour le classifier acoustique (whisperClassifier) : une phrase
+// canonique par commande accessible au rôle. Le classifier force-décode chaque
+// phrase sur l'audio et garde la mieux scorée — utilisé en secours quand la
+// transcription + matchCommand échoue.
+//
+// Restreint aux destinations de navigation principales : les sous-menus
+// (`#...`) et actions (`?action=...`) sont des phrases multi-mots que Whisper
+// transcrit correctement et que matchCommand attrape déjà — les inclure ne
+// ferait qu'alourdir le scoring (1 forward décodeur par candidat).
+export function getCommandCandidates(role?: UserRole | null): CommandCandidate[] {
+  return listAvailableCommands(role)
+    .filter((command) => !command.path.includes('#') && !command.path.includes('?'))
+    .map((command) => ({ phrase: command.phrases[0], command }))
+}

--- a/src/lib/voice/whisperClassifier.test.ts
+++ b/src/lib/voice/whisperClassifier.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { pickWinner, type CommandScore } from './whisperClassifier'
+import { getCommandCandidates } from './voiceCommands'
+
+// Note : classifyCommand (forced-decoding Whisper) n'est pas testé en unitaire
+// — il charge le modèle ONNX. Seule la logique de décision pure (pickWinner)
+// est couverte ici ; le scoring acoustique se valide au micro.
+
+describe('whisperClassifier.pickWinner', () => {
+  const candidates = getCommandCandidates('employer')
+
+  it('returns null for empty scores', () => {
+    expect(pickWinner([], candidates).command).toBeNull()
+  })
+
+  it('returns the best command when score is high and margin is clear', () => {
+    const scores: CommandScore[] = [
+      { phrase: 'planning', avgLogProb: -0.25 },
+      { phrase: 'équipe', avgLogProb: -1.0 },
+    ]
+    expect(pickWinner(scores, candidates).command?.path).toBe('/planning')
+  })
+
+  it('rejects when even the best score is below the minimum (audio unlike any command)', () => {
+    const scores: CommandScore[] = [
+      { phrase: 'planning', avgLogProb: -1.6 },
+      { phrase: 'équipe', avgLogProb: -2.0 },
+    ]
+    expect(pickWinner(scores, candidates).command).toBeNull()
+  })
+
+  it('rejects when the top two scores are too close (ambiguous)', () => {
+    const scores: CommandScore[] = [
+      { phrase: 'planning', avgLogProb: -0.3 },
+      { phrase: 'équipe', avgLogProb: -0.4 },
+    ]
+    expect(pickWinner(scores, candidates).command).toBeNull()
+  })
+
+  it('accepts a lone candidate above the threshold (no margin check)', () => {
+    const scores: CommandScore[] = [{ phrase: 'planning', avgLogProb: -0.5 }]
+    expect(pickWinner(scores, candidates).command?.path).toBe('/planning')
+  })
+})

--- a/src/lib/voice/whisperClassifier.ts
+++ b/src/lib/voice/whisperClassifier.ts
@@ -1,0 +1,241 @@
+// =============================================================================
+// whisperClassifier — reconnaissance de commande par scoring acoustique
+// =============================================================================
+// Au lieu de « transcrire puis matcher du texte » (qui échoue dès que Whisper
+// se trompe de mot, ex : "planning" -> "Plague"), on inverse : pour chaque
+// commande connue, on force le décodeur Whisper à « lire » cette commande sur
+// l'audio et on récupère sa log-probabilité. La commande la mieux scorée gagne.
+//
+// La sortie est donc toujours une commande valide : la mauvaise transcription
+// devient structurellement impossible. Particulièrement robuste pour les voix
+// atypiques (cf. mémoire user-imc-elocution) — on ne demande plus à Whisper de
+// produire le texte exact, juste de dire « de quelle commande c'est le plus
+// proche acoustiquement ».
+//
+// Utilisé en SECOURS (cf. useVoiceNavigation) : seulement quand la
+// transcription classique + matchCommand a échoué. Tout échec ici est attrapé
+// et renvoie [] -> l'appelant retombe sur "commande non reconnue".
+// =============================================================================
+
+import { logger } from '@/lib/logger'
+import { getTranscriber } from './whisperEngine'
+import { preprocessAudio } from './audioPreprocessing'
+import type { CommandCandidate, VoiceCommand } from './voiceCommands'
+
+export interface CommandScore {
+  phrase: string
+  /** Log-probabilité moyenne par token (≤ 0 ; plus proche de 0 = meilleur match). */
+  avgLogProb: number
+}
+
+// Tokens spéciaux Whisper multilingue — filet de secours si la dérivation via
+// le tokenizer échoue. Ids valables pour les modèles whisper-{tiny..large}.
+const FALLBACK_TOKENS = {
+  prefix: [50258, 50265, 50359, 50363], // <|startoftranscript|><|fr|><|transcribe|><|notimestamps|>
+  eot: 50257, // <|endoftext|>
+}
+
+// Accès bas niveau au pipeline transformers.js (model/processor/tokenizer ne
+// sont pas dans le type Transcriber exposé par whisperEngine).
+interface LooseTensor {
+  type: string
+  data: Float32Array | BigInt64Array | Uint16Array | number[]
+  dims: number[]
+  to: (type: string) => LooseTensor
+}
+interface WhisperPipeline {
+  model: {
+    forward: (inputs: Record<string, unknown>) => Promise<{ logits: LooseTensor }>
+    // Exécute une session par nom et renvoie une sortie — ici l'encodeur seul.
+    _encode_input: (
+      sessionName: string,
+      inputs: Record<string, unknown>,
+      outputName: string,
+    ) => Promise<unknown>
+  }
+  processor: (audio: Float32Array) => Promise<{ input_features: unknown }>
+  tokenizer: {
+    encode: (text: string, opts?: { add_special_tokens?: boolean }) => number[]
+  }
+}
+
+let cachedPrefix: number[] | null = null
+let cachedEot: number | null = null
+
+function resolveSpecialTokens(tokenizer: WhisperPipeline['tokenizer']): {
+  prefix: number[]
+  eot: number
+} {
+  if (cachedPrefix && cachedEot !== null) return { prefix: cachedPrefix, eot: cachedEot }
+  try {
+    const prefix = tokenizer.encode(
+      '<|startoftranscript|><|fr|><|transcribe|><|notimestamps|>',
+      { add_special_tokens: false },
+    )
+    const eot = tokenizer.encode('<|endoftext|>', { add_special_tokens: false })[0]
+    // Sanity check : 4 tokens de prefixe + un eot valide, sinon fallback.
+    if (prefix.length === 4 && prefix.every(Number.isInteger) && Number.isInteger(eot)) {
+      cachedPrefix = prefix
+      cachedEot = eot
+      return { prefix, eot }
+    }
+    logger.warn('[Classifier] dérivation tokens spéciaux inattendue, fallback', { prefix, eot })
+  } catch (err) {
+    logger.warn('[Classifier] tokenizer.encode des tokens spéciaux a échoué, fallback', err)
+  }
+  cachedPrefix = FALLBACK_TOKENS.prefix
+  cachedEot = FALLBACK_TOKENS.eot
+  return { prefix: cachedPrefix, eot: cachedEot }
+}
+
+// log-softmax appliqué à une seule cible : logit[target] - logsumexp(row).
+function targetLogProb(row: Float32Array, target: number): number {
+  let max = -Infinity
+  for (let i = 0; i < row.length; i++) if (row[i] > max) max = row[i]
+  let sumExp = 0
+  for (let i = 0; i < row.length; i++) sumExp += Math.exp(row[i] - max)
+  const logSumExp = max + Math.log(sumExp)
+  return row[target] - logSumExp
+}
+
+/**
+ * Score chaque phrase candidate contre l'audio par forced-decoding Whisper.
+ * Renvoie les scores triés (meilleur d'abord). En cas d'échec : [].
+ */
+export async function classifyCommand(
+  audio: Float32Array,
+  phrases: string[],
+): Promise<CommandScore[]> {
+  if (phrases.length === 0) return []
+  const t0 = performance.now()
+  try {
+    const pipe = (await getTranscriber()) as unknown as WhisperPipeline
+    const { prefix, eot } = resolveSpecialTokens(pipe.tokenizer)
+    logger.info(`[Classifier] prefix=[${prefix}] eot=${eot}`)
+
+    const processed = preprocessAudio(audio)
+    const { input_features } = await pipe.processor(processed)
+
+    const { Tensor } = await import('@huggingface/transformers')
+
+    // Encodeur exécuté UNE seule fois (c'est la passe coûteuse, ~plusieurs
+    // secondes). On réutilise `encoder_outputs` pour chaque candidat : le
+    // forward ne fait alors tourner que le décodeur (passe légère).
+    const encoderOutputs = await pipe.model._encode_input(
+      'model',
+      { input_features },
+      'last_hidden_state',
+    )
+    // Diagnostic : confirme que la chaîne audio est saine.
+    const featDims = (input_features as { dims?: number[] })?.dims
+    const encDims = (encoderOutputs as { dims?: number[] })?.dims
+    logger.info(`[Classifier] input_features.dims=[${featDims}] encoder_outputs.dims=[${encDims}]`)
+
+    const scores: CommandScore[] = []
+    for (const phrase of phrases) {
+      // Whisper produit du texte naturel : espace initial (BPE GPT-2) +
+      // majuscule en début de segment. On ne score PAS <|endoftext|> :
+      // après une phrase courte le modèle ne l'attend pas, ce qui plombait
+      // injustement les commandes courtes ("planning", "aide").
+      const display = phrase.charAt(0).toUpperCase() + phrase.slice(1)
+      const targets = pipe.tokenizer.encode(' ' + display, { add_special_tokens: false })
+      const ids = [...prefix, ...targets]
+
+      const decoderInputIds = new Tensor(
+        'int64',
+        BigInt64Array.from(ids.map((x) => BigInt(x))),
+        [1, ids.length],
+      )
+
+      const { logits } = await pipe.model.forward({
+        encoder_outputs: encoderOutputs,
+        decoder_input_ids: decoderInputIds,
+      })
+
+      // Le décodeur tourne en fp16 : les logits sont alors stockés en
+      // Uint16Array (demi-flottants). Conversion en float32 indispensable
+      // avant tout calcul — sinon on lit des bits bruts comme des nombres.
+      const logitsF32 = logits.to('float32')
+      const vocab = logitsF32.dims[logitsF32.dims.length - 1]
+      const data = logitsF32.data as Float32Array
+      // La ligne de logits à la position p prédit le token p+1. On score les
+      // `targets` (tokens de la phrase + eot), dont le 1er est à la position
+      // `prefix.length` dans la séquence.
+      let sum = 0
+      for (let j = 0; j < targets.length; j++) {
+        const seqPos = prefix.length + j
+        const row = data.subarray((seqPos - 1) * vocab, seqPos * vocab) as Float32Array
+        sum += targetLogProb(row, targets[j])
+      }
+      scores.push({ phrase, avgLogProb: sum / targets.length })
+    }
+
+    scores.sort((a, b) => b.avgLogProb - a.avgLogProb)
+    logger.info(
+      `[Classifier] ${phrases.length} commandes scorées en ${Math.round(performance.now() - t0)}ms`,
+    )
+    logger.info(
+      `[Classifier] classement: ${scores
+        .map((s) => `${s.phrase}=${s.avgLogProb.toFixed(2)}`)
+        .join('  ')}`,
+    )
+    return scores
+  } catch (err) {
+    logger.error('[Classifier] classifyCommand a échoué', err)
+    return []
+  }
+}
+
+// --- Décision ----------------------------------------------------------------
+//
+// Seuils À CALIBRER au micro (le panneau diagnostic logge les scores) :
+//  - MIN_AVG_LOGPROB : score minimal du meilleur candidat ; en-dessous, l'audio
+//    ne ressemble à aucune commande -> rejet.
+//  - MIN_MARGIN : écart minimal entre le 1er et le 2e ; trop proche = ambigu.
+const MIN_AVG_LOGPROB = -1.2
+const MIN_MARGIN = 0.15
+
+export interface RecognitionResult {
+  command: VoiceCommand | null
+  /** Scores triés (debug / panneau diagnostic). */
+  scores: CommandScore[]
+}
+
+/**
+ * Applique les seuils de décision à des scores déjà calculés (fonction pure).
+ * `scores` doit être trié décroissant. Renvoie `command: null` si rejet.
+ */
+export function pickWinner(
+  scores: CommandScore[],
+  candidates: CommandCandidate[],
+): RecognitionResult {
+  if (scores.length === 0) return { command: null, scores }
+
+  const [best, second] = scores
+  if (best.avgLogProb < MIN_AVG_LOGPROB) {
+    logger.info(`[Classifier] rejet : meilleur score ${best.avgLogProb.toFixed(3)} < ${MIN_AVG_LOGPROB}`)
+    return { command: null, scores }
+  }
+  if (second && best.avgLogProb - second.avgLogProb < MIN_MARGIN) {
+    logger.info(
+      `[Classifier] rejet : marge ${(best.avgLogProb - second.avgLogProb).toFixed(3)} < ${MIN_MARGIN} ` +
+        `("${best.phrase}" vs "${second.phrase}")`,
+    )
+    return { command: null, scores }
+  }
+
+  const match = candidates.find((c) => c.phrase === best.phrase)
+  return { command: match?.command ?? null, scores }
+}
+
+/**
+ * Reconnaît une commande à partir de l'audio par scoring acoustique.
+ * Renvoie `command: null` si rejet (sous seuil, marge insuffisante, ou échec).
+ */
+export async function recognizeCommand(
+  audio: Float32Array,
+  candidates: CommandCandidate[],
+): Promise<RecognitionResult> {
+  const scores = await classifyCommand(audio, candidates.map((c) => c.phrase))
+  return pickWinner(scores, candidates)
+}

--- a/src/stores/voiceDiagnosticsStore.ts
+++ b/src/stores/voiceDiagnosticsStore.ts
@@ -3,12 +3,12 @@ import { create } from 'zustand'
 /**
  * Diagnostic vocal — store éphémère (RAM only, pas persisté).
  *
- * Garde les 10 dernières transcriptions Whisper qui n'ont pas matché
- * une commande, pour permettre à l'utilisateur (ou à un proche dev) de
- * voir ce que le moteur de reconnaissance a réellement entendu quand
- * une commande échoue. Utile pour ajuster les variantes phonétiques
- * dans `src/lib/voice/voiceCommands.ts` quand un utilisateur cible
- * (ex: Marie) reporte que "ça ne reconnaît rien".
+ * Deux flux :
+ *  - `entries` : les 10 dernières transcriptions Whisper qui n'ont pas matché
+ *    une commande, pour voir ce que le moteur a réellement entendu.
+ *  - `classifications` : les 5 derniers classements du classifier acoustique
+ *    (forced-decoding Whisper), pour calibrer le scoring sans la console
+ *    devtools — chaque commande candidate avec sa log-probabilité moyenne.
  *
  * Pas de persistance : les données sont vidées au reload, le panneau
  * Paramètres affiche uniquement la session courante. Évite toute fuite
@@ -22,30 +22,55 @@ export interface VoiceDiagnosticEntry {
   alternatives: string[]
 }
 
+/** Score d'une commande candidate — miroir léger de `CommandScore`. */
+export interface VoiceClassificationScore {
+  phrase: string
+  avgLogProb: number
+}
+
+export interface VoiceClassificationEntry {
+  id: string
+  timestamp: number
+  /** Scores triés (meilleur d'abord, tel que renvoyé par le classifier). */
+  scores: VoiceClassificationScore[]
+}
+
 interface VoiceDiagnosticsState {
   entries: VoiceDiagnosticEntry[]
+  classifications: VoiceClassificationEntry[]
   pushEntry: (entry: Omit<VoiceDiagnosticEntry, 'id' | 'timestamp'>) => void
+  pushClassification: (scores: VoiceClassificationScore[]) => void
   clear: () => void
 }
 
 const MAX_ENTRIES = 10
+const MAX_CLASSIFICATIONS = 5
+
+function makeId(): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
 
 export const useVoiceDiagnosticsStore = create<VoiceDiagnosticsState>((set) => ({
   entries: [],
+  classifications: [],
   pushEntry: ({ primary, alternatives }) =>
     set((state) => ({
       entries: [
-        {
-          id:
-            typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-              ? crypto.randomUUID()
-              : `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-          timestamp: Date.now(),
-          primary,
-          alternatives,
-        },
+        { id: makeId(), timestamp: Date.now(), primary, alternatives },
         ...state.entries,
       ].slice(0, MAX_ENTRIES),
     })),
-  clear: () => set({ entries: [] }),
+  pushClassification: (scores) =>
+    set((state) => {
+      if (scores.length === 0) return state
+      return {
+        classifications: [
+          { id: makeId(), timestamp: Date.now(), scores },
+          ...state.classifications,
+        ].slice(0, MAX_CLASSIFICATIONS),
+      }
+    }),
+  clear: () => set({ entries: [], classifications: [] }),
 }))


### PR DESCRIPTION
## Summary
Classifier acoustique Whisper en secours de la navigation vocale : quand la transcription se trompe de mot ("planning" → "Plague"), on force-décode chaque commande sur l'audio et la mieux scorée gagne. Le classement est remonté dans le panneau diagnostic pour calibrer le scoring avec un utilisateur cible.

⚠️ **Branche de calibration — NON validée.** Le scoring de fond est encore à régler (biais longueur de phrase, trou synonymes). Ne pas merger en l'état. Un bloc `[DEBUG TEMP]` DEV-only est à retirer avant merge.

### Changements
- `whisperClassifier.ts` : forced-decoding Whisper + décision (seuil + marge)
- `voiceCommands.ts` : `getCommandCandidates` (12 destinations de nav)
- `useVoiceNavigation` : classifier câblé en secours du chemin Whisper
- `voiceDiagnosticsStore` : flux `classifications` (classement RAM only)
- `VoiceDiagnosticsCard` : section "Classement du classifier acoustique"

## Test plan
- [ ] Firefox : nav vocale, dire une commande, vérifier le classement dans Paramètres > Accessibilité > Diagnostic vocal
- [ ] Calibrer `MIN_AVG_LOGPROB` / `MIN_MARGIN` sur données réelles
- [ ] Retirer le bloc `[DEBUG TEMP]` de `useVoiceNavigation`
- [ ] Tests automatisés passent (lint ✅ / test:run ✅ au moment du push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)