### PR TITLE
chore(landing): remove GitHub link from footer support section

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1134,9 +1134,6 @@ export function HomePage() {
               <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
                 Accessibilité (DSFR)
               </Link>
-              <Link href="https://github.com/zephdev-92/Unilien" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
-                GitHub
-              </Link>
             </Stack>
           </Box>
         </Grid>


### PR DESCRIPTION
## Summary
Suppression du lien GitHub de la section Support du footer de la landing page.

### Changements
- `HomePage.tsx:1137-1139` : `<Link>` GitHub retiré

## Test plan
- [ ] Vérifier visuellement que la section Support n'affiche plus que Contact / Documentation / Accessibilité (DSFR)
- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` (2337 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)