### PR TITLE
chore(infra): 3 basic auth accounts for staging

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -57,7 +57,9 @@ staging.unilien.app {
     # Le hash se génère SUR LE VPS : caddy hash-password --plaintext 'MOT_DE_PASSE'
     # puis on colle le hash bcrypt ci-dessous. Cf. PREPROD_SETUP.md §5.
     basic_auth {
-        staging REMPLACER_PAR_LE_HASH_BCRYPT
+        marie REMPLACER_PAR_LE_HASH_MARIE
+        fred REMPLACER_PAR_LE_HASH_FRED
+        zeph REMPLACER_PAR_LE_HASH_ZEPH
     }
 
     header {


### PR DESCRIPTION
## Summary
Remplace l'unique identifiant partagé du portail basic auth de `staging.unilien.app` par **un compte par testeur** : `marie`, `fred`, `zeph`.

Déjà appliqué et vérifié sur le VPS (les 3 comptes répondent `200`, l'ancien `staging` est désactivé).

### Changements
- **`infra/caddy/Caddyfile`** — bloc `basic_auth` du site staging : 1 → 3 comptes. Les hashes restent des placeholders en git ; les vrais hashes bcrypt sont uniquement dans le Caddyfile du VPS.

## Test plan
- [x] `caddy validate` OK, reload OK
- [x] `marie` / `fred` / `zeph` → 200 sur `staging.unilien.app`
- [x] Ancien compte `staging` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)