### PR TITLE
chore(infra): add staging preprod environment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,123 @@
+name: Deploy to Staging
+
+# Déploie une branche arbitraire sur la préprod (staging.unilien.app).
+# Déclenchement MANUEL uniquement : Actions > Deploy to Staging > Run workflow,
+# en choisissant la branche à tester. Cf. docs/PREPROD_SETUP.md.
+#
+# Volontairement SANS étape de tests : la préprod sert à faire tester des
+# branches en cours (potentiellement imparfaites) à des utilisateurs non-dev.
+# La CI sur les PR couvre déjà lint + tests.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branche à déployer en préprod'
+        required: true
+        default: 'main'
+
+jobs:
+  deploy-staging:
+    name: Deploy ${{ inputs.branch }} to staging
+    runs-on: ubuntu-latest
+    environment:
+      name: env_unilien_staging
+      url: https://staging.unilien.app
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_APP_NAME: 'Unilien (préprod)'
+          VITE_APP_URL: https://staging.unilien.app
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: staging-build
+          path: dist/
+          retention-days: 7
+
+      - name: Check secret presence
+        env:
+          SSH_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "ERROR: VPS_SSH_PRIVATE_KEY is empty"
+            exit 1
+          fi
+          echo "SSH_KEY length: ${#SSH_KEY}"
+          echo "VPS_HOST set: ${VPS_HOST:+yes}"
+          echo "VPS_USER set: ${VPS_USER:+yes}"
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" | tr -d '\r' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "Key fingerprint:"
+          ssh-keygen -l -f ~/.ssh/deploy_key || (echo "INVALID KEY FORMAT" && exit 1)
+          ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy to VPS (staging)
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          rsync -avz --delete \
+            --exclude='.DS_Store' \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            dist/ "$VPS_USER@$VPS_HOST:/var/www/unilien-staging/"
+
+      - name: Deploy Edge Functions to VPS (staging)
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+        run: |
+          # Sync Edge Functions vers la stack Supabase staging (preserve les
+          # entrypoints runtime main/ et hello/).
+          rsync -avz --delete \
+            --exclude='.DS_Store' \
+            --exclude='*.test.ts' \
+            --exclude='main/' \
+            --exclude='hello/' \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            supabase/functions/ "$VPS_USER@$VPS_HOST:/opt/supabase-staging/docker/volumes/functions/"
+
+          # Redémarre le conteneur edge-runtime de la stack staging.
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "$VPS_USER@$VPS_HOST" \
+            "sudo -n docker compose --project-directory /opt/supabase-staging/docker restart functions"
+
+      - name: Health check
+        run: |
+          sleep 3
+          # La préprod est protégée par basic auth : sans identifiants Caddy
+          # renvoie 401. Un 200 OU un 401 prouvent que le site répond.
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" https://staging.unilien.app)
+          echo "HTTP $CODE"
+          if [ "$CODE" != "200" ] && [ "$CODE" != "401" ]; then
+            echo "Health check failed (attendu 200 ou 401)"
+            exit 1
+          fi

--- a/docs/PREPROD_SETUP.md
+++ b/docs/PREPROD_SETUP.md
@@ -1,22 +1,23 @@
-# Préprod — Plan de mise en place
+# Préprod — Mise en place & runbook
 
-> **Statut : à valider.** Document de cadrage, rien n'est encore implémenté.
-> Objectif : un environnement de préproduction pour faire tester des branches
-> non mergées à des utilisateurs cibles (Marie, etc.) sans toucher à la prod.
+> Environnement de préproduction pour faire tester des branches non mergées à
+> des utilisateurs cibles (Marie, etc.) sans toucher à la prod.
+>
+> **Statut : décisions tranchées, code livré (branche `chore/preprod-staging-env`).**
+> Reste à exécuter le runbook §5 (actions VPS / DNS / GitHub).
 
 ---
 
 ## 1. Objectif
 
