### PR TITLE
chore(landing): remove dead Documentation and Accessibilité links from footer

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1128,12 +1128,6 @@ export function HomePage() {
               <Link asChild color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
                 <RouterLink to="/contact">Contact</RouterLink>
               </Link>
-              <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
-                Documentation
-              </Link>
-              <Link href="#" color="text.muted" fontSize="sm" _hover={{ color: 'text.default' }}>
-                Accessibilité (DSFR)
-              </Link>
             </Stack>
           </Box>
         </Grid>


### PR DESCRIPTION
## Summary
Suppression des 2 liens morts (`href="#"`) de la section Support du footer :
- Documentation
- Accessibilité (DSFR)

À ré-ajouter quand les pages correspondantes existeront (pour Documentation : pointer vers `/help` qui existe déjà ; pour Accessibilité : créer une déclaration RGAA — pas DSFR).

### Changements
- `HomePage.tsx:1131-1136` : 2 `<Link href="#">` retirés

## Test plan
- [x] Vérifier sur prod que la section Support n'affiche plus que Contact
- [x] `npm run lint` (0 erreurs)
- [x] `npm run test:run` (2337 passed / 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)