### PR TITLE
fix(landing-nav): SPA navigation + mobile burger menu

### DIFF
--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '@/test/helpers'
 import { HomePage } from './HomePage'
 
@@ -21,8 +22,24 @@ describe('HomePage', () => {
 
     it('affiche le lien de connexion et le bouton essai gratuit', () => {
       renderWithProviders(<HomePage />)
-      expect(screen.getByRole('link', { name: /se connecter/i })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: /^essai gratuit$/i })).toBeInTheDocument()
+      // Liens dupliqués entre la nav desktop et le menu mobile (panneau inert tant qu'il est fermé)
+      expect(screen.getAllByRole('link', { name: /se connecter/i }).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByRole('link', { name: /^essai gratuit$/i }).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('ouvre et ferme le menu mobile via le bouton burger', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<HomePage />)
+
+      const burger = screen.getByRole('button', { name: /ouvrir le menu/i })
+      expect(burger).toHaveAttribute('aria-expanded', 'false')
+
+      await user.click(burger)
+      const burgerOpen = screen.getByRole('button', { name: /fermer le menu/i })
+      expect(burgerOpen).toHaveAttribute('aria-expanded', 'true')
+
+      await user.click(burgerOpen)
+      expect(screen.getByRole('button', { name: /ouvrir le menu/i })).toHaveAttribute('aria-expanded', 'false')
     })
   })
 