-Aujourd'hui le seul environnement déployé est la **prod** (`unilien.app`).
-Pour faire tester une feature en cours (ex : le classifier vocal de la branche
-`feat/voice-acoustic-classifier`) à un utilisateur non-dev, il faut un
-environnement intermédiaire :
+`unilien.app` est le seul environnement déployé. Pour faire tester une feature
+en cours (ex : le classifier vocal, branche `fix/voice-classifier-prior-normalization`)
+à un utilisateur non-dev, il faut un environnement intermédiaire :
 
 - accessible via une URL publique,
-- déployable depuis une branche (pas seulement `main`),
-- isolé de la prod (données, déploiement, monitoring),
-- sans données de santé réelles (RGPD art. 9).
+- déployable depuis une branche arbitraire (pas seulement `main`),
+- isolé de la prod (déploiement, backend, monitoring),
+- protégé et non indexé.
 
 ---
 
@@ -30,93 +31,208 @@ environnement intermédiaire :
 | Studio         | `studio.unilien.app` → `localhost:8000`                     |
 | Analytics      | Plausible self-hosted, `plausible.unilien.app:8001`         |
 | Déploiement    | GitHub Actions `deploy.yml`, sur push `main` → rsync VPS    |
-| Hébergement    | VPS unique OVH (Debian 13)                                  |
+| Hébergement    | VPS unique OVH VPS-3 (8 vCores, 24 Go RAM, Debian 13)       |
 
 ---
 
-## 3. Décisions à trancher
+## 3. Décisions (tranchées)
 
-| # | Question                       | Options                                                                 | Reco |
-|---|--------------------------------|--------------------------------------------------------------------------|------|
-| 1 | Sous-domaine                   | `staging.unilien.app` / `preprod.unilien.app`                            | `staging.unilien.app` |
-| 2 | Où ça tourne                   | Même VPS (nouveau site Caddy) / VPS dédié                                | Même VPS (coût, simplicité) |
-| 3 | Backend / données              | Même Supabase prod / **Instance Supabase préprod dédiée** / schéma séparé | Instance dédiée |
-| 4 | Déclencheur de déploiement     | `workflow_dispatch` manuel / push sur branche `staging`                  | `workflow_dispatch` |
-| 5 | Accès                          | Public / protégé (basic auth Caddy)                                      | Basic auth Caddy |
+| # | Question                   | Choix                                                          |
+|---|----------------------------|-----------------------------------------------------------------|
+| 1 | Sous-domaine               | `staging.unilien.app`                                          |
+| 2 | Où ça tourne               | Même VPS (nouveaux blocs Caddy)                                |
+| 3 | Backend / données          | **Instance Supabase self-host dédiée** (stack Docker n°2, ports 8100+) |
+| 4 | Déclencheur de déploiement | `workflow_dispatch` manuel (workflow `deploy-staging.yml`)      |
+| 5 | Accès                      | Basic auth Caddy (un couple identifiant / mot de passe partagé) |
 
-### Pourquoi une instance Supabase dédiée (décision 3)
+### Données du backend staging — copie de la prod
 
-Réutiliser la base prod exposerait des **données de santé réelles** à un
-environnement de test moins surveillé — incompatible RGPD art. 9. Une instance
-préprod dédiée part du `000_baseline_schema.sql` + un seed de données fictives.
-Plus lourd à mettre en place, mais c'est la seule option propre.
+Tant qu'il n'y a **aucun client réel**, la base prod ne contient que des
+données de test internes — donc **pas de donnée de santé de tiers**, RGPD
+art. 9 sans objet. La base staging est donc **initialisée par une copie de la
+prod** (`pg_dump` → `psql`, cf. §5 étape 3), pas par un seed fictif.
 
-> Alternative légère si l'instance dédiée est trop coûteuse à court terme :
-> garder la préprod **front-only**, branchée sur une base Supabase Cloud
-> gratuite (tier free) avec données fictives — pas de self-host à dupliquer.
+> ⚠️ **À revoir dès l'arrivée de vrais clients.** Copier la prod exposerait
+> alors des données de santé réelles à un environnement moins surveillé. Il
+> faudra basculer sur un **seed de données fictives** (à partir du baseline
+> `000_baseline_schema.sql`) et ne plus jamais copier la prod.
 
 ---
 
