### PR TITLE
chore(voice): hide voice diagnostics card in production

### DIFF
--- a/src/components/voice/VoiceDiagnosticsCard.tsx
+++ b/src/components/voice/VoiceDiagnosticsCard.tsx
@@ -1,10 +1,11 @@
 import { Box, Button, Card, HStack, Stack, Text, VStack } from '@chakra-ui/react'
 import { useAccessibilityStore } from '@/stores/authStore'
 import { useVoiceDiagnosticsStore } from '@/stores/voiceDiagnosticsStore'
+import { isProdHost } from '@/lib/env'
 
 /**
- * Carte "Diagnostic vocal" — visible uniquement quand le contrôle vocal
- * est activé. Affiche :
+ * Carte "Diagnostic vocal" — masquée en production, visible en préprod et en
+ * dev quand le contrôle vocal est activé. Affiche :
  *  - les 10 dernières transcriptions Whisper qui n'ont pas matché une
  *    commande (variantes phonétiques manquantes) ;
  *  - les 5 derniers classements du classifier acoustique : pour chaque
@@ -21,7 +22,8 @@ export function VoiceDiagnosticsCard() {
   const classifications = useVoiceDiagnosticsStore((s) => s.classifications)
   const clear = useVoiceDiagnosticsStore((s) => s.clear)
 
-  if (!voiceEnabled) return null
+  // Outil de calibration : masqué en prod, gardé en préprod et en dev.
+  if (!voiceEnabled || isProdHost()) return null
 
   const hasData = entries.length > 0 || classifications.length > 0
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,18 @@
+/**
+ * Détection de l'environnement d'exécution, côté navigateur.
+ *
+ * Le build préprod (staging.unilien.app) est un build de production
+ * (`import.meta.env.PROD === true`), donc indistinguable de la prod via les
+ * flags Vite. On se base sur le hostname réel pour les distinguer.
+ */
+
+/** Domaines considérés comme la production. */
+const PROD_HOSTS = ['unilien.app', 'www.unilien.app']
+
+/**
+ * `true` uniquement sur le domaine de production.
+ * Préprod (`staging.unilien.app`) et dev (`localhost`) renvoient `false`.
+ */
+export function isProdHost(): boolean {
+  return typeof window !== 'undefined' && PROD_HOSTS.includes(window.location.hostname)
+}


### PR DESCRIPTION
## Summary
Masque le panneau **Diagnostic vocal** (Paramètres > Accessibilité) sur la production. C'est un outil de calibration du classifier — il n'a pas sa place pour les utilisateurs finaux, mais reste utile en préprod et en dev.

### Changements
- **`src/lib/env.ts`** (nouveau) — helper `isProdHost()`. Le build préprod étant un build de production, on distingue prod/préprod via le hostname réel (`unilien.app` vs `staging.unilien.app`).
- **`src/components/voice/VoiceDiagnosticsCard.tsx`** — la carte renvoie `null` sur la prod. Toujours visible en préprod (`staging.unilien.app`) et en dev (`localhost`).

## Test plan
- [x] `npm run typecheck` OK
- [x] `npm run lint` OK (warnings pré-existants uniquement)
- [x] `npm run test:run` — 2338 tests passés
- [ ] Vérifier en préprod que le panneau reste visible, et absent en prod après déploiement

🤖 Generated with [Claude Code](https://claude.com/claude-code)