### PR TITLE
chore(content): update legal dates to June 2026 and fix bento copy

### DIFF
--- a/src/pages/LegalPage.tsx
+++ b/src/pages/LegalPage.tsx
@@ -29,7 +29,7 @@ export default function LegalPage() {
             Mentions légales
           </Text>
           <Text fontSize="sm" color="text.inactive" mt={1}>
-            Dernière mise à jour : mars 2026
+            Dernière mise à jour : juin 2026
           </Text>
         </Container>
       </Box>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -29,7 +29,7 @@ export default function PrivacyPage() {
             Politique de confidentialité
           </Text>
           <Text fontSize="sm" color="text.inactive" mt={1}>
-            Dernière mise à jour : avril 2026 — brouillon, projet en développement
+            Dernière mise à jour : juin 2026 — brouillon, projet en développement
           </Text>
         </Container>
       </Box>

--- a/src/pages/landing/LandingBento.tsx
+++ b/src/pages/landing/LandingBento.tsx
@@ -51,7 +51,7 @@ export function LandingBento() {
           <div className="cell span-2">
             <div className="bignum" style={{ color: 'var(--slate)' }}>+40%</div>
             <h3 style={{ fontSize: '17px' }}>de temps retrouvé</h3>
-            <p>dès le premier mois, les tâches administratives se font toutes seules. Vos soirées vous reviennent.</p>
+            <p>Dès le premier mois, les tâches administratives se font toutes seules. Vos soirées vous reviennent.</p>
           </div>
 
           <div className="cell span-2">


### PR DESCRIPTION
## Summary
Petits ajustements de contenu (stacked sur `feat/landing-v4`).

### Changements
- `LegalPage` : « Dernière mise à jour » mars 2026 → **juin 2026**
- `PrivacyPage` : « Dernière mise à jour » avril 2026 → **juin 2026**
- `LandingBento` : capitalisation du début de phrase (« dès » → « Dès »)

> ⚠️ PR **stacked** : base = `feat/landing-v4`. À merger après la PR landing.

## Test plan
- [x] `npm run lint` OK (0 erreur)
- [x] `npm run test:run` OK (2333 passed / 4 skipped)
- [x] Vérifier les dates sur /mentions-legales et /confidentialite

🤖 Generated with [Claude Code](https://claude.com/claude-code)