### PR TITLE
refactor(pch): derive PCH_RATES from PCH_TARIFFS_2026

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 // Types de base pour Unilien
 
-import type { PchType } from '@/lib/pch/pchTariffs'
+import { PCH_TARIFFS_2026, type PchType } from '@/lib/pch/pchTariffs'
 export type { PchType }
 
 // Rôles utilisateur
@@ -154,10 +154,12 @@ export interface TimeSlot {
 export type ContractCategory = 'employment' | 'caregiver_pch'
 export type CaregiverContractStatus = 'active' | 'full_time' | 'voluntary'
 
-// Taux PCH CNSA — au 01/06/2026
+// Taux PCH CNSA — dérivés de PCH_TARIFFS_2026 (source unique des tarifs)
+// active = aidant familial dédommagé (50% SMIC net)
+// full_time = aidant ayant cessé son activité (75% SMIC net)
 export const PCH_RATES = {
-  active: 4.93,     // Aidant maintenant une activité pro (50% SMIC net)
-  full_time: 7.39,  // Aidant ayant cessé son activité (75% SMIC net)
+  active: PCH_TARIFFS_2026.aidantFamilial,
+  full_time: PCH_TARIFFS_2026.aidantFamilialCessation,
 } as const
 
 // Contrat


### PR DESCRIPTION
## Summary
Suite à la review de la mise à jour des tarifs PCH (#422) : suppression de la double source de vérité pour les tarifs aidant familial.

`PCH_RATES` (dans `types/index.ts`) redéfinissait en dur les mêmes valeurs légales que `PCH_TARIFFS_2026` (dans `lib/pch/pchTariffs.ts`) — il fallait éditer les deux fichiers en parallèle à chaque révision de barème, avec un risque de divergence silencieuse.

### Changements
- `PCH_RATES.active` → `PCH_TARIFFS_2026.aidantFamilial` (50% SMIC net)
- `PCH_RATES.full_time` → `PCH_TARIFFS_2026.aidantFamilialCessation` (75% SMIC net)
- `PCH_TARIFFS_2026` devient l'unique source des tarifs ; aucune valeur dupliquée
- Consommateurs inchangés (`NewCaregiverContractModal`, `EditCaregiverModal`, `useNewCaregiverContractForm`, `caregiverContractSchema`) — ils lisent `PCH_RATES` dynamiquement
- Pas de cycle d'import : `pchTariffs.ts` n'importe rien

## Test plan
- [x] `npm run typecheck` (0 erreur)
- [x] `npm run lint` (0 erreur)
- [x] `npm run test:run` — 2334 passed / 4 skipped
- [ ] Vérifier les libellés de tarif dans les modales de contrat aidant

🤖 Generated with [Claude Code](https://claude.com/claude-code)