-## 4. Architecture cible recommandée
+## 4. Architecture cible
 
 ```
-staging.unilien.app   → Caddy → /var/www/unilien-staging   (build de la branche)
-api-staging.unilien.app → Caddy → localhost:8100            (Supabase préprod)
+staging.unilien.app      → Caddy (basic auth) → /var/www/unilien-staging
+api-staging.unilien.app  → Caddy              → localhost:8100  (Supabase staging)
 ```
 
-- **Même VPS**, nouveaux blocs Caddy ajoutés à `infra/caddy/Caddyfile`.
+- **Même VPS**, blocs Caddy ajoutés à `infra/caddy/Caddyfile` (déjà fait).
 - Build préprod = `npm run build` avec `VITE_*` pointant vers `api-staging`.
-- Basic auth Caddy sur `staging.unilien.app` (un seul couple identifiant /
-  mot de passe partagé avec les testeurs).
-- CSP du bloc staging = copie du bloc prod, en remplaçant `api.unilien.app`
-  par `api-staging.unilien.app`.
+- Basic auth Caddy sur `staging.unilien.app`, header `X-Robots-Tag: noindex`.
+- CSP du bloc staging = copie de la prod, `api.unilien.app` → `api-staging.unilien.app`.
 
 ---
 
-## 5. Étapes d'implémentation (checklist)
+## 5. Runbook de mise en place (à exécuter une fois)
 
-- [ ] **DNS OVH** : enregistrements `A` pour `staging` et `api-staging`
-- [ ] **Supabase préprod** : nouvelle stack Docker (`/opt/supabase-staging/`),
-      ports décalés (`8100`…), `db reset` sur le baseline + seed fictif
-- [ ] **Caddyfile** : ajouter les blocs `staging` (+ basic auth) et
-      `api-staging`, déployer (workflow scp + validate + reload habituel)
-- [ ] **GitHub** : environnement `env_unilien_staging` + secrets/variables
-      `VITE_*` pointant vers `api-staging`
-- [ ] **Workflow** : `deploy-staging.yml` — `workflow_dispatch` avec input
-      `branch`, build, rsync vers `/var/www/unilien-staging`
-- [ ] **Seed** : script de données fictives (comptes employer/employee/
-      caregiver de démo, aucune donnée de santé réelle)
-- [ ] **Doc** : procédure « déployer une branche en préprod » dans ce fichier
+Ordre impératif : DNS d'abord (propagation), puis backend, puis Caddy, puis
+GitHub, puis premier déploiement.
+
+### Étape 1 — DNS OVH
+
+Dans la zone DNS OVH de `unilien.app`, ajouter deux enregistrements `A`
+pointant vers l'IP du VPS :
+
+| Sous-domaine  | Type | Cible        |
+|---------------|------|--------------|
+| `staging`     | A    | `<IP du VPS>` |
+| `api-staging` | A    | `<IP du VPS>` |
+
+Attendre la propagation (`dig staging.unilien.app +short` renvoie l'IP).
+
+### Étape 2 — Stack Supabase staging
+
+Sur le VPS, créer une 2ᵉ stack Docker isolée de la prod :
+
+```bash
+# Copier l'arborescence Supabase self-host existante
+sudo cp -r /opt/supabase /opt/supabase-staging
+cd /opt/supabase-staging/docker
+```
+
+Éditer le `.env` de la stack staging (`nano .env`) :
+
+- **Isolation Docker** : `COMPOSE_PROJECT_NAME=supabase-staging`
+  (sinon les conteneurs entrent en collision avec la prod).
+- **Ports** : décaler tout ce qui est exposé sur l'hôte — au minimum
+  `KONG_HTTP_PORT=8100` (Studio/API). Les autres services communiquent par le
+  réseau Docker interne, pas besoin de port hôte.
+- **Secrets neufs** (ne JAMAIS réutiliser ceux de la prod) :
+  `POSTGRES_PASSWORD`, `JWT_SECRET`, `ANON_KEY`, `SERVICE_ROLE_KEY`
+  (les deux clés se dérivent du `JWT_SECRET` — générateur dans la doc Supabase
+  self-host), `SECRET_KEY_BASE`, `VAULT_ENC_KEY`, identifiants dashboard.
+- **URLs** :
+  `API_EXTERNAL_URL=https://api-staging.unilien.app`,
+  `SUPABASE_PUBLIC_URL=https://api-staging.unilien.app`,
+  `SITE_URL=https://staging.unilien.app`,
+  `ADDITIONAL_REDIRECT_URLS=https://staging.unilien.app`.
+
+Démarrer :
+
+```bash
+sudo docker compose up -d
+```
+
+### Étape 3 — Copier la base prod dans le staging
+
+```bash
+# Dump de la base prod (schéma + données)
+sudo docker exec supabase-db \
+  pg_dump -U postgres -d postgres --clean --if-exists \
+  > /tmp/prod-dump.sql
+
+# Restauration dans la base staging
+cat /tmp/prod-dump.sql | sudo docker exec -i supabase-staging-db \
+  psql -U postgres -d postgres
+
+rm /tmp/prod-dump.sql
+```
+
+> ⚠️ **pgsodium / données de santé chiffrées** : `employer_health_data` est
+> chiffré avec la clé pgsodium de la prod. Le staging ayant une `VAULT_ENC_KEY`
+> différente, le déchiffrement de ces lignes échouera. Sans client réel ce
+> n'est pas bloquant (aucune donnée santé exploitable). Si besoin de les lire
+> en préprod : copier aussi la clé racine pgsodium — à éviter.
+
+### Étape 4 — Basic auth Caddy
+
+Sur le VPS, générer le hash du mot de passe partagé :
+
+```bash
+caddy hash-password --plaintext 'LE_MOT_DE_PASSE_CHOISI'
+```
+
+Coller le hash bcrypt obtenu dans `infra/caddy/Caddyfile`, bloc
+`staging.unilien.app`, en remplacement de `REMPLACER_PAR_LE_HASH_BCRYPT`.
+Identifiant par défaut : `staging` (modifiable dans le même bloc).
+
+### Étape 5 — Déployer le Caddyfile
+
+Workflow manuel habituel (cf. déploiements CSP précédents) :
+
+```bash
+scp infra/caddy/Caddyfile <user>@<vps>:/tmp/Caddyfile
+ssh <user>@<vps> 'sudo caddy validate --config /tmp/Caddyfile --adapter caddyfile \
+  && sudo cp /tmp/Caddyfile /etc/caddy/Caddyfile \
+  && sudo systemctl reload caddy'
+```
+
+### Étape 6 — Environnement GitHub `env_unilien_staging`
+
+Dans **Settings > Environments**, créer l'environnement `env_unilien_staging`
+et y définir :
+
+| Nom                       | Type   | Valeur                             |
+|---------------------------|--------|------------------------------------|
+| `VITE_SUPABASE_URL`       | secret | `https://api-staging.unilien.app`  |
+| `VITE_SUPABASE_ANON_KEY`  | secret | clé `ANON_KEY` de la stack staging |
+
+Le workflow réutilise aussi `VPS_SSH_PRIVATE_KEY`, `VPS_HOST`, `VPS_USER`.
+S'ils sont définis au niveau **repo**, ils sont déjà visibles. S'ils sont
+scopés à l'environnement `env_unilien`, les **dupliquer** dans
+`env_unilien_staging`.
+
+### Étape 7 — Premier déploiement
+
+GitHub > **Actions** > **Deploy to Staging** > **Run workflow** > choisir la
+branche (ex : `fix/voice-classifier-prior-normalization`).
+
+Vérifier ensuite `https://staging.unilien.app` (le navigateur demande les
+identifiants basic auth).
 
 ---
 
-## 6. Point spécifique — classifier vocal sur préprod
+## 6. Procédure récurrente — déployer une branche en préprod
 
-Le bloc `[DEBUG TEMP]` de `useVoiceNavigation.ts` qui force le classifier à
-tourner à chaque essai est gardé par `import.meta.env.DEV`. **Un build préprod
-est un build de production → `import.meta.env.DEV` vaut `false`** : le bloc ne
-s'exécutera pas, et le classifier ne se déclenchera qu'en vrai secours (quand
-la transcription échoue).
+GitHub > **Actions** > **Deploy to Staging** > **Run workflow**, saisir le nom
+de la branche. Le workflow `deploy-staging.yml` build (sans tests — la préprod
+sert à tester des branches en cours) et rsync vers `/var/www/unilien-staging`,
+puis pousse les Edge Functions vers la stack staging.
 
-Pour qu'un testeur à voix typique (Marie) exerce réellement le classifier, il
-faut un déclencheur **non-DEV**. Au choix :
+**Re-synchroniser la base staging avec la prod** : ré-exécuter l'étape 3
+(écrase les données staging).
+
+---
+
+## 7. Point spécifique — classifier vocal sur préprod
+
+Le bloc `[DEBUG TEMP]` de `useVoiceNavigation.ts`, qui force le classifier
+acoustique à chaque essai, est gardé par `import.meta.env.DEV`. **Un build
+préprod est un build de production → `DEV` vaut `false`** : le bloc ne
+s'exécute pas, et le classifier ne se déclenche qu'en vrai secours (quand la
+transcription Whisper échoue).
+
+Un testeur à voix typique (Marie) verra donc sa transcription réussir souvent
+et **n'exercera quasiment jamais le classifier**. Pour qu'il soit réellement
+testé, il faut un déclencheur non-DEV — **non encore implémenté** (décision
+reportée) :
 
 - **Toggle UI (recommandé)** : case « Forcer le classifier acoustique » dans la
-  carte Diagnostic vocal (Paramètres > Accessibilité). Le testeur l'active
-  lui-même, le classement s'affiche à chaque essai.
-- **Flag build** : variable `VITE_VOICE_DEBUG` activée uniquement sur le build
-  préprod. Zéro UI, mais le testeur ne peut pas le couper.
+  carte Diagnostic vocal (Paramètres > Accessibilité).
+- **Flag build** : variable `VITE_VOICE_DEBUG` activée sur le build préprod.
 
-À trancher avant le premier déploiement préprod de la branche vocale.
+> En l'état, déployer la branche vocale en préprod permet de tester la
+> **navigation vocale globale**, pas spécifiquement le classifier de secours.
 
 ---
 
-## 7. Risques & garde-fous
+## 8. Risques & garde-fous
 
-- **RGPD** : aucune donnée de santé réelle en préprod — instance + seed dédiés.
-- **SEO / indexation** : `staging.unilien.app` doit renvoyer
-  `X-Robots-Tag: noindex` (header Caddy) pour ne pas être indexé.
-- **Confusion testeur** : bannière visuelle « PRÉPROD » sur l'environnement
-  (réutiliser le pattern de la demo banner du gap checklist).
-- **Coût VPS** : surveiller la RAM — une 2ᵉ stack Supabase Docker est lourde.
-  Si le VPS sature, basculer sur l'alternative front-only (§3).
+- **RGPD** : valable tant qu'il n'y a aucun client réel (cf. §3). Dès les
+  premiers clients → seed fictif obligatoire, ne plus copier la prod.
+- **SEO** : `staging.unilien.app` renvoie `X-Robots-Tag: noindex` (bloc Caddy).
+- **Confusion testeur** : `VITE_APP_NAME` vaut `Unilien (préprod)` sur le build
+  staging. Une bannière visuelle « PRÉPROD » reste un TODO (réutiliser le
+  pattern de la demo banner du gap checklist).
+- **RAM VPS** : une 2ᵉ stack Supabase Docker est lourde, mais le VPS-3 dispose
+  de 24 Go — marge confortable. Surveiller tout de même `docker stats`.

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -40,3 +40,48 @@ plausible.unilien.app {
     encode zstd gzip
     reverse_proxy localhost:8001
 }
+
+# =============================================================================
+# Préprod — environnement de test de branches non mergées (cf. PREPROD_SETUP.md)
+# =============================================================================
+# Isolé de la prod : build statique séparé (/var/www/unilien-staging), instance
+# Supabase dédiée (localhost:8100), accès protégé par basic auth, non indexé.
+
+staging.unilien.app {
+    encode zstd gzip
+    root * /var/www/unilien-staging
+    try_files {path} /index.html
+    file_server
+
+    # Accès restreint aux testeurs (un seul couple identifiant / mot de passe).
+    # Le hash se génère SUR LE VPS : caddy hash-password --plaintext 'MOT_DE_PASSE'
+    # puis on colle le hash bcrypt ci-dessous. Cf. PREPROD_SETUP.md §5.
+    basic_auth {
+        staging REMPLACER_PAR_LE_HASH_BCRYPT
+    }
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Frame-Options "DENY"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        Permissions-Policy "camera=(), microphone=(self), geolocation=()"
+        # Préprod jamais indexée par les moteurs de recherche.
+        X-Robots-Tag "noindex, nofollow"
+        # CSP identique à la prod, mais pointée vers le backend staging
+        # (api-staging) au lieu d'api.unilien.app. 'unsafe-eval' requis par
+        # onnxruntime-web (nav vocale Whisper) — cf. bloc prod ci-dessus.
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api-staging.unilien.app wss://api-staging.unilien.app https://huggingface.co https://*.huggingface.co https://*.hf.co; img-src 'self' data: blob: https://api-staging.unilien.app; font-src 'self'; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    }
+
+    @assets path /assets/*
+    header @assets Cache-Control "public, max-age=31536000, immutable"
+
+    @sw path /sw.js /workbox-*.js
+    header @sw Cache-Control "public, max-age=0, must-revalidate"
+}
+
+api-staging.unilien.app {
+    encode zstd gzip
+    reverse_proxy localhost:8100
+}


### PR DESCRIPTION
## Summary
Ajoute l'environnement de préproduction `staging.unilien.app` pour faire tester des branches non mergées (nav vocale, etc.) sans toucher à la prod.

L'infra VPS est **déjà en place et opérationnelle** (stack Supabase staging, DNS, Caddy, secrets GitHub) — cette PR ne contient que le code/config versionné.

### Changements
- **`infra/caddy/Caddyfile`** — blocs `staging.unilien.app` (basic auth, `X-Robots-Tag: noindex`, SPA, CSP vers api-staging) et `api-staging.unilien.app` (→ `localhost:8100`). Le hash bcrypt reste un placeholder en git, le vrai hash est uniquement sur le VPS.
- **`.github/workflows/deploy-staging.yml`** — workflow `workflow_dispatch` avec input `branch` : build (sans tests, la préprod sert à tester des branches en cours) + rsync vers `/var/www/unilien-staging` + Edge Functions. Environnement `env_unilien_staging`.
- **`docs/PREPROD_SETUP.md`** — décisions tranchées + runbook complet (DNS / stack Supabase staging / copie BDD / basic auth / GitHub).

### État de l'infra (hors git)
- Stack Supabase staging : 13 conteneurs `supabase-staging-*`, ports 8100/8543/5532/6643, isolée de la prod ✅
- BDD staging peuplée depuis la prod via `pg_dump` ✅
- DNS `staging` + `api-staging` → VPS, certificats Let's Encrypt OK ✅
- Caddy déployé, basic auth actif ✅
- `env_unilien_staging` créé avec ses 5 secrets ✅

## Test plan
- [ ] CI verte
- [ ] Une fois mergé : Actions > Deploy to Staging > Run workflow → frontend déployé sur `staging.unilien.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)