### PR TITLE
fix(ci): use custom SSH port for VPS deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -72,6 +72,7 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
           VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_PORT || '52022' }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
@@ -79,22 +80,24 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           echo "Key fingerprint:"
           ssh-keygen -l -f ~/.ssh/deploy_key || (echo "INVALID KEY FORMAT" && exit 1)
-          ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p "$VPS_PORT" -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Deploy to VPS (staging)
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ vars.VPS_PORT || '52022' }}
         run: |
           rsync -avz --delete \
             --exclude='.DS_Store' \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            -e "ssh -p $VPS_PORT -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
             dist/ "$VPS_USER@$VPS_HOST:/var/www/unilien-staging/"
 
       - name: Deploy Edge Functions to VPS (staging)
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ vars.VPS_PORT || '52022' }}
         run: |
           # Sync Edge Functions vers la stack Supabase staging (preserve les
           # entrypoints runtime main/ et hello/).
@@ -103,11 +106,11 @@ jobs:
             --exclude='*.test.ts' \
             --exclude='main/' \
             --exclude='hello/' \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            -e "ssh -p $VPS_PORT -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
             supabase/functions/ "$VPS_USER@$VPS_HOST:/opt/supabase-staging/docker/volumes/functions/"
 
           # Redémarre le conteneur edge-runtime de la stack staging.
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "$VPS_USER@$VPS_HOST" \
+          ssh -p "$VPS_PORT" -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "$VPS_USER@$VPS_HOST" \
             "sudo -n docker compose --project-directory /opt/supabase-staging/docker restart functions"
 
       - name: Health check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
           VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_PORT || '52022' }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
@@ -72,22 +73,24 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           echo "Key fingerprint:"
           ssh-keygen -l -f ~/.ssh/deploy_key || (echo "INVALID KEY FORMAT" && exit 1)
-          ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p "$VPS_PORT" -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
       - name: Deploy to VPS
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ vars.VPS_PORT || '52022' }}
         run: |
           rsync -avz --delete \
             --exclude='.DS_Store' \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            -e "ssh -p $VPS_PORT -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
             dist/ "$VPS_USER@$VPS_HOST:/var/www/unilien/"
 
       - name: Deploy Edge Functions to VPS
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_PORT: ${{ vars.VPS_PORT || '52022' }}
         run: |
           # Sync Edge Functions (preserve main/ and hello/ — runtime entrypoints)
           rsync -avz --delete \
@@ -95,11 +98,11 @@ jobs:
             --exclude='*.test.ts' \
             --exclude='main/' \
             --exclude='hello/' \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            -e "ssh -p $VPS_PORT -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
             supabase/functions/ "$VPS_USER@$VPS_HOST:/opt/supabase/docker/volumes/functions/"
 
           # Restart edge-runtime container to pick up new code
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "$VPS_USER@$VPS_HOST" \
+          ssh -p "$VPS_PORT" -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no "$VPS_USER@$VPS_HOST" \
             "sudo -n docker compose --project-directory /opt/supabase/docker restart functions"
 
       - name: Health check


### PR DESCRIPTION
## Summary
Le port SSH du VPS a été migré de 22 → 52022 dans le cadre du hardening sécurité (cf. memory `vps-security-hardening`). Les 2 workflows `deploy.yml` et `deploy-staging.yml` ciblaient encore le port 22 → `ssh-keyscan` échoue (UFW drop 22) → `exit code 1` au step "Setup SSH".

### Fix
Ajout d'une variable `VPS_PORT` (lue depuis `vars.VPS_PORT` avec fallback `52022` si non définie) et propagation dans :
- `ssh-keyscan -p $VPS_PORT ...`
- `rsync -e "ssh -p $VPS_PORT ..."` (build dist + edge functions)
- `ssh -p $VPS_PORT ...` (restart container)

Modification appliquée à `deploy.yml` (prod) et `deploy-staging.yml` (staging).

### Changements
- `.github/workflows/deploy.yml` : `Setup SSH`, `Deploy to VPS`, `Deploy Edge Functions to VPS`
- `.github/workflows/deploy-staging.yml` : `Setup SSH`, `Deploy to VPS (staging)`, `Deploy Edge Functions to VPS (staging)`

## Test plan
- [x] YAML syntax validée (`yaml.safe_load`)
- [x] `npm run lint` (0 erreurs, 2 warnings préexistants)
- [ ] Une fois mergé, le workflow `Deploy to Production` doit passer le step "Setup SSH" et déployer
- [ ] Optionnel : définir une variable GitHub Actions `VPS_PORT=52022` dans l'environnement `env_unilien` pour rendre la config explicite (sinon le fallback inline marche)

## Suivi mémoire
Ajouter à `vps-security-hardening.md` : "Quand on change le port SSH, **toujours vérifier les workflows GitHub Actions**" (raté cette fois, j'ai dû fixer en follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)