### PR TITLE
chore(pch): update PCH tariffs to 2026-06-01 CNSA rates

### DIFF
--- a/src/lib/pch/pchTariffs.test.ts
+++ b/src/lib/pch/pchTariffs.test.ts
@@ -13,24 +13,24 @@ describe('pchTariffs', () => {
       expect(Object.keys(PCH_TARIFFS_2026)).toHaveLength(5)
     })
 
-    it('emploiDirect = 19,34 €/h (tarif 2026)', () => {
-      expect(PCH_TARIFFS_2026.emploiDirect).toBe(19.34)
+    it('emploiDirect = 19,92 €/h (tarif au 01/06/2026)', () => {
+      expect(PCH_TARIFFS_2026.emploiDirect).toBe(19.92)
     })
 
-    it('mandataire = 21,27 €/h', () => {
-      expect(PCH_TARIFFS_2026.mandataire).toBe(21.27)
+    it('mandataire = 21,91 €/h', () => {
+      expect(PCH_TARIFFS_2026.mandataire).toBe(21.91)
     })
 
     it('prestataire = 25,00 €/h', () => {
       expect(PCH_TARIFFS_2026.prestataire).toBe(25.00)
     })
 
-    it('aidantFamilial = 4,78 €/h', () => {
-      expect(PCH_TARIFFS_2026.aidantFamilial).toBe(4.78)
+    it('aidantFamilial = 4,93 €/h', () => {
+      expect(PCH_TARIFFS_2026.aidantFamilial).toBe(4.93)
     })
 
-    it('aidantFamilialCessation = 7,16 €/h', () => {
-      expect(PCH_TARIFFS_2026.aidantFamilialCessation).toBe(7.16)
+    it('aidantFamilialCessation = 7,39 €/h', () => {
+      expect(PCH_TARIFFS_2026.aidantFamilialCessation).toBe(7.39)
     })
   })
 
@@ -50,19 +50,19 @@ describe('pchTariffs', () => {
     })
 
     it('les labels incluent le tarif horaire', () => {
-      expect(PCH_TYPE_LABELS.emploiDirect).toContain('19,34')
-      expect(PCH_TYPE_LABELS.mandataire).toContain('21,27')
+      expect(PCH_TYPE_LABELS.emploiDirect).toContain('19,92')
+      expect(PCH_TYPE_LABELS.mandataire).toContain('21,91')
       expect(PCH_TYPE_LABELS.prestataire).toContain('25,00')
     })
   })
 
   describe('getPchElementRate', () => {
     it('retourne le tarif correct pour emploiDirect', () => {
-      expect(getPchElementRate('emploiDirect')).toBe(19.34)
+      expect(getPchElementRate('emploiDirect')).toBe(19.92)
     })
 
     it('retourne le tarif correct pour mandataire', () => {
-      expect(getPchElementRate('mandataire')).toBe(21.27)
+      expect(getPchElementRate('mandataire')).toBe(21.91)
     })
 
     it('retourne le tarif correct pour prestataire', () => {
@@ -70,23 +70,23 @@ describe('pchTariffs', () => {
     })
 
     it('retourne le tarif correct pour aidantFamilial', () => {
-      expect(getPchElementRate('aidantFamilial')).toBe(4.78)
+      expect(getPchElementRate('aidantFamilial')).toBe(4.93)
     })
 
     it('retourne le tarif correct pour aidantFamilialCessation', () => {
-      expect(getPchElementRate('aidantFamilialCessation')).toBe(7.16)
+      expect(getPchElementRate('aidantFamilialCessation')).toBe(7.39)
     })
   })
 
   describe('calcEnveloppePch', () => {
     it('calcule correctement l\'enveloppe pour emploiDirect (60h)', () => {
-      // 60h × 19,34 = 1160,40
-      expect(calcEnveloppePch(60, 'emploiDirect')).toBeCloseTo(1160.40, 2)
+      // 60h × 19,92 = 1195,20
+      expect(calcEnveloppePch(60, 'emploiDirect')).toBeCloseTo(1195.20, 2)
     })
 
     it('calcule correctement l\'enveloppe pour mandataire (40h)', () => {
-      // 40h × 21,27 = 850,80
-      expect(calcEnveloppePch(40, 'mandataire')).toBeCloseTo(850.80, 2)
+      // 40h × 21,91 = 876,40
+      expect(calcEnveloppePch(40, 'mandataire')).toBeCloseTo(876.40, 2)
     })
 
     it('retourne 0 pour 0 heures', () => {
@@ -94,8 +94,8 @@ describe('pchTariffs', () => {
     })
 
     it('calcule l\'enveloppe pour aidantFamilial (100h)', () => {
-      // 100h × 4,78 = 478
-      expect(calcEnveloppePch(100, 'aidantFamilial')).toBeCloseTo(478, 2)
+      // 100h × 4,93 = 493
+      expect(calcEnveloppePch(100, 'aidantFamilial')).toBeCloseTo(493, 2)
     })
   })
 })

--- a/src/lib/pch/pchTariffs.ts
+++ b/src/lib/pch/pchTariffs.ts
@@ -1,6 +1,8 @@
 /**
  * Tarifs PCH (Prestation de Compensation du Handicap)
- * Référence : Art. L245-12 CASF — tarifs en vigueur au 01/01/2026
+ * Référence : Art. L245-12 CASF — tarifs en vigueur au 01/06/2026
+ * Source : CNSA, « Tarifs PCH au 1er juin 2026 » (relèvement SMIC + arrêté du 4 mai 2026,
+ * extension de l'avenant n°10 du 5 février 2026 à la convention IDCC 3239)
  * Indexés sur IDCC 3239 + SMIC
  */
 
@@ -11,22 +13,22 @@ export type PchType =
   | 'aidantFamilial'
   | 'aidantFamilialCessation'
 
-/** Tarifs horaires PCH Élément 1 au 01/01/2026 (€/h) */
+/** Tarifs horaires PCH Élément 1 au 01/06/2026 (€/h) */
 export const PCH_TARIFFS_2026: Record<PchType, number> = {
-  emploiDirect:            19.34,
-  mandataire:              21.27,
+  emploiDirect:            19.92,
+  mandataire:              21.91,
   prestataire:             25.00,
-  aidantFamilial:           4.78,
-  aidantFamilialCessation:  7.16,
+  aidantFamilial:           4.93,
+  aidantFamilialCessation:  7.39,
 }
 
 /** Labels affichés dans l'interface */
 export const PCH_TYPE_LABELS: Record<PchType, string> = {
-  emploiDirect:            'Emploi direct — 19,34 €/h',
-  mandataire:              'Mandataire — 21,27 €/h',
+  emploiDirect:            'Emploi direct — 19,92 €/h',
+  mandataire:              'Mandataire — 21,91 €/h',
   prestataire:             'Prestataire — 25,00 €/h',
-  aidantFamilial:          'Aidant familial — 4,78 €/h',
-  aidantFamilialCessation: 'Aidant familial (cessation activité) — 7,16 €/h',
+  aidantFamilial:          'Aidant familial — 4,93 €/h',
+  aidantFamilialCessation: 'Aidant familial (cessation activité) — 7,39 €/h',
 }
 
 /** Retourne le tarif horaire PCH pour un type donné */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,10 +154,10 @@ export interface TimeSlot {
 export type ContractCategory = 'employment' | 'caregiver_pch'
 export type CaregiverContractStatus = 'active' | 'full_time' | 'voluntary'
 
-// Taux PCH CNSA 2026
+// Taux PCH CNSA — au 01/06/2026
 export const PCH_RATES = {
-  active: 4.78,     // Aidant maintenant une activité pro (50% SMIC net)
-  full_time: 7.16,  // Aidant ayant cessé son activité (75% SMIC net)
+  active: 4.93,     // Aidant maintenant une activité pro (50% SMIC net)
+  full_time: 7.39,  // Aidant ayant cessé son activité (75% SMIC net)
 } as const
 
 // Contrat


### PR DESCRIPTION
## Summary
Mise à jour des tarifs horaires PCH (Élément 1 — aide humaine) selon le barème CNSA au 1er juin 2026 (relèvement du SMIC + extension de l'avenant n°10 à l'IDCC 3239).

### Changements
- Emploi direct : 19,34 → **19,92 €/h**
- Mandataire : 21,27 → **21,91 €/h**
- Prestataire : 25,00 €/h (inchangé)
- Aidant familial : 4,78 → **4,93 €/h**
- Aidant familial (cessation activité) : 7,16 → **7,39 €/h**
- `PCH_TARIFFS_2026`, labels et `PCH_RATES` mis à jour + commentaire de référence (date + source CNSA)
- Tests `pchTariffs.test.ts` alignés (assertions + calculs d'enveloppe)

## Test plan
- [x] `npm run lint` (0 erreur)
- [x] `npm run test:run` — 2334 passed / 4 skipped
- [ ] Vérifier l'affichage des tarifs dans NewCaregiverContractModal / EditCaregiverModal

🤖 Generated with [Claude Code](https://claude.com/claude-code)