### PR TITLE
refactor(banner): replace dev banner with Unilien Beta 1.0 label

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -193,7 +193,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
         zIndex={9999}
         transition="top 0.15s ease"
         _focusVisible={{
-          top: showBanner ? 'calc(80px + 16px)' : '16px',
+          top: showBanner ? 'calc(44px + 16px)' : '16px',
         }}
         css={{
           '@media (prefers-reduced-motion: reduce)': {
@@ -209,7 +209,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
         as="header"
         role="banner"
         position="fixed"
-        top={showBanner ? '80px' : 0}
+        top={showBanner ? '44px' : 0}
         left={0}
         right={0}
         h="60px"
@@ -507,7 +507,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
         aria-label="Navigation principale"
         position="fixed"
         left={0}
-        top={showBanner ? 'calc(60px + 80px)' : '60px'}
+        top={showBanner ? 'calc(60px + 44px)' : '60px'}
         bottom={0}
         w={{ base: isSidebarOpen ? '240px' : '0', md: '240px' }}
         bg="bg.surface"
@@ -652,7 +652,7 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
         <Box
           position="fixed"
           inset={0}
-          top={showBanner ? 'calc(60px + 80px)' : '60px'}
+          top={showBanner ? 'calc(60px + 44px)' : '60px'}
           bg="rgba(0,0,0,0.4)"
           zIndex={199}
           display={{ base: 'block', md: 'none' }}
@@ -667,9 +667,9 @@ export function DashboardLayout({ children, title = 'Tableau de bord', topbarRig
         id="main-content"
         direction="column"
         ml={{ base: 0, md: '240px' }}
-        mt={showBanner ? 'calc(60px + 80px)' : '60px'}
+        mt={showBanner ? 'calc(60px + 44px)' : '60px'}
         p={6}
-        h={showBanner ? 'calc(100vh - 60px - 80px)' : 'calc(100vh - 60px)'}
+        h={showBanner ? 'calc(100vh - 60px - 44px)' : 'calc(100vh - 60px)'}
         minH={0}
         overflow={fillHeight ? 'hidden' : 'auto'}
       >

--- a/src/components/ui/DevelopmentBanner.test.tsx
+++ b/src/components/ui/DevelopmentBanner.test.tsx
@@ -14,12 +14,7 @@ describe('DevelopmentBanner', () => {
   describe('Rendu initial', () => {
     it('affiche le bandeau par défaut', () => {
       renderWithProviders(<DevelopmentBanner />)
-      expect(screen.getByText(/application en cours de développement/i)).toBeInTheDocument()
-    })
-
-    it('affiche le lien de feedback', () => {
-      renderWithProviders(<DevelopmentBanner />)
-      expect(screen.getByText(/donnez votre avis/i)).toBeInTheDocument()
+      expect(screen.getByText(/beta 1\.0/i)).toBeInTheDocument()
     })
 
     it('affiche le bouton de fermeture', () => {
@@ -49,7 +44,7 @@ describe('DevelopmentBanner', () => {
 
       await user.click(screen.getByRole('button', { name: /fermer le bandeau/i }))
 
-      expect(screen.queryByText(/application en cours de développement/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/beta 1\.0/i)).not.toBeInTheDocument()
     })
 
     it('persiste le rejet dans localStorage après clic', async () => {

--- a/src/components/ui/DevelopmentBanner.tsx
+++ b/src/components/ui/DevelopmentBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Box, Flex, Text, Link, IconButton } from '@chakra-ui/react'
+import { Box, Flex, Text, IconButton } from '@chakra-ui/react'
 
 interface DevelopmentBannerProps {
   /** Clé unique pour le localStorage */
@@ -31,9 +31,7 @@ export function DevelopmentBanner({ storageKey = 'unilien_dev_banner_dismissed',
 
   return (
     <Box
-      bg="warm.subtle"
-      borderBottomWidth="1px"
-      borderColor="warm.200"
+      bg="gray.800"
       py={3}
       px={4}
       position="fixed"
@@ -44,46 +42,27 @@ export function DevelopmentBanner({ storageKey = 'unilien_dev_banner_dismissed',
     >
       <Flex
         align="center"
-        justify="space-between"
+        justify="center"
         maxW="container.xl"
         mx="auto"
         gap={3}
+        position="relative"
       >
-        <Flex align="center" gap={3} flex={1}>
-          <Text fontSize="xl" aria-hidden="true">
-            ⚠️
-          </Text>
-          <Box flex={1}>
-            <Text fontSize="sm" fontWeight="semibold" color="warm.700">
-              Application en cours de développement
-            </Text>
-            <Text fontSize="sm" color="warm.600">
-              Nous travaillons activement sur Unilien. Vos retours sont précieux !{' '}
-              <Link
-                href="https://airtable.com/apphPLBwuWxsAq75J/pag4GuwcKDs4nw1C6/form"
-                target="_blank"
-                rel="noopener noreferrer"
-                color="warm.500"
-                fontWeight="semibold"
-                textDecoration="underline"
-                _hover={{
-                  color: 'warm.700',
-                }}
-              >
-                Donnez votre avis ici
-              </Link>
-            </Text>
-          </Box>
-        </Flex>
+        <Text fontSize="sm" fontWeight="semibold" color="white">
+          Unilien <Text as="span" color="green.300">Beta 1.0</Text>
+        </Text>
         <IconButton
+          position="absolute"
+          right={0}
           aria-label="Fermer le bandeau"
           variant="ghost"
           size="sm"
           onClick={handleDismiss}
-          color="warm.600"
+          color="gray.300"
           borderRadius="10px"
           _hover={{
-            bg: 'warm.100',
+            bg: 'gray.700',
+            color: 'white',
           }}
         >
           ✕


### PR DESCRIPTION
## Summary
Refonte du bandeau d'avertissement : ancien message "Application en cours de développement" + lien Airtable → simple label "Unilien Beta 1.0".

### Changements
- Bandeau : fond `gray.800`, "Unilien" en blanc + "Beta 1.0" en `green.300`
- Suppression icône ⚠️, texte feedback et lien Airtable
- Label centré, croix de fermeture en absolute à droite
- `DashboardLayout` : offsets `80px → 44px` (5 refs) pour matcher la nouvelle hauteur du bandeau

## Test plan
- [x] `npm run test:run` — 2337 passed / 4 skipped
- [x] `npm run lint` — 0 errors
- [x] Vérif visuelle : header colle au bandeau, sidebar/main alignés, fermeture du bandeau OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)