### PR TITLE
feat(analytics): instrument acquisition & activation Plausible events

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { supabase } from '@/lib/supabase/client'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserRole } from '@/types'
 import { logger } from '@/lib/logger'
+import { track } from '@/lib/analytics/track'
 import { createDefaultProfile } from '@/lib/mappers'
 import { getProfileById, createFallbackProfile } from '@/services/profileService'
 
@@ -242,6 +243,8 @@ export function useAuth() {
 
         // Le profil sera créé automatiquement par le trigger Supabase
         // lors de la confirmation de l'email
+
+        track('Signup', { role: data.role })
 
         return { success: true, user: authData.user }
       } catch (err) {

--- a/src/lib/analytics/track.test.ts
+++ b/src/lib/analytics/track.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { track } from './track'
+
+describe('track', () => {
+  beforeEach(() => {
+    // Réinitialise le stub Plausible entre les tests
+    delete (window as { plausible?: unknown }).plausible
+  })
+
+  it('appelle window.plausible avec le nom de l’event', () => {
+    const spy = vi.fn()
+    window.plausible = spy
+    track('Signup')
+    expect(spy).toHaveBeenCalledWith('Signup', undefined)
+  })
+
+  it('passe les props quand fournies', () => {
+    const spy = vi.fn()
+    window.plausible = spy
+    track('Signup', { role: 'employer' })
+    expect(spy).toHaveBeenCalledWith('Signup', { props: { role: 'employer' } })
+  })
+
+  it('empile l’event dans la queue si le script n’est pas chargé', () => {
+    expect(window.plausible).toBeUndefined()
+    track('CTA Signup Click', { location: 'hero' })
+    expect(window.plausible).toBeDefined()
+    expect(window.plausible?.q).toEqual([
+      ['CTA Signup Click', { props: { location: 'hero' } }],
+    ])
+  })
+})

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -1,0 +1,40 @@
+/**
+ * Helper de tracking d'events custom Plausible.
+ *
+ * Le script Plausible est injecté conditionnellement par `Analytics.tsx`
+ * (selon `VITE_PLAUSIBLE_*` + toggle Confidentialité de l'utilisateur).
+ * Tant qu'il n'est pas chargé, les events sont empilés dans `window.plausible.q`
+ * et envoyés au chargement du script — exactement comme le snippet officiel.
+ * Si l'utilisateur a désactivé les analytics, aucun script ne charge : les
+ * events restent en mémoire et ne sont jamais transmis.
+ *
+ * ⚠️ RGPD art. 9 : ne JAMAIS passer de PII ni de donnée de santé en `props`
+ * (email, nom, téléphone, handicap_type, pch_*…). Voir `docs/KPIS.md`.
+ */
+
+type PlausibleProps = Record<string, string | number | boolean>
+
+interface PlausibleFn {
+  (event: string, options?: { props?: PlausibleProps }): void
+  q?: unknown[]
+}
+
+declare global {
+  interface Window {
+    plausible?: PlausibleFn
+  }
+}
+
+export function track(event: string, props?: PlausibleProps): void {
+  if (typeof window === 'undefined') return
+
+  // Queue stub : empile les events tant que le script réel n'est pas chargé.
+  if (!window.plausible) {
+    const stub: PlausibleFn = (...args: unknown[]) => {
+      ;(stub.q = stub.q ?? []).push(args)
+    }
+    window.plausible = stub
+  }
+
+  window.plausible(event, props ? { props } : undefined)
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
+import { track } from '@/lib/analytics/track'
 import {
   Box,
   Container,
@@ -328,7 +329,7 @@ export function HomePage() {
               transform: 'translateY(0)',
             }}
           >
-            <RouterLink to="/inscription">Essai gratuit</RouterLink>
+            <RouterLink to="/inscription" onClick={() => track('CTA Signup Click', { location: 'nav' })}>Essai gratuit</RouterLink>
           </Button>
         </Flex>
       </Flex>
@@ -406,7 +407,7 @@ export function HomePage() {
                 _hover={{ bg: 'brand.600', boxShadow: 'md', transform: 'translateY(-1px)' }}
                 _active={{ transform: 'translateY(0)' }}
               >
-                <RouterLink to="/inscription">
+                <RouterLink to="/inscription" onClick={() => track('CTA Signup Click', { location: 'hero' })}>
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="18" height="18" aria-hidden="true" style={{ flexShrink: 0 }}>
                     <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" strokeLinecap="round" />
                   </svg>
@@ -975,7 +976,7 @@ export function HomePage() {
                 _active={{ transform: 'translateY(0)' }}
                 mb={4}
               >
-                <RouterLink to="/inscription">
+                <RouterLink to="/inscription" onClick={() => track('CTA Signup Click', { location: 'pricing' })}>
                   Commencer gratuitement
                 </RouterLink>
               </Button>
@@ -1053,7 +1054,7 @@ export function HomePage() {
           _hover={{ bg: 'accent.600', boxShadow: 'md', transform: 'translateY(-1px)' }}
           _active={{ transform: 'translateY(0)' }}
         >
-          <RouterLink to="/inscription">
+          <RouterLink to="/inscription" onClick={() => track('CTA Signup Click', { location: 'cta_banner' })}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="18" height="18" aria-hidden="true" style={{ flexShrink: 0 }}>
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
             </svg>

--- a/src/pages/OnboardingRolePage.tsx
+++ b/src/pages/OnboardingRolePage.tsx
@@ -15,6 +15,7 @@ import {
 import { AccessibleButton, AccessibleInput } from '@/components/ui'
 import { supabase } from '@/lib/supabase/client'
 import { logger } from '@/lib/logger'
+import { track } from '@/lib/analytics/track'
 import { sanitizeText } from '@/lib/sanitize'
 import { useAuth } from '@/hooks/useAuth'
 import { consumePendingRole } from '@/lib/auth/pendingRole'
@@ -137,6 +138,8 @@ export default function OnboardingRolePage() {
       }
 
       if (rpcError) throw rpcError
+
+      track('Onboarding Completed', { role: selectedRole })
 
       // Recharger pour que useAuth récupère le profil à jour
       window.location.href = '/tableau-de-bord'

--- a/src/services/shiftService.ts
+++ b/src/services/shiftService.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/lib/supabase/client'
 import { resolveAvatarUrl } from '@/lib/supabase/avatars'
 import { logger } from '@/lib/logger'
 import { sanitizeText } from '@/lib/sanitize'
+import { track } from '@/lib/analytics/track'
 import type { Shift, ShiftType, GuardSegment, UserRole } from '@/types'
 import type { ShiftDbRow } from '@/types/database'
 import {
@@ -184,6 +185,8 @@ export async function createShift(
     logger.error('Erreur création shift:', error)
     throw new Error(error.message)
   }
+
+  track('Shift Created')
 
   // Notifier l'auxiliaire de la nouvelle intervention
   try {


### PR DESCRIPTION
## Summary
Instrumente les 4 events Plausible définis dans `docs/KPIS.md` (étages Acquisition & Activation). Ajoute un helper `track()` central et le câble aux points clés du parcours.

### Changements
- `src/lib/analytics/track.ts` — helper `track()` + queue stub (events empilés tant que le script Plausible n'est pas chargé) + test unitaire
- `CTA Signup Click` — 4 CTA de la landing (`HomePage.tsx`), prop `location` : `nav` / `hero` / `pricing` / `cta_banner`
- `Signup` — après création de compte (`useAuth.ts`), prop `role`
- `Onboarding Completed` — après RPC `complete_onboarding` OK (`OnboardingRolePage.tsx`), prop `role`
- `Shift Created` — après insert réussi (`shiftService.ts`)

### RGPD
Aucune PII ni donnée de santé en propriété d'event (art. 9) — seules des props non sensibles (`role`, `location`).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (0 erreur)
- [x] `npm run test:run` (2340 passed / 4 skipped, +3 helper)
- [ ] Vérifier la remontée des Goals dans le dashboard Plausible une fois mergé/déployé
- [ ] Créer les 4 Goals correspondants côté Plausible (Settings > Goals > Custom event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)