--- a/src/pages/landing/LandingCta.tsx
+++ b/src/pages/landing/LandingCta.tsx
@@ -1,8 +1,41 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 import { track } from '@/lib/analytics/track'
 
 interface CtaAction {
   label: string
   href: string
+}
+
+/**
+ * Route interne (commence par "/") → navigation SPA via <Link>.
+ * Ancre (#…) ou lien externe → <a> classique.
+ */
+function CtaLink({
+  href,
+  className,
+  style,
+  onClick,
+  children,
+}: {
+  href: string
+  className: string
+  style?: React.CSSProperties
+  onClick?: () => void
+  children: ReactNode
+}) {
+  if (href.startsWith('/')) {
+    return (
+      <Link to={href} className={className} style={style} onClick={onClick}>
+        {children}
+      </Link>
+    )
+  }
+  return (
+    <a href={href} className={className} style={style} onClick={onClick}>
+      {children}
+    </a>
+  )
 }
 
 interface LandingCtaProps {
@@ -27,14 +60,14 @@ export function LandingCta({ wide, title, text, primary, secondary, sign, trackL
           <h2>{title}</h2>
           <p>{text}</p>
           <div className="actions">
-            <a
+            <CtaLink
               href={primary.href}
               className="btn green lg"
               onClick={trackLocation ? () => track('CTA Signup Click', { location: trackLocation }) : undefined}
             >
               {primary.label}
-            </a>
-            <a href={secondary.href} className="btn ghost lg" style={ghostStyle}>{secondary.label}</a>
+            </CtaLink>
+            <CtaLink href={secondary.href} className="btn ghost lg" style={ghostStyle}>{secondary.label}</CtaLink>
           </div>
           {sign && <div className="sign">{sign}</div>}
         </div>

--- a/src/pages/landing/LandingFooter.tsx
+++ b/src/pages/landing/LandingFooter.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { ASSET } from './constants'
 
 export function LandingFooter() {
@@ -23,16 +24,16 @@ export function LandingFooter() {
           <div>
             <h5>Légal</h5>
             <ul>
-              <li><a href="/mentions-legales">Mentions légales</a></li>
-              <li><a href="/politique-confidentialite">Confidentialité</a></li>
-              <li><a href="/conditions-utilisation">CGU</a></li>
-              <li><a href="/politique-confidentialite">RGPD</a></li>
+              <li><Link to="/mentions-legales">Mentions légales</Link></li>
+              <li><Link to="/politique-confidentialite">Confidentialité</Link></li>
+              <li><Link to="/conditions-utilisation">CGU</Link></li>
+              <li><Link to="/politique-confidentialite">RGPD</Link></li>
             </ul>
           </div>
           <div>
             <h5>Support</h5>
             <ul>
-              <li><a href="/contact">Contact</a></li>
+              <li><Link to="/contact">Contact</Link></li>
             </ul>
           </div>
         </div>

--- a/src/pages/landing/LandingHero.tsx
+++ b/src/pages/landing/LandingHero.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { track } from '@/lib/analytics/track'
 import { ASSET } from './constants'
 import { Check, Clock, Search, Bell, Grid, Calendar, Users, Chat, Book, Shield, FileDoc, BarChart } from './icons'
@@ -17,13 +18,13 @@ export function LandingHero() {
           Un outil pensé avec et pour les personnes en situation de handicap et leurs proches.
         </p>
         <div className="hero-actions">
-          <a
-            href="/inscription"
+          <Link
+            to="/inscription"
             className="btn lg"
             onClick={() => track('CTA Signup Click', { location: 'hero' })}
           >
             Essayer gratuitement
-          </a>
+          </Link>
           <a href="#produit" className="btn ghost lg">Découvrir les fonctionnalités</a>
         </div>
         <div className="hero-fineprint">

--- a/src/pages/landing/LandingNav.tsx
+++ b/src/pages/landing/LandingNav.tsx
@@ -1,29 +1,71 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { track } from '@/lib/analytics/track'
 import { ASSET } from './constants'
+import { Menu, Close } from './icons'
+
+const NAV_LINKS = [
+  { href: '#produit', label: 'Produit' },
+  { href: '#copilote', label: 'Le copilote' },
+  { href: '#pour-qui', label: 'Pour qui' },
+  { href: '#tarifs', label: 'Tarifs' },
+  { href: '#faq', label: 'FAQ' },
+]
 
 export function LandingNav() {
+  const [open, setOpen] = useState(false)
+
   return (
     <nav className="top">
       <div className="container-wide row">
-        <a className="brand" href="/">
+        <Link className="brand" to="/" onClick={() => setOpen(false)}>
           <img src={`${ASSET}/logo-unilien.svg`} alt="Unilien" />
-        </a>
+        </Link>
         <div className="nav-links">
-          <a href="#produit">Produit</a>
-          <a href="#copilote">Le copilote</a>
-          <a href="#pour-qui">Pour qui</a>
-          <a href="#tarifs">Tarifs</a>
-          <a href="#faq">FAQ</a>
+          {NAV_LINKS.map((l) => (
+            <a key={l.href} href={l.href}>{l.label}</a>
+          ))}
         </div>
         <div className="nav-actions">
-          <a href="/connexion" className="btn ghost sm">Se connecter</a>
-          <a
-            href="/inscription"
+          <Link to="/connexion" className="btn ghost sm">Se connecter</Link>
+          <Link
+            to="/inscription"
             className="btn green sm"
             onClick={() => track('CTA Signup Click', { location: 'nav' })}
           >
             Essai gratuit
-          </a>
+          </Link>
+          <button
+            type="button"
+            className="nav-burger"
+            aria-label={open ? 'Fermer le menu' : 'Ouvrir le menu'}
+            aria-expanded={open}
+            aria-controls="landing-mobile-menu"
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? <Close /> : <Menu />}
+          </button>
+        </div>
+      </div>
+
+      <div id="landing-mobile-menu" className="mobile-menu" data-open={open} inert={!open}>
+        <div className="container-wide">
+          {NAV_LINKS.map((l) => (
+            <a key={l.href} href={l.href} onClick={() => setOpen(false)}>{l.label}</a>
+          ))}
+          <Link to="/connexion" className="btn ghost" onClick={() => setOpen(false)}>
+            Se connecter
+          </Link>
+          <Link
+            to="/inscription"
+            className="btn green"
+            onClick={() => {
+              track('CTA Signup Click', { location: 'nav_mobile' })
+              setOpen(false)
+            }}
+          >
+            Essai gratuit
+          </Link>
         </div>
       </div>
     </nav>

--- a/src/pages/landing/LandingPricing.tsx
+++ b/src/pages/landing/LandingPricing.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { track } from '@/lib/analytics/track'
 import { Check, Shield } from './icons'
 
@@ -34,13 +35,13 @@ export function LandingPricing() {
               <li><Check size={19} sw={2.4} /> Des réponses sous 24h <span style={noteStyle}>(* hors jours fériés et week-ends)</span></li>
             </ul>
             <div className="price-cta">
-              <a
-                href="/inscription"
+              <Link
+                to="/inscription"
                 className="btn green lg"
                 onClick={() => track('CTA Signup Click', { location: 'pricing' })}
               >
                 Commencer gratuitement
-              </a>
+              </Link>
             </div>
           </div>
 

--- a/src/pages/landing/icons.tsx
+++ b/src/pages/landing/icons.tsx
@@ -141,3 +141,22 @@ export function ListDoc({ size = 22, sw = 1.9 }: { size?: number; sw?: number })
     </Svg>
   )
 }
+
+export function Menu({ size = 24, sw = 2 }: { size?: number; sw?: number }) {
+  return (
+    <Svg size={size} sw={sw}>
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </Svg>
+  )
+}
+
+export function Close({ size = 24, sw = 2 }: { size?: number; sw?: number }) {
+  return (
+    <Svg size={size} sw={sw}>
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </Svg>
+  )
+}

--- a/src/pages/landing/landing.css
+++ b/src/pages/landing/landing.css
@@ -94,7 +94,65 @@ html:has(.landing-v4) { scroll-behavior: smooth; }
 .landing-v4 .nav-links a:hover { color: var(--ink); background: var(--bg-soft); }
 @media (max-width: 960px) { .landing-v4 .nav-links { display: none; } }
 .landing-v4 .nav-actions { display: flex; gap: 10px; align-items: center; }
-@media (max-width: 540px) { .landing-v4 .nav-actions .btn.ghost { display: none; } }
+/* ≤ 960px : seul le burger reste dans la barre, les CTA passent dans le panneau */
+@media (max-width: 960px) { .landing-v4 .nav-actions .btn { display: none; } }
+
+/* Burger (mobile ≤ 960px) */
+.landing-v4 .nav-burger {
+  display: none;
+  align-items: center; justify-content: center;
+  width: 42px; height: 42px;
+  border: 1px solid var(--rule-2);
+  border-radius: 12px;
+  background: transparent; color: var(--ink);
+  cursor: pointer;
+  transition: background .15s ease, border-color .15s ease;
+}
+.landing-v4 .nav-burger:hover { background: var(--bg-soft); }
+
+/* Panneau déroulant mobile : replié par défaut, animé via grid-rows */
+.landing-v4 .mobile-menu { display: none; }
+@media (max-width: 960px) {
+  .landing-v4 .nav-burger { display: inline-flex; }
+  .landing-v4 .mobile-menu {
+    display: grid;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    border-bottom: 1px solid transparent;
+    background: color-mix(in srgb, var(--bg) 92%, transparent);
+    backdrop-filter: blur(18px) saturate(1.4);
+    transition: grid-template-rows .28s cubic-bezier(.2,.7,.3,1), border-color .28s ease;
+  }
+  .landing-v4 .mobile-menu[data-open="true"] {
+    grid-template-rows: 1fr;
+    border-bottom-color: var(--rule);
+  }
+  .landing-v4 .mobile-menu > .container-wide {
+    /* overflow:hidden ramène le minimum automatique de l'élément de grille à 0,
+       sans quoi la piste 0fr ne se réduit pas et le panneau « dépasse » fermé */
+    overflow: hidden;
+    min-height: 0;
+    /* l'item hérite de `margin: 0 auto` (.container-wide) qui, en contexte grid,
+       le rétrécit au contenu et le centre → forcer la pleine largeur */
+    width: 100%;
+    margin-inline: 0;
+    display: flex; flex-direction: column; gap: 6px;
+    /* padding nul fermé (sinon il reste visible), appliqué à l'ouverture */
+    padding-block: 0;
+    transition: padding-block .28s cubic-bezier(.2,.7,.3,1);
+  }
+  .landing-v4 .mobile-menu[data-open="true"] > .container-wide {
+    padding-block: 14px 20px;
+  }
+  .landing-v4 .mobile-menu a:not(.btn) {
+    text-decoration: none; color: var(--ink-soft);
+    font-size: 16px; font-weight: 500;
+    padding: 12px 8px; border-radius: 12px;
+    transition: background .15s ease, color .15s ease;
+  }
+  .landing-v4 .mobile-menu a:not(.btn):hover { background: var(--bg-soft); color: var(--ink); }
+  .landing-v4 .mobile-menu .btn { width: 100%; margin-top: 4px; }
+}
 
 /* ---------- HERO ---------- */
 .landing-v4 .hero {


### PR DESCRIPTION
## Summary
Deux corrections sur la navigation de la landing page (`/`).

### Changements
- **Liens internes en SPA** : logo, « Se connecter », « Essai gratuit », liens légaux et Contact passés en `<Link>` react-router → plus de rechargement complet de page ; le beacon Plausible des CTA n'est plus avorté par un full reload.
- `LandingCta` : helper `CtaLink` (rend `<Link>` pour les routes `/…`, `<a>` pour les ancres `#…`).
- **Menu burger mobile (≤ 960px)** : les liens de nav étaient masqués sans alternative. Ajout d'un burger ; au breakpoint mobile la barre ne garde que le burger (CTA déplacés dans le panneau, pas de doublon). Panneau déroulant animé, `inert` quand fermé (a11y : non focusable / non lu). CTA mobile taggé `location: 'nav_mobile'`.
- Icônes `Menu` / `Close`, tests CTA en `getAllByRole`, nouveau test toggle burger.

### Détails CSS (panneau mobile)
- Repli à 0px strict : `overflow:hidden` sur l'item de grille + `padding-block` nul fermé (piège des pistes `grid-template-rows: 0fr`).
- Pleine largeur : `width:100%; margin-inline:0` pour neutraliser le `margin:0 auto` hérité qui rétrécissait l'item en contexte grid.

## Test plan
- [x] lint + typecheck + build + 2334 tests OK
- [x] Vérif navigateur 390 / 860 / 1280px (Playwright)
- [ ] Mobile (<960px) : burger ouvre/ferme, liens scrollent vers les sections, fermeture au clic
- [ ] Desktop : nav inchangée, pas de burger
- [ ] Clic connexion/inscription/légal/contact = pas de rechargement complet

🤖 Generated with [Claude Code](https://claude.com/claude-